### PR TITLE
feat: native CDP browser, cross-platform README, Telegram bot in gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # NanoClaw
 
-Lean AI agent for remote host control. One binary, one process, no microservices.
+Lean AI agent that gives Claude full control over your computer. One binary, one process, no microservices.
 
-NanoClaw gives Claude full control over your Mac through Telegram or a local CLI.
-It runs an agentic loop — the model calls tools, sees results, and keeps going
+NanoClaw turns any machine — Linux, macOS, or Windows (via WSL) — into an
+AI-controlled workstation you can command from Telegram or a local CLI.
+It runs an agentic loop: the model calls tools, sees results, and keeps going
 until the task is done. Think of it as a personal, self-hosted Claude Code
 that you talk to from anywhere.
 
 **Philosophy:**
+- Full computer control — shell, files, processes, clipboard, browser, screenshots
+- Cross-platform — runs wherever Go compiles (Linux, macOS, Windows/WSL)
 - Small enough to understand (~45 source files, 14 packages)
-- Full host control — agents run on your machine
 - Built for one user — bespoke, not a framework
 - Customization = code changes, not config sprawl
 
@@ -20,9 +22,12 @@ that you talk to from anywhere.
 git clone https://github.com/phanngoc/goterm-control.git
 cd goterm-control
 
+# Authenticate with Claude CLI (uses your Pro/Max subscription)
+claude login
+
 # Set up credentials
 cp .env.example .env
-# Edit .env: add TELEGRAM_TOKEN and ANTHROPIC_API_KEY
+# Edit .env: add TELEGRAM_TOKEN (optional, for Telegram access)
 
 # Build
 go build -o nanoclaw ./cmd/nanoclaw/
@@ -30,21 +35,35 @@ go build -o nanoclaw ./cmd/nanoclaw/
 # Interactive chat (no Telegram needed)
 ./nanoclaw chat
 
-# Or start the gateway (Telegram + WebSocket RPC)
+# Or start the gateway (Telegram + Web Dashboard + WebSocket RPC)
 ./nanoclaw gateway
 ```
 
 ### Prerequisites
 
 - Go 1.22+
-- An Anthropic API key (set `ANTHROPIC_API_KEY` in `.env`)
+- [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) installed and logged in (`claude login`)
+  - Uses your Claude Pro/Max subscription via OAuth2 — no API key needed
+  - Or alternatively, set `ANTHROPIC_API_KEY` for direct API access
 - For Telegram: a bot token from [@BotFather](https://t.me/BotFather)
+
+### Authentication
+
+NanoClaw supports two authentication modes, auto-detected at startup:
+
+| Mode | Token prefix | How it works |
+|---|---|---|
+| **Claude CLI (recommended)** | `sk-ant-oat...` | Uses `claude` CLI subprocess with your Pro/Max subscription. No per-token billing. |
+| **Direct API** | `sk-ant-api03...` | Calls Anthropic Messages API directly. Pay-per-use. |
+
+Run `claude login` and NanoClaw picks up the OAuth token automatically.
+To use a direct API key instead, set `ANTHROPIC_API_KEY` in `.env`.
 
 ### Environment Variables
 
 | Variable | Required | Description |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | Yes | Anthropic API key for Claude |
+| `ANTHROPIC_API_KEY` | No | Anthropic API key (only if not using Claude CLI OAuth) |
 | `TELEGRAM_TOKEN` | For Telegram | Telegram bot token |
 
 ## Commands
@@ -92,31 +111,53 @@ Once the gateway is running with a Telegram token:
 ## Architecture
 
 ```
-                    ┌──────────────┐
-                    │   Telegram   │
-                    │   Channel    │
-                    └──────┬───────┘
-                           │
-┌──────────┐       ┌───────▼────────┐       ┌──────────────┐
-│  CLI     │       │    Handler /   │       │   Execution  │
-│  Channel ├──────►│    Gateway     ├──────►│   Engine     │
-└──────────┘       │    (RPC)       │       │  (FIFO/chat) │
-                   └───────┬────────┘       └──────┬───────┘
-                           │                       │
-                   ┌───────▼────────┐       ┌──────▼───────┐
-                   │  Model         │       │   Agent      │
-                   │  Resolver      │       │   Loop       │
-                   └───────┬────────┘       └──────┬───────┘
-                           │                       │
-                   ┌───────▼────────┐       ┌──────▼───────┐
-                   │  Anthropic     │◄──────│   Context    │
-                   │  Direct API    │       │   Engine     │
-                   └───────┬────────┘       └──────────────┘
-                           │
-                   ┌───────▼────────┐
-                   │  Tool Executor │
-                   │  (14 tools)    │
-                   └────────────────┘
+┌───────────┐  ┌──────────────┐  ┌───────────────┐
+│  Telegram │  │ Web Dashboard│  │   CLI Chat    │
+│  Bot      │  │  (React SPA) │  │  (nanoclaw    │
+└─────┬─────┘  └──────┬───────┘  │   chat)       │
+      │               │          └───────┬───────┘
+      │          WebSocket               │
+      │               │            direct call
+      ▼               ▼                  ▼
+┌─────────────────────────────────────────────────┐
+│              Gateway (JSON-RPC)                  │
+│         session mgmt · model resolver            │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+              ┌─────────────────┐
+              │   Agent Loop    │  ← up to 50 iterations
+              │  (stream + tool │     per request
+              │   call cycle)   │
+              └────────┬────────┘
+                       │
+          ┌────────────┼────────────┐
+          ▼            │            ▼
+┌──────────────┐       │    ┌──────────────┐
+│  Claude CLI  │       │    │  Anthropic   │
+│  (OAuth2     │       │    │  Direct API  │
+│  subscription│       │    │  (sk-ant-api)│
+│  sk-ant-oat) │       │    └──────────────┘
+└──────────────┘       │
+                       ▼
+        ┌──────────────────────────────┐
+        │        Tool Executor         │
+        ├──────────────┬───────────────┤
+        │ System Tools │ Browser Tools │
+        │ · run_shell  │ · navigate    │
+        │ · read/write │ · click/fill  │
+        │ · screenshot │ · snapshot    │
+        │ · clipboard  │ · eval JS     │
+        │ · processes  │ · screenshot  │
+        │ · sysinfo    │ · scroll/wait │
+        └──────────────┴───────────────┘
+                       │
+        ┌──────────────┼──────────────┐
+        ▼              ▼              ▼
+   ┌─────────┐  ┌───────────┐  ┌──────────┐
+   │ Context │  │  Memory   │  │Transcript│
+   │ Engine  │  │  (JSONL)  │  │  (JSONL) │
+   └─────────┘  └───────────┘  └──────────┘
 ```
 
 ### The Agent Loop (the core)
@@ -145,26 +186,29 @@ tool calls, read results, and keep working until the task is done.
 
 ### Packages
 
-| Package | Purpose | Inspired by |
-|---|---|---|
-| `agent/` | Core agentic loop with retry and tool execution | openclaw `pi-embedded-runner` |
-| `anthropic/` | Direct Anthropic Messages API with streaming | openclaw provider plugins |
-| `channel/` | Channel abstraction (Telegram, CLI) | openclaw `channels/plugins` |
-| `context/` | Token counting, budget assembly, compaction | openclaw `context-engine` |
-| `gateway/` | WebSocket JSON-RPC server for remote control | openclaw `gateway` |
-| `execution/` | Per-session FIFO queue (prevents concurrent calls) | openclaw `process/command-queue` |
-| `session/` | Persistent sessions with idle timeout | openclaw `config/sessions` |
-| `memory/` | Cross-session keyword memory | openclaw LanceDB memory |
-| `models/` | Model catalog with aliases and per-session override | openclaw `model-catalog` |
-| `transcript/` | JSONL event recording per session | openclaw session transcripts |
-| `tools/` | 14 Mac control tools (shell, files, screenshot, ...) | openclaw agent tools |
-| `config/` | YAML config with env var overrides | openclaw config system |
-| `bot/` | Telegram bot with streaming message edits | openclaw Telegram channel |
-| `claude/` | Claude CLI subprocess (fallback provider) | — |
+| Package | Purpose |
+|---|---|
+| `agent/` | Core agentic loop with retry and tool execution |
+| `anthropic/` | Direct Anthropic Messages API client (streaming) |
+| `claude/` | Claude CLI subprocess provider (OAuth2 subscription) |
+| `browser/` | Chrome DevTools Protocol (CDP) client for browser automation |
+| `bot/` | Telegram bot with streaming message edits |
+| `channel/` | Channel abstraction (Telegram, CLI) |
+| `config/` | YAML config with env var overrides |
+| `context/` | Token counting, budget assembly, compaction |
+| `execution/` | Per-session FIFO queue (prevents concurrent calls) |
+| `gateway/` | WebSocket JSON-RPC server + static file serving (dashboard) |
+| `memory/` | Cross-session keyword memory |
+| `models/` | Model catalog with aliases and per-session override |
+| `session/` | Persistent session management |
+| `tools/` | System control tools (shell, files, screenshot, browser, ...) |
+| `transcript/` | JSONL event recording per session |
 
 ### Tools
 
-The agent has 14 tools for full Mac control:
+The agent has 25 tools for full computer control:
+
+**System tools:**
 
 | Tool | What it does |
 |---|---|
@@ -176,12 +220,28 @@ The agent has 14 tools for full Mac control:
 | `take_screenshot` | Capture screen |
 | `get_clipboard` | Read clipboard |
 | `set_clipboard` | Write to clipboard |
-| `run_applescript` | Control Mac apps via AppleScript |
-| `open_app` | Open applications or files |
+| `run_applescript` | Control apps via AppleScript (macOS) |
+| `open_app` | Open applications or files (`open`/`xdg-open`) |
 | `get_system_info` | Hardware, OS, CPU, memory, disk |
 | `list_processes` | Running processes with filter/sort |
 | `kill_process` | Kill by PID or name (TERM/KILL) |
-| `browse_url` | Open URL in default browser |
+| `browse_url` | Fetch URL content or open in browser |
+
+**Browser automation tools (Chrome DevTools Protocol):**
+
+| Tool | What it does |
+|---|---|
+| `browser_navigate` | Navigate to a URL (auto-launches Chrome) |
+| `browser_snapshot` | DOM snapshot with interactive element refs |
+| `browser_click` | Click an element by ref |
+| `browser_fill` | Clear and type into an input field |
+| `browser_type` | Append text to an input field |
+| `browser_select` | Select a dropdown option |
+| `browser_scroll` | Scroll page in any direction |
+| `browser_screenshot` | Screenshot the current page |
+| `browser_get_text` | Get text, HTML, value, or URL from elements |
+| `browser_eval` | Execute JavaScript in the browser |
+| `browser_wait` | Wait for element, text, or timeout |
 
 ### Data Persistence
 
@@ -214,10 +274,10 @@ Edit `config.yaml`:
 
 ```yaml
 claude:
-  api_key: ""                    # or set ANTHROPIC_API_KEY env var
+  api_key: ""                    # auto-detected from claude CLI OAuth; or set ANTHROPIC_API_KEY
   model: "claude-sonnet-4-6"     # default model
   system_prompt: |
-    You are an AI assistant with full control over a Mac...
+    You are an AI assistant with full control over this computer...
 
 models:
   default: ""                    # override claude.model
@@ -242,8 +302,8 @@ tools:
   max_output_bytes: 8192         # truncation limit
 ```
 
-Minimal config — most fields have sensible defaults. Set `ANTHROPIC_API_KEY`
-and `TELEGRAM_TOKEN` in `.env` and you're running.
+Minimal config — most fields have sensible defaults. Run `claude login`
+and optionally set `TELEGRAM_TOKEN` in `.env` and you're running.
 
 ## Development
 
@@ -268,20 +328,23 @@ cmd/
   nanoclaw/main.go          CLI entry point (gateway, chat, send, status, models)
   goterm/main.go            Legacy Telegram-only entry point
 
+dashboard/                  React web dashboard (Vite + TailwindCSS)
+
 internal/
   agent/                    Core agent loop + types
   anthropic/                Direct Anthropic API client
   bot/                      Telegram bot (handler, streamer)
+  browser/                  Chrome DevTools Protocol (CDP) client
   channel/                  Channel interface + CLI implementation
-  claude/                   Claude CLI subprocess (fallback)
+  claude/                   Claude CLI subprocess (OAuth2 provider)
   config/                   YAML config loading
   context/                  Context engine (tokens, assembly, compaction)
   execution/                Per-session FIFO execution queue
-  gateway/                  WebSocket JSON-RPC server
+  gateway/                  WebSocket JSON-RPC server + dashboard hosting
   memory/                   Cross-session keyword memory
   models/                   Model catalog + resolver
   session/                  Persistent session management
-  tools/                    14 Mac control tools
+  tools/                    System + browser control tools
   transcript/               JSONL event recording
 ```
 
@@ -291,7 +354,7 @@ internal/
   execute without confirmation. This is intentional for a personal bot.
 - Restrict access via `security.allowed_user_ids` in config.
 - The gateway binds to `127.0.0.1` by default (localhost only).
-- API keys are read from `.env` (gitignored) or environment variables.
+- Auth via Claude CLI OAuth2 (subscription) or API keys from `.env` (gitignored).
 
 ## Compared to openclaw
 
@@ -303,8 +366,9 @@ radically simplified:
 | Language | TypeScript | Go |
 | Binary | Node.js + many deps | Single static binary (13MB) |
 | Source files | 1000+ | 45 |
-| Providers | 40+ (plugin system) | Claude (direct API + CLI fallback) |
-| Channels | 20+ (plugin system) | Telegram + CLI + Gateway |
+| Auth | API keys only | Claude CLI OAuth2 or API key |
+| Providers | 40+ (plugin system) | Claude (CLI OAuth + direct API) |
+| Channels | 20+ (plugin system) | Telegram + Web Dashboard + CLI |
 | Memory | LanceDB + embeddings | JSONL + keyword search |
 | Config | ~200 config fields | ~15 config fields |
 | Context engine | Pluggable with DAG branching | Simple budget-based trimming |

--- a/cmd/nanoclaw/main.go
+++ b/cmd/nanoclaw/main.go
@@ -17,6 +17,7 @@ import (
 
 	anthropicClient "github.com/ngocp/goterm-control/internal/anthropic"
 	"github.com/ngocp/goterm-control/internal/agent"
+	"github.com/ngocp/goterm-control/internal/bot"
 	"github.com/ngocp/goterm-control/internal/channel"
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/config"
@@ -165,14 +166,18 @@ func runGateway(args []string) {
 
 	srv := gateway.NewServer(addr, gateway.NewMethodHandler(deps), gateway.NewStreamSendHandler(deps), "dashboard/dist")
 
-	// Also start Telegram bot in background if configured
+	// Start Telegram bot in background if configured
 	if cfg.Telegram.Token != "" {
-		go func() {
-			// Import the old bot package for Telegram support
-			// For now, the gateway runs standalone — Telegram integration
-			// will be wired through the channel interface
-			log.Printf("gateway: Telegram channel available (use existing goterm binary for now)")
-		}()
+		tgBot, err := bot.New(cfg)
+		if err != nil {
+			log.Printf("gateway: telegram bot init failed: %v", err)
+		} else {
+			go func() {
+				log.Println("gateway: starting Telegram bot")
+				tgBot.Run()
+			}()
+			defer tgBot.Shutdown()
+		}
 	}
 
 	log.Printf("nanoclaw gateway starting on %s", addr)
@@ -393,13 +398,13 @@ func buildToolDefs() []agent.ToolDef {
 		{"list_processes", "List running processes"},
 		{"kill_process", "Kill a process"},
 		{"browse_url", "Open URL in browser"},
-		// Browser automation (agent-browser)
-		{"browser_navigate", "Navigate browser to a URL. Opens the page in a headless Chrome browser."},
-		{"browser_snapshot", "Get an accessibility snapshot of the current page with element refs (@e1, @e2, etc). Use -i for interactive elements only."},
-		{"browser_click", "Click an element by its ref (e.g. @e3). Always snapshot first to get refs."},
-		{"browser_fill", "Clear and type text into an input field by ref. Use for form fields."},
+		// Browser automation (native CDP)
+		{"browser_navigate", "Navigate browser to a URL. Launches Chrome with CDP if needed."},
+		{"browser_snapshot", "Get a DOM snapshot of the current page with element refs (n1, n2, etc). Always snapshot first to get refs."},
+		{"browser_click", "Click an element by its ref (e.g. n3). Always snapshot first to get refs."},
+		{"browser_fill", "Clear and type text into an input field by ref (e.g. n5). Use for form fields."},
 		{"browser_type", "Append text to an input field by ref (does not clear first)."},
-		{"browser_select", "Select a dropdown option by ref and value."},
+		{"browser_select", "Select a dropdown option by ref (e.g. n7) and value."},
 		{"browser_scroll", "Scroll the page in a direction (up/down/left/right)."},
 		{"browser_screenshot", "Take a screenshot of the current browser page."},
 		{"browser_get_text", "Get text, HTML, value, title, or URL from an element or page."},
@@ -474,7 +479,7 @@ func findToolSchema(name string) map[string]any {
 			"url": map[string]any{"type": "string", "description": "URL to open"},
 		}, "required": []string{"url"}},
 
-		// Browser automation tools (agent-browser)
+		// Browser automation tools (native CDP)
 		"browser_navigate": {"type": "object", "properties": map[string]any{
 			"url": map[string]any{"type": "string", "description": "URL to navigate to"},
 		}, "required": []string{"url"}},
@@ -483,7 +488,7 @@ func findToolSchema(name string) map[string]any {
 			"interactive": map[string]any{"type": "boolean", "description": "Show only interactive elements (default true)"},
 		}},
 		"browser_click": {"type": "object", "properties": map[string]any{
-			"ref":     map[string]any{"type": "string", "description": "Element ref from snapshot (e.g. @e3)"},
+			"ref":     map[string]any{"type": "string", "description": "Element ref from snapshot (e.g. n3)"},
 			"new_tab": map[string]any{"type": "boolean", "description": "Open in new tab"},
 		}, "required": []string{"ref"}},
 		"browser_fill": {"type": "object", "properties": map[string]any{

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -34,6 +34,19 @@ func New(cfg *config.Config) (*Bot, error) {
 	api.Debug = false
 	log.Printf("bot: logged in as @%s", api.Self.UserName)
 
+	// Register commands with Telegram menu
+	commands := tgbotapi.NewSetMyCommands(
+		tgbotapi.BotCommand{Command: "start", Description: "Show welcome message and help"},
+		tgbotapi.BotCommand{Command: "reset", Description: "Clear conversation history"},
+		tgbotapi.BotCommand{Command: "status", Description: "Show session info"},
+		tgbotapi.BotCommand{Command: "models", Description: "List available models"},
+		tgbotapi.BotCommand{Command: "model", Description: "Switch model (e.g. /model sonnet)"},
+		tgbotapi.BotCommand{Command: "cancel", Description: "Cancel current request"},
+	)
+	if _, err := api.Request(commands); err != nil {
+		log.Printf("bot: warning: failed to set commands menu: %v", err)
+	}
+
 	executor := tools.New(tools.ExecutorConfig{
 		ShellTimeout:   cfg.Tools.ShellTimeout,
 		MaxOutputBytes: cfg.Tools.MaxOutputBytes,

--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -1,0 +1,116 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const wsHandshakeTimeout = 5 * time.Second
+
+// CdpSendFn sends a CDP method call and returns the raw JSON result.
+type CdpSendFn func(method string, params map[string]any) (json.RawMessage, error)
+
+type cdpRequest struct {
+	ID     int            `json:"id"`
+	Method string         `json:"method"`
+	Params map[string]any `json:"params,omitempty"`
+}
+
+type cdpResponse struct {
+	ID     int              `json:"id"`
+	Result json.RawMessage  `json:"result,omitempty"`
+	Error  *cdpError        `json:"error,omitempty"`
+}
+
+type cdpError struct {
+	Message string `json:"message"`
+}
+
+// WithCdpSocket opens a WebSocket to wsURL, creates a CdpSendFn,
+// executes fn, then closes the connection. This is the core primitive
+// that all CDP operations use.
+func WithCdpSocket(ctx context.Context, wsURL string, fn func(CdpSendFn) error) error {
+	dialer := websocket.Dialer{
+		HandshakeTimeout: wsHandshakeTimeout,
+	}
+	conn, _, err := dialer.DialContext(ctx, wsURL, http.Header{})
+	if err != nil {
+		return fmt.Errorf("cdp dial: %w", err)
+	}
+
+	var (
+		nextID  atomic.Int64
+		pending sync.Map          // map[int]chan cdpResponse
+		writeMu sync.Mutex        // gorilla/websocket requires serialized writes
+		done    = make(chan struct{})
+	)
+
+	// Reader goroutine: dispatch responses to pending requests.
+	go func() {
+		defer close(done)
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				// Connection closed or error — reject all pending.
+				pending.Range(func(key, val any) bool {
+					ch := val.(chan cdpResponse)
+					select {
+					case ch <- cdpResponse{Error: &cdpError{Message: "CDP socket closed"}}:
+					default:
+					}
+					return true
+				})
+				return
+			}
+			var resp cdpResponse
+			if json.Unmarshal(msg, &resp) != nil {
+				continue
+			}
+			if val, ok := pending.LoadAndDelete(resp.ID); ok {
+				ch := val.(chan cdpResponse)
+				ch <- resp
+			}
+		}
+	}()
+
+	send := func(method string, params map[string]any) (json.RawMessage, error) {
+		id := int(nextID.Add(1))
+		ch := make(chan cdpResponse, 1)
+		pending.Store(id, ch)
+
+		req := cdpRequest{ID: id, Method: method, Params: params}
+		writeMu.Lock()
+		werr := conn.WriteJSON(req)
+		writeMu.Unlock()
+		if werr != nil {
+			pending.Delete(id)
+			return nil, fmt.Errorf("cdp write %s: %w", method, werr)
+		}
+
+		select {
+		case resp := <-ch:
+			if resp.Error != nil {
+				return nil, fmt.Errorf("cdp %s: %s", method, resp.Error.Message)
+			}
+			return resp.Result, nil
+		case <-ctx.Done():
+			pending.Delete(id)
+			return nil, ctx.Err()
+		}
+	}
+
+	fnErr := fn(send)
+
+	// Close WebSocket and wait for reader to exit.
+	conn.Close()
+	<-done
+
+	return fnErr
+}

--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -1,0 +1,184 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultCdpPort       = 9222
+	httpTimeout          = 1500 * time.Millisecond
+	reachabilityTimeout  = 500 * time.Millisecond
+	launchReadyWindow    = 15 * time.Second
+	launchPollInterval   = 200 * time.Millisecond
+	stopTimeout          = 2500 * time.Millisecond
+	stopPollInterval     = 100 * time.Millisecond
+)
+
+// Chrome candidates on Linux, ordered by preference.
+var chromePaths = []string{
+	"/usr/bin/google-chrome",
+	"/usr/bin/google-chrome-stable",
+	"/usr/bin/brave-browser",
+	"/usr/bin/brave-browser-stable",
+	"/usr/bin/microsoft-edge",
+	"/usr/bin/microsoft-edge-stable",
+	"/usr/bin/chromium",
+	"/usr/bin/chromium-browser",
+	"/snap/bin/chromium",
+}
+
+// Chrome manages a local Chrome process with CDP enabled.
+type Chrome struct {
+	cmd         *exec.Cmd
+	cdpPort     int
+	userDataDir string
+	mu          sync.Mutex
+}
+
+// FindChrome returns the path to the first available Chrome executable.
+func FindChrome() (string, error) {
+	for _, p := range chromePaths {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	// Fallback: check PATH.
+	for _, name := range []string{"google-chrome", "chromium", "chromium-browser"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no Chrome/Chromium found; install google-chrome or chromium")
+}
+
+// Launch starts Chrome with --remote-debugging-port and waits for CDP ready.
+func Launch(ctx context.Context) (*Chrome, error) {
+	exe, err := FindChrome()
+	if err != nil {
+		return nil, err
+	}
+
+	home, _ := os.UserHomeDir()
+	dataDir := filepath.Join(home, ".goterm", "browser", "user-data")
+	os.MkdirAll(dataDir, 0o755)
+
+	c := &Chrome{
+		cdpPort:     defaultCdpPort,
+		userDataDir: dataDir,
+	}
+
+	args := []string{
+		fmt.Sprintf("--remote-debugging-port=%d", c.cdpPort),
+		fmt.Sprintf("--user-data-dir=%s", dataDir),
+		"--no-first-run",
+		"--no-default-browser-check",
+		"--disable-sync",
+		"--disable-background-networking",
+		"--disable-component-update",
+		"--disable-features=Translate,MediaRouter",
+		"--disable-session-crashed-bubble",
+		"--hide-crash-restore-bubble",
+		"--password-store=basic",
+		"--disable-dev-shm-usage",
+	}
+
+	c.cmd = exec.CommandContext(ctx, exe, args...)
+	c.cmd.Stdout = nil
+	c.cmd.Stderr = nil
+	// Detach from parent process group so Chrome survives if we crash mid-launch.
+	c.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := c.cmd.Start(); err != nil {
+		return nil, fmt.Errorf("chrome launch: %w", err)
+	}
+
+	// Poll for CDP readiness.
+	deadline := time.Now().Add(launchReadyWindow)
+	for time.Now().Before(deadline) {
+		if c.IsReachable() {
+			return c, nil
+		}
+		time.Sleep(launchPollInterval)
+	}
+
+	// Timed out — kill and report.
+	c.cmd.Process.Kill()
+	return nil, fmt.Errorf("chrome CDP not ready after %s on port %d", launchReadyWindow, c.cdpPort)
+}
+
+// Stop terminates Chrome gracefully (SIGTERM), falling back to SIGKILL.
+func (c *Chrome) Stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cmd == nil || c.cmd.Process == nil {
+		return nil
+	}
+
+	c.cmd.Process.Signal(syscall.SIGTERM)
+
+	deadline := time.Now().Add(stopTimeout)
+	for time.Now().Before(deadline) {
+		if !c.IsReachable() {
+			c.cmd.Wait()
+			return nil
+		}
+		time.Sleep(stopPollInterval)
+	}
+
+	c.cmd.Process.Kill()
+	c.cmd.Wait()
+	return nil
+}
+
+// IsReachable returns true if Chrome's CDP HTTP endpoint responds.
+func (c *Chrome) IsReachable() bool {
+	client := http.Client{Timeout: reachabilityTimeout}
+	resp, err := client.Get(c.cdpBaseURL() + "/json/version")
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == 200
+}
+
+// PageWsURL returns the WebSocket debugger URL for the active page tab.
+func (c *Chrome) PageWsURL() (string, error) {
+	client := http.Client{Timeout: httpTimeout}
+	resp, err := client.Get(c.cdpBaseURL() + "/json/list")
+	if err != nil {
+		return "", fmt.Errorf("cdp /json/list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var targets []struct {
+		Type                 string `json:"type"`
+		WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&targets); err != nil {
+		return "", fmt.Errorf("cdp /json/list decode: %w", err)
+	}
+
+	// Prefer "page" type targets.
+	for _, t := range targets {
+		if t.Type == "page" && t.WebSocketDebuggerURL != "" {
+			return t.WebSocketDebuggerURL, nil
+		}
+	}
+	if len(targets) > 0 && targets[0].WebSocketDebuggerURL != "" {
+		return targets[0].WebSocketDebuggerURL, nil
+	}
+	return "", fmt.Errorf("no page target found")
+}
+
+func (c *Chrome) cdpBaseURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", c.cdpPort)
+}

--- a/internal/browser/operations.go
+++ b/internal/browser/operations.go
@@ -1,0 +1,358 @@
+package browser
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Navigate loads a URL in the active page tab.
+func (c *Chrome) Navigate(ctx context.Context, url string) error {
+	wsURL, err := c.PageWsURL()
+	if err != nil {
+		return err
+	}
+	return WithCdpSocket(ctx, wsURL, func(send CdpSendFn) error {
+		_, err := send("Page.navigate", map[string]any{"url": url})
+		return err
+	})
+}
+
+// CaptureScreenshot takes a PNG screenshot. If fullPage is true,
+// the viewport is temporarily expanded to capture the entire page.
+func (c *Chrome) CaptureScreenshot(ctx context.Context, fullPage bool) ([]byte, error) {
+	wsURL, err := c.PageWsURL()
+	if err != nil {
+		return nil, err
+	}
+	var data []byte
+	err = WithCdpSocket(ctx, wsURL, func(send CdpSendFn) error {
+		send("Page.enable", nil)
+
+		if fullPage {
+			// Get content size and expand viewport.
+			metrics, _ := send("Page.getLayoutMetrics", nil)
+			var m struct {
+				CSSContentSize struct {
+					Width  float64 `json:"width"`
+					Height float64 `json:"height"`
+				} `json:"cssContentSize"`
+			}
+			json.Unmarshal(metrics, &m)
+			if m.CSSContentSize.Width > 0 && m.CSSContentSize.Height > 0 {
+				send("Emulation.setDeviceMetricsOverride", map[string]any{
+					"width":             int(m.CSSContentSize.Width),
+					"height":            int(m.CSSContentSize.Height),
+					"deviceScaleFactor": 1,
+					"mobile":            false,
+				})
+				defer send("Emulation.clearDeviceMetricsOverride", nil)
+			}
+		}
+
+		result, err := send("Page.captureScreenshot", map[string]any{
+			"format":                "png",
+			"captureBeyondViewport": true,
+		})
+		if err != nil {
+			return err
+		}
+		var ss struct {
+			Data string `json:"data"`
+		}
+		json.Unmarshal(result, &ss)
+		if ss.Data == "" {
+			return fmt.Errorf("screenshot: empty data")
+		}
+		data, err = base64.StdEncoding.DecodeString(ss.Data)
+		return err
+	})
+	return data, err
+}
+
+// EvalJS evaluates a JavaScript expression and returns the string result.
+func (c *Chrome) EvalJS(ctx context.Context, expr string) (string, error) {
+	wsURL, err := c.PageWsURL()
+	if err != nil {
+		return "", err
+	}
+	var result string
+	err = WithCdpSocket(ctx, wsURL, func(send CdpSendFn) error {
+		send("Runtime.enable", nil)
+		raw, err := send("Runtime.evaluate", map[string]any{
+			"expression":            expr,
+			"returnByValue":         true,
+			"awaitPromise":          true,
+			"userGesture":           true,
+			"includeCommandLineAPI": true,
+		})
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			Result struct {
+				Type  string          `json:"type"`
+				Value json.RawMessage `json:"value"`
+			} `json:"result"`
+			ExceptionDetails *struct {
+				Text string `json:"text"`
+			} `json:"exceptionDetails"`
+		}
+		json.Unmarshal(raw, &resp)
+		if resp.ExceptionDetails != nil {
+			return fmt.Errorf("js error: %s", resp.ExceptionDetails.Text)
+		}
+		// Try to get string value; fall back to raw JSON.
+		var s string
+		if json.Unmarshal(resp.Result.Value, &s) == nil {
+			result = s
+		} else {
+			result = string(resp.Result.Value)
+		}
+		return nil
+	})
+	return result, err
+}
+
+// SnapshotDOM returns a text representation of the DOM with element refs.
+// The injected JS does a DFS traversal, matching OpenClaw's snapshotDom.
+func (c *Chrome) SnapshotDOM(ctx context.Context, selector string) (string, error) {
+	expr := `(() => {
+  const maxNodes = 800, maxText = 220;
+  const nodes = [];
+  const root = document.documentElement;
+  if (!root) return JSON.stringify({nodes});
+  const stack = [{el: root, depth: 0, parentRef: null}];
+  while (stack.length && nodes.length < maxNodes) {
+    const cur = stack.pop();
+    const el = cur.el;
+    if (!el || el.nodeType !== 1) continue;
+    const ref = "n" + (nodes.length + 1);
+    const tag = (el.tagName || "").toLowerCase();
+    const id = el.id || undefined;
+    const role = el.getAttribute && el.getAttribute("role") || undefined;
+    const name = el.getAttribute && el.getAttribute("aria-label") || undefined;
+    let text = "";
+    try { text = (el.innerText || "").trim(); } catch {}
+    if (text.length > maxText) text = text.slice(0, maxText) + "...";
+    const href = el.href || undefined;
+    const type = el.type || undefined;
+    const value = el.value !== undefined && el.value !== null && el.value !== "" ? String(el.value).slice(0, 500) : undefined;
+    nodes.push({ref, parentRef: cur.parentRef, depth: cur.depth, tag, id, role, name, text, href, type, value});
+    const children = el.children ? Array.from(el.children) : [];
+    for (let i = children.length - 1; i >= 0; i--) {
+      stack.push({el: children[i], depth: cur.depth + 1, parentRef: ref});
+    }
+  }
+  return JSON.stringify({nodes});
+})()`
+
+	raw, err := c.EvalJS(ctx, expr)
+	if err != nil {
+		return "", err
+	}
+
+	var snap struct {
+		Nodes []struct {
+			Ref   string `json:"ref"`
+			Depth int    `json:"depth"`
+			Tag   string `json:"tag"`
+			ID    string `json:"id,omitempty"`
+			Role  string `json:"role,omitempty"`
+			Name  string `json:"name,omitempty"`
+			Text  string `json:"text,omitempty"`
+			Href  string `json:"href,omitempty"`
+			Type  string `json:"type,omitempty"`
+			Value string `json:"value,omitempty"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal([]byte(raw), &snap); err != nil {
+		return raw, nil // Return raw text if parse fails.
+	}
+
+	// Format as readable text tree.
+	var b strings.Builder
+	for _, n := range snap.Nodes {
+		indent := strings.Repeat("  ", n.Depth)
+		fmt.Fprintf(&b, "%s[%s] <%s>", indent, n.Ref, n.Tag)
+		if n.Role != "" {
+			fmt.Fprintf(&b, " role=%s", n.Role)
+		}
+		if n.Name != "" {
+			fmt.Fprintf(&b, " %q", n.Name)
+		}
+		if n.ID != "" {
+			fmt.Fprintf(&b, " #%s", n.ID)
+		}
+		if n.Type != "" {
+			fmt.Fprintf(&b, " type=%s", n.Type)
+		}
+		if n.Value != "" {
+			fmt.Fprintf(&b, " value=%q", n.Value)
+		}
+		if n.Href != "" {
+			fmt.Fprintf(&b, " href=%s", n.Href)
+		}
+		if n.Text != "" && len(n.Text) < 80 {
+			fmt.Fprintf(&b, " %q", n.Text)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+// refActionJS builds a JS expression that finds an element by DFS ref
+// and executes the given action code on it. The action code can use "el"
+// as the found element. Returns "ref not found" if the ref is invalid.
+func refActionJS(ref, actionCode string) string {
+	return fmt.Sprintf(`(() => {
+  const idx = parseInt(%q.replace("n","")) - 1;
+  const stack = [document.documentElement];
+  let count = 0;
+  while (stack.length) {
+    const el = stack.pop();
+    if (!el || el.nodeType !== 1) continue;
+    if (count === idx) { %s }
+    count++;
+    const ch = el.children ? Array.from(el.children) : [];
+    for (let i = ch.length - 1; i >= 0; i--) stack.push(ch[i]);
+  }
+  return "ref not found";
+})()`, ref, actionCode)
+}
+
+// execRefAction evaluates a ref-based JS action and returns an error
+// if the ref was not found.
+func (c *Chrome) execRefAction(ctx context.Context, ref, actionCode, refLabel string) error {
+	result, err := c.EvalJS(ctx, refActionJS(ref, actionCode))
+	if err != nil {
+		return err
+	}
+	if result == "ref not found" {
+		return fmt.Errorf("element %s not found", refLabel)
+	}
+	return nil
+}
+
+// Click clicks the element identified by a snapshot ref (e.g. "n5").
+func (c *Chrome) Click(ctx context.Context, ref string) error {
+	return c.execRefAction(ctx, ref, `el.click(); return "clicked";`, ref)
+}
+
+// Fill clears an input and sets its value, dispatching input events.
+func (c *Chrome) Fill(ctx context.Context, ref string, text string) error {
+	textJSON, _ := json.Marshal(text)
+	action := fmt.Sprintf(`el.focus(); el.value = %s; el.dispatchEvent(new Event("input", {bubbles: true})); el.dispatchEvent(new Event("change", {bubbles: true})); return "filled";`, string(textJSON))
+	return c.execRefAction(ctx, ref, action, ref)
+}
+
+// TypeText appends text to an input element (does not clear first).
+func (c *Chrome) TypeText(ctx context.Context, ref string, text string) error {
+	textJSON, _ := json.Marshal(text)
+	action := fmt.Sprintf(`el.focus(); el.value += %s; el.dispatchEvent(new Event("input", {bubbles: true})); return "typed";`, string(textJSON))
+	return c.execRefAction(ctx, ref, action, ref)
+}
+
+// SelectOption selects a dropdown value.
+func (c *Chrome) SelectOption(ctx context.Context, ref string, value string) error {
+	valJSON, _ := json.Marshal(value)
+	action := fmt.Sprintf(`el.value = %s; el.dispatchEvent(new Event("change", {bubbles: true})); return "selected";`, string(valJSON))
+	return c.execRefAction(ctx, ref, action, ref)
+}
+
+// Scroll scrolls the page in the given direction.
+func (c *Chrome) Scroll(ctx context.Context, direction string, pixels int) error {
+	if pixels <= 0 {
+		pixels = 300
+	}
+	var dx, dy int
+	switch direction {
+	case "up":
+		dy = -pixels
+	case "down":
+		dy = pixels
+	case "left":
+		dx = -pixels
+	case "right":
+		dx = pixels
+	default:
+		dy = pixels
+	}
+	expr := fmt.Sprintf("window.scrollBy(%d, %d)", dx, dy)
+	_, err := c.EvalJS(ctx, expr)
+	return err
+}
+
+// GetText extracts a property from an element or the page.
+func (c *Chrome) GetText(ctx context.Context, ref string, property string) (string, error) {
+	if property == "" {
+		property = "text"
+	}
+
+	// Page-level properties (no ref needed).
+	if ref == "" {
+		switch property {
+		case "title":
+			return c.EvalJS(ctx, "document.title")
+		case "url":
+			return c.EvalJS(ctx, "location.href")
+		case "html":
+			return c.EvalJS(ctx, "document.documentElement.outerHTML.slice(0, 200000)")
+		default:
+			return c.EvalJS(ctx, "(document.body && document.body.innerText || '').slice(0, 200000)")
+		}
+	}
+
+	propExpr := "el.innerText || ''"
+	switch property {
+	case "html":
+		propExpr = "el.outerHTML || ''"
+	case "value":
+		propExpr = "String(el.value || '')"
+	}
+
+	return c.EvalJS(ctx, refActionJS(ref, fmt.Sprintf("return %s;", propExpr)))
+}
+
+// GoBack navigates back in history.
+func (c *Chrome) GoBack(ctx context.Context) error {
+	_, err := c.EvalJS(ctx, "history.back()")
+	return err
+}
+
+// WaitFor waits for an element ref, text on page, or a duration.
+func (c *Chrome) WaitFor(ctx context.Context, ref string, text string, ms int) error {
+	if ms > 0 && ref == "" && text == "" {
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+		return nil
+	}
+
+	timeout := 10 * time.Second
+	if ms > 0 {
+		timeout = time.Duration(ms) * time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+	poll := 200 * time.Millisecond
+
+	for time.Now().Before(deadline) {
+		if ref != "" {
+			result, err := c.EvalJS(ctx, refActionJS(ref, `return "found";`))
+			if err == nil && result == "found" {
+				return nil
+			}
+		}
+		if text != "" {
+			textJSON, _ := json.Marshal(text)
+			expr := fmt.Sprintf("(document.body && document.body.innerText || '').includes(%s)", string(textJSON))
+			result, err := c.EvalJS(ctx, expr)
+			if err == nil && result == "true" {
+				return nil
+			}
+		}
+		time.Sleep(poll)
+	}
+	return fmt.Errorf("wait timed out after %s", timeout)
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -1,39 +1,47 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
-	"strconv"
-	"strings"
+	"os"
+	"sync"
+
+	"github.com/ngocp/goterm-control/internal/browser"
 )
 
-const (
-	browserBin            = "agent-browser"
-	browserScreenshotPath = "/tmp/browser-screenshot.png"
-)
+const browserScreenshotPath = "/tmp/browser-screenshot.png"
 
-// BrowserTool wraps the agent-browser CLI for browser automation via CDP.
-// See: https://github.com/vercel-labs/agent-browser
-type BrowserTool struct{}
+// BrowserTool provides browser automation via native CDP over WebSocket.
+// Chrome is launched lazily on first use.
+type BrowserTool struct {
+	chrome *browser.Chrome
+	mu     sync.Mutex
+}
 
-// run executes an agent-browser command and returns stdout.
-func (b *BrowserTool) run(ctx context.Context, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, browserBin, args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		errMsg := strings.TrimSpace(stderr.String())
-		if errMsg == "" {
-			errMsg = err.Error()
-		}
-		return "", fmt.Errorf("%s", errMsg)
+// EnsureChrome lazily launches Chrome if not already running.
+func (b *BrowserTool) EnsureChrome(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.chrome != nil && b.chrome.IsReachable() {
+		return nil
 	}
-	return strings.TrimRight(stdout.String(), "\n"), nil
+	c, err := browser.Launch(ctx)
+	if err != nil {
+		return err
+	}
+	b.chrome = c
+	return nil
+}
+
+// Shutdown stops the Chrome process.
+func (b *BrowserTool) Shutdown() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.chrome != nil {
+		b.chrome.Stop()
+		b.chrome = nil
+	}
 }
 
 // --- Navigate ---
@@ -47,33 +55,28 @@ func (b *BrowserTool) Navigate(ctx context.Context, raw json.RawMessage) (string
 	if err := json.Unmarshal(raw, &inp); err != nil {
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
-	out, err := b.run(ctx, "open", inp.URL)
-	if err != nil {
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
+	if err := b.chrome.Navigate(ctx, inp.URL); err != nil {
 		return fmt.Sprintf("Navigation failed: %v", err), nil
 	}
-	if out == "" {
-		return fmt.Sprintf("Navigated to %s", inp.URL), nil
-	}
-	return out, nil
+	return fmt.Sprintf("Navigated to %s", inp.URL), nil
 }
 
 // --- Snapshot ---
 
 type browserSnapshotInput struct {
-	Selector    string `json:"selector"`
-	Interactive bool   `json:"interactive"`
+	Selector string `json:"selector"`
 }
 
 func (b *BrowserTool) Snapshot(ctx context.Context, raw json.RawMessage) (string, error) {
 	var inp browserSnapshotInput
 	_ = json.Unmarshal(raw, &inp)
-
-	args := []string{"snapshot", "-i", "-c"}
-	if inp.Selector != "" {
-		args = append(args, "-s", inp.Selector)
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
 	}
-
-	out, err := b.run(ctx, args...)
+	out, err := b.chrome.SnapshotDOM(ctx, inp.Selector)
 	if err != nil {
 		return fmt.Sprintf("Snapshot failed: %v", err), nil
 	}
@@ -83,8 +86,7 @@ func (b *BrowserTool) Snapshot(ctx context.Context, raw json.RawMessage) (string
 // --- Click ---
 
 type browserClickInput struct {
-	Ref    string `json:"ref"`
-	NewTab bool   `json:"new_tab"`
+	Ref string `json:"ref"`
 }
 
 func (b *BrowserTool) Click(ctx context.Context, raw json.RawMessage) (string, error) {
@@ -92,18 +94,13 @@ func (b *BrowserTool) Click(ctx context.Context, raw json.RawMessage) (string, e
 	if err := json.Unmarshal(raw, &inp); err != nil {
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
-	args := []string{"click", inp.Ref}
-	if inp.NewTab {
-		args = append(args, "--new-tab")
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
 	}
-	out, err := b.run(ctx, args...)
-	if err != nil {
+	if err := b.chrome.Click(ctx, inp.Ref); err != nil {
 		return fmt.Sprintf("Click failed: %v", err), nil
 	}
-	if out == "" {
-		return fmt.Sprintf("Clicked %s", inp.Ref), nil
-	}
-	return out, nil
+	return fmt.Sprintf("Clicked %s", inp.Ref), nil
 }
 
 // --- Fill ---
@@ -118,14 +115,13 @@ func (b *BrowserTool) Fill(ctx context.Context, raw json.RawMessage) (string, er
 	if err := json.Unmarshal(raw, &inp); err != nil {
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
-	out, err := b.run(ctx, "fill", inp.Ref, inp.Text)
-	if err != nil {
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
+	if err := b.chrome.Fill(ctx, inp.Ref, inp.Text); err != nil {
 		return fmt.Sprintf("Fill failed: %v", err), nil
 	}
-	if out == "" {
-		return fmt.Sprintf("Filled %s with %q", inp.Ref, inp.Text), nil
-	}
-	return out, nil
+	return fmt.Sprintf("Filled %s with %q", inp.Ref, inp.Text), nil
 }
 
 // --- Type ---
@@ -140,14 +136,13 @@ func (b *BrowserTool) Type(ctx context.Context, raw json.RawMessage) (string, er
 	if err := json.Unmarshal(raw, &inp); err != nil {
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
-	out, err := b.run(ctx, "type", inp.Ref, inp.Text)
-	if err != nil {
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
+	if err := b.chrome.TypeText(ctx, inp.Ref, inp.Text); err != nil {
 		return fmt.Sprintf("Type failed: %v", err), nil
 	}
-	if out == "" {
-		return fmt.Sprintf("Typed %q into %s", inp.Text, inp.Ref), nil
-	}
-	return out, nil
+	return fmt.Sprintf("Typed %q into %s", inp.Text, inp.Ref), nil
 }
 
 // --- Select ---
@@ -162,44 +157,36 @@ func (b *BrowserTool) Select(ctx context.Context, raw json.RawMessage) (string, 
 	if err := json.Unmarshal(raw, &inp); err != nil {
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
-	out, err := b.run(ctx, "select", inp.Ref, inp.Value)
-	if err != nil {
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
+	if err := b.chrome.SelectOption(ctx, inp.Ref, inp.Value); err != nil {
 		return fmt.Sprintf("Select failed: %v", err), nil
 	}
-	if out == "" {
-		return fmt.Sprintf("Selected %q in %s", inp.Value, inp.Ref), nil
-	}
-	return out, nil
+	return fmt.Sprintf("Selected %q in %s", inp.Value, inp.Ref), nil
 }
 
 // --- Scroll ---
 
 type browserScrollInput struct {
-	Direction string `json:"direction"` // up, down, left, right
+	Direction string `json:"direction"`
 	Pixels    int    `json:"pixels"`
 }
 
 func (b *BrowserTool) Scroll(ctx context.Context, raw json.RawMessage) (string, error) {
 	var inp browserScrollInput
 	_ = json.Unmarshal(raw, &inp)
-
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
 	dir := inp.Direction
 	if dir == "" {
 		dir = "down"
 	}
-	args := []string{"scroll", dir}
-	if inp.Pixels > 0 {
-		args = append(args, strconv.Itoa(inp.Pixels))
-	}
-
-	out, err := b.run(ctx, args...)
-	if err != nil {
+	if err := b.chrome.Scroll(ctx, dir, inp.Pixels); err != nil {
 		return fmt.Sprintf("Scroll failed: %v", err), nil
 	}
-	if out == "" {
-		return fmt.Sprintf("Scrolled %s", dir), nil
-	}
-	return out, nil
+	return fmt.Sprintf("Scrolled %s", dir), nil
 }
 
 // --- Screenshot ---
@@ -211,15 +198,21 @@ type browserScreenshotInput struct {
 func (b *BrowserTool) Screenshot(ctx context.Context, raw json.RawMessage) (string, error) {
 	var inp browserScreenshotInput
 	_ = json.Unmarshal(raw, &inp)
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
 
 	path := inp.Path
 	if path == "" {
 		path = browserScreenshotPath
 	}
 
-	_, err := b.run(ctx, "screenshot", path)
+	data, err := b.chrome.CaptureScreenshot(ctx, true)
 	if err != nil {
 		return fmt.Sprintf("Screenshot failed: %v", err), nil
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Sprintf("Screenshot write failed: %v", err), nil
 	}
 	return "SCREENSHOT:" + path, nil
 }
@@ -228,26 +221,18 @@ func (b *BrowserTool) Screenshot(ctx context.Context, raw json.RawMessage) (stri
 
 type browserGetTextInput struct {
 	Ref      string `json:"ref"`
-	Property string `json:"property"` // text, html, value, title, url
+	Property string `json:"property"`
 }
 
 func (b *BrowserTool) GetText(ctx context.Context, raw json.RawMessage) (string, error) {
 	var inp browserGetTextInput
 	_ = json.Unmarshal(raw, &inp)
-
-	prop := inp.Property
-	if prop == "" {
-		prop = "text"
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
 	}
-
-	args := []string{"get", prop}
-	if inp.Ref != "" {
-		args = append(args, inp.Ref)
-	}
-
-	out, err := b.run(ctx, args...)
+	out, err := b.chrome.GetText(ctx, inp.Ref, inp.Property)
 	if err != nil {
-		return fmt.Sprintf("Get %s failed: %v", prop, err), nil
+		return fmt.Sprintf("Get %s failed: %v", inp.Property, err), nil
 	}
 	return out, nil
 }
@@ -263,7 +248,10 @@ func (b *BrowserTool) Eval(ctx context.Context, raw json.RawMessage) (string, er
 	if err := json.Unmarshal(raw, &inp); err != nil {
 		return "", fmt.Errorf("invalid input: %w", err)
 	}
-	out, err := b.run(ctx, "eval", inp.Expression)
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
+	out, err := b.chrome.EvalJS(ctx, inp.Expression)
 	if err != nil {
 		return fmt.Sprintf("Eval failed: %v", err), nil
 	}
@@ -281,38 +269,23 @@ type browserWaitInput struct {
 func (b *BrowserTool) Wait(ctx context.Context, raw json.RawMessage) (string, error) {
 	var inp browserWaitInput
 	_ = json.Unmarshal(raw, &inp)
-
-	var args []string
-	switch {
-	case inp.Ref != "":
-		args = []string{"wait", inp.Ref}
-	case inp.Text != "":
-		args = []string{"wait", "--text", inp.Text}
-	case inp.Ms > 0:
-		args = []string{"wait", strconv.Itoa(inp.Ms)}
-	default:
-		args = []string{"wait", "1000"}
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
 	}
-
-	out, err := b.run(ctx, args...)
-	if err != nil {
+	if err := b.chrome.WaitFor(ctx, inp.Ref, inp.Text, inp.Ms); err != nil {
 		return fmt.Sprintf("Wait failed: %v", err), nil
 	}
-	if out == "" {
-		return "Wait completed", nil
-	}
-	return out, nil
+	return "Wait completed", nil
 }
 
 // --- Back ---
 
 func (b *BrowserTool) Back(ctx context.Context, _ json.RawMessage) (string, error) {
-	out, err := b.run(ctx, "back")
-	if err != nil {
+	if err := b.EnsureChrome(ctx); err != nil {
+		return "", err
+	}
+	if err := b.chrome.GoBack(ctx); err != nil {
 		return fmt.Sprintf("Back failed: %v", err), nil
 	}
-	if out == "" {
-		return "Navigated back", nil
-	}
-	return out, nil
+	return "Navigated back", nil
 }

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -43,6 +43,13 @@ type ExecutorConfig struct {
 	AllowedPaths   []string
 }
 
+// Shutdown stops any managed resources (e.g. Chrome process).
+func (e *Executor) Shutdown() {
+	if e.browser != nil {
+		e.browser.Shutdown()
+	}
+}
+
 func (e *Executor) Run(ctx context.Context, name string, input json.RawMessage) ToolResult {
 	var (
 		out string

--- a/start.sh
+++ b/start.sh
@@ -15,55 +15,29 @@ GATEWAY_PORT="${GATEWAY_PORT:-19000}"
 
 build() {
   echo "⚙️  Building..."
-  go build -o goterm ./cmd/goterm/
   go build -o nanoclaw ./cmd/nanoclaw/
-  echo "✅ Built: goterm + nanoclaw"
-}
-
-start_telegram() {
-  echo "📱 Starting Telegram bot (@Goterm_bot)..."
-  ./goterm -config config.yaml -env .env &
-  echo "   PID: $!"
+  echo "✅ Built: nanoclaw"
 }
 
 start_gateway() {
-  echo "🌐 Starting gateway on :${GATEWAY_PORT}..."
+  echo "🌐 Starting gateway (+ Telegram bot) on :${GATEWAY_PORT}..."
   ./nanoclaw gateway --config config.yaml --env .env --port "$GATEWAY_PORT" &
   echo "   PID: $!"
 }
 
 stop_all() {
   echo "🛑 Stopping..."
-  pkill -f "./goterm -config" 2>/dev/null || true
   pkill -f "./nanoclaw gateway" 2>/dev/null || true
   sleep 1
 }
 
 case "$MODE" in
-  telegram)
+  gateway|all)
     build
     stop_all
-    start_telegram
-    echo "✅ Telegram bot running. Send messages to @Goterm_bot"
-    ;;
-  gateway)
-    build
-    stop_all
-    start_gateway
-    echo "✅ Gateway running. Use: ./nanoclaw send \"hello\""
-    ;;
-  chat)
-    build
-    echo "💬 Starting interactive chat..."
-    ./nanoclaw chat --config config.yaml --env .env
-    ;;
-  all)
-    build
-    stop_all
-    start_telegram
     start_gateway
     echo ""
-    echo "✅ All services running:"
+    echo "✅ Gateway running (Telegram bot auto-starts if token configured):"
     echo "   📱 Telegram: @Goterm_bot"
     echo "   🌐 Gateway:  ws://127.0.0.1:${GATEWAY_PORT}/ws"
     echo "   📊 Health:   http://127.0.0.1:${GATEWAY_PORT}/health"
@@ -73,6 +47,11 @@ case "$MODE" in
     echo "   ./nanoclaw status                     # check status"
     echo "   ./nanoclaw models                     # list models"
     echo "   ./start.sh stop                       # stop all"
+    ;;
+  chat)
+    build
+    echo "💬 Starting interactive chat..."
+    ./nanoclaw chat --config config.yaml --env .env
     ;;
   stop)
     stop_all


### PR DESCRIPTION
- Replace agent-browser CLI dependency with native Chrome DevTools Protocol client (internal/browser/) — no external binary needed
- README rewritten: "full control your computer" instead of Mac-only, document OAuth2 CLI auth as primary, add browser automation tools
- Wire Telegram bot directly into gateway (no separate goterm binary)
- Register bot commands menu with Telegram API
- Add executor.Shutdown() for clean Chrome process cleanup
- Simplify start.sh: single gateway entry point