### PR TITLE
feat: switch Telegram from Markdown to HTML parse mode

### DIFF
--- a/internal/bot/format.go
+++ b/internal/bot/format.go
@@ -1,0 +1,290 @@
+package bot
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// --- Markdown to Telegram HTML conversion ---
+// Ported from goclaw's format.go, simplified (no table rendering).
+// Converts LLM markdown output to Telegram-safe HTML for parse_mode: "HTML".
+
+// htmlTagToMarkdown converts common HTML tags in LLM output to markdown equivalents
+// so they survive the escapeHTML step and get re-converted by the markdown pipeline.
+var htmlToMdReplacers = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	{regexp.MustCompile(`(?i)<br\s*/?>`), "\n"},
+	{regexp.MustCompile(`(?i)</?p\s*>`), "\n"},
+	{regexp.MustCompile(`(?i)<b>([\s\S]*?)</b>`), "**$1**"},
+	{regexp.MustCompile(`(?i)<strong>([\s\S]*?)</strong>`), "**$1**"},
+	{regexp.MustCompile(`(?i)<i>([\s\S]*?)</i>`), "_$1_"},
+	{regexp.MustCompile(`(?i)<em>([\s\S]*?)</em>`), "_$1_"},
+	{regexp.MustCompile(`(?i)<s>([\s\S]*?)</s>`), "~~$1~~"},
+	{regexp.MustCompile(`(?i)<strike>([\s\S]*?)</strike>`), "~~$1~~"},
+	{regexp.MustCompile(`(?i)<del>([\s\S]*?)</del>`), "~~$1~~"},
+	{regexp.MustCompile(`(?i)<code>([\s\S]*?)</code>`), "`$1`"},
+	{regexp.MustCompile(`(?i)<a\s+href="([^"]+)"[^>]*>([\s\S]*?)</a>`), "[$2]($1)"},
+}
+
+func htmlTagToMarkdown(text string) string {
+	for _, r := range htmlToMdReplacers {
+		text = r.re.ReplaceAllString(text, r.repl)
+	}
+	return text
+}
+
+// markdownToTelegramHTML converts markdown text to Telegram HTML.
+func markdownToTelegramHTML(text string) string {
+	if text == "" {
+		return ""
+	}
+
+	// Pre-process: convert any HTML tags in LLM output to markdown equivalents.
+	text = htmlTagToMarkdown(text)
+
+	// Extract and protect code blocks
+	codeBlocks := extractCodeBlocks(text)
+	text = codeBlocks.text
+
+	// Extract and protect inline code
+	inlineCodes := extractInlineCodes(text)
+	text = inlineCodes.text
+
+	// Strip markdown headers
+	text = reHeader.ReplaceAllString(text, "$1")
+
+	// Convert blockquotes: > text → <blockquote>text</blockquote>
+	text = convertBlockquotes(text)
+
+	// Escape HTML
+	text = escapeHTML(text)
+
+	// Convert markdown links
+	text = reLink.ReplaceAllString(text, `<a href="$2">$1</a>`)
+
+	// Bold
+	text = reBoldAsterisks.ReplaceAllString(text, "<b>$1</b>")
+	text = reBoldUnderscores.ReplaceAllString(text, "<b>$1</b>")
+
+	// Protect @mentions from italic conversion.
+	var mentionPlaceholders []string
+	text = reMention.ReplaceAllStringFunc(text, func(s string) string {
+		match := reMention.FindStringSubmatch(s)
+		if len(match) < 3 {
+			return s
+		}
+		idx := len(mentionPlaceholders)
+		mentionPlaceholders = append(mentionPlaceholders, match[2])
+		return match[1] + fmt.Sprintf("\x00MN%d\x00", idx)
+	})
+
+	// Italic
+	text = reItalic.ReplaceAllStringFunc(text, func(s string) string {
+		match := reItalic.FindStringSubmatch(s)
+		if len(match) < 2 {
+			return s
+		}
+		return "<i>" + match[1] + "</i>"
+	})
+
+	// Strikethrough
+	text = reStrike.ReplaceAllString(text, "<s>$1</s>")
+
+	// Restore @mentions as plain text
+	for i, mention := range mentionPlaceholders {
+		text = strings.ReplaceAll(text, fmt.Sprintf("\x00MN%d\x00", i), mention)
+	}
+
+	// List items
+	text = reListItem.ReplaceAllString(text, "• ")
+
+	// Restore inline code
+	for i, code := range inlineCodes.codes {
+		escaped := escapeHTML(code)
+		text = strings.ReplaceAll(text, fmt.Sprintf("\x00IC%d\x00", i), "<code>"+escaped+"</code>")
+	}
+
+	// Restore code blocks
+	for i, code := range codeBlocks.codes {
+		escaped := escapeHTML(code)
+		text = strings.ReplaceAll(text, fmt.Sprintf("\x00CB%d\x00", i), "<pre><code>"+escaped+"</code></pre>")
+	}
+
+	return text
+}
+
+// --- Compiled regexes ---
+
+var (
+	reHeader         = regexp.MustCompile(`(?m)^#{1,6}\s+(.+)$`)
+	reLink           = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	reBoldAsterisks  = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	reBoldUnderscores = regexp.MustCompile(`__(.+?)__`)
+	reMention        = regexp.MustCompile(`(^|\W)(@\w+)`)
+	reItalic         = regexp.MustCompile(`_([^_]+)_`)
+	reStrike         = regexp.MustCompile(`~~(.+?)~~`)
+	reListItem       = regexp.MustCompile(`(?m)^[-*]\s+`)
+	reCodeBlock      = regexp.MustCompile("```[\\w]*\\n?([\\s\\S]*?)```")
+	reInlineCode     = regexp.MustCompile("`([^`]+)`")
+	reBlockquoteLine = regexp.MustCompile(`(?m)^>\s?(.*)$`)
+	reHTMLTag        = regexp.MustCompile(`<[^>]+>`)
+)
+
+// --- Blockquote conversion ---
+
+// convertBlockquotes converts consecutive `> ` prefixed lines into <blockquote> blocks.
+func convertBlockquotes(text string) string {
+	lines := strings.Split(text, "\n")
+	var result []string
+	inQuote := false
+
+	for _, line := range lines {
+		match := reBlockquoteLine.FindStringSubmatch(line)
+		if match != nil {
+			if !inQuote {
+				result = append(result, "<blockquote>")
+				inQuote = true
+			}
+			result = append(result, match[1])
+		} else {
+			if inQuote {
+				result = append(result, "</blockquote>")
+				inQuote = false
+			}
+			result = append(result, line)
+		}
+	}
+	if inQuote {
+		result = append(result, "</blockquote>")
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// --- Code block extraction ---
+
+type codeBlockMatch struct {
+	text  string
+	codes []string
+}
+
+func extractCodeBlocks(text string) codeBlockMatch {
+	matches := reCodeBlock.FindAllStringSubmatch(text, -1)
+	codes := make([]string, 0, len(matches))
+	for _, match := range matches {
+		codes = append(codes, match[1])
+	}
+
+	i := 0
+	text = reCodeBlock.ReplaceAllStringFunc(text, func(_ string) string {
+		placeholder := fmt.Sprintf("\x00CB%d\x00", i)
+		i++
+		return placeholder
+	})
+
+	return codeBlockMatch{text: text, codes: codes}
+}
+
+type inlineCodeMatch struct {
+	text  string
+	codes []string
+}
+
+func extractInlineCodes(text string) inlineCodeMatch {
+	matches := reInlineCode.FindAllStringSubmatch(text, -1)
+	codes := make([]string, 0, len(matches))
+	for _, match := range matches {
+		codes = append(codes, match[1])
+	}
+
+	i := 0
+	text = reInlineCode.ReplaceAllStringFunc(text, func(_ string) string {
+		placeholder := fmt.Sprintf("\x00IC%d\x00", i)
+		i++
+		return placeholder
+	})
+
+	return inlineCodeMatch{text: text, codes: codes}
+}
+
+// --- HTML utilities ---
+
+func escapeHTML(text string) string {
+	text = strings.ReplaceAll(text, "&", "&amp;")
+	text = strings.ReplaceAll(text, "<", "&lt;")
+	text = strings.ReplaceAll(text, ">", "&gt;")
+	return text
+}
+
+// stripHTML removes all HTML tags for plain-text fallback.
+func stripHTML(text string) string {
+	// Decode common entities first
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&quot;", `"`)
+	// Strip tags
+	text = reHTMLTag.ReplaceAllString(text, "")
+	return text
+}
+
+// --- HTML-safe message chunking ---
+
+// chunkHTML splits HTML text into chunks that fit within maxLen.
+// Prefers splitting at paragraph boundaries (\n\n), then line (\n), then word (space).
+// Avoids splitting inside HTML tags or entities.
+func chunkHTML(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	remaining := text
+
+	for len(remaining) > 0 {
+		if len(remaining) <= maxLen {
+			chunks = append(chunks, remaining)
+			break
+		}
+
+		cutAt := maxLen
+
+		// 1. Look for preferred boundaries: paragraph, then newline, then space.
+		if idx := strings.LastIndex(remaining[:cutAt], "\n\n"); idx > 0 {
+			cutAt = idx + 2
+		} else if idx := strings.LastIndex(remaining[:cutAt], "\n"); idx > 0 {
+			cutAt = idx + 1
+		} else if idx := strings.LastIndex(remaining[:cutAt], " "); idx > 0 {
+			cutAt = idx + 1
+		}
+
+		// 2. Safety: don't cut in the middle of an HTML tag.
+		if lastOpen := strings.LastIndex(remaining[:cutAt], "<"); lastOpen != -1 {
+			lastClose := strings.LastIndex(remaining[:cutAt], ">")
+			if lastOpen > lastClose {
+				cutAt = lastOpen
+			}
+		}
+
+		// 3. Safety: don't cut in the middle of an HTML entity.
+		if lastAmp := strings.LastIndex(remaining[:cutAt], "&"); lastAmp != -1 {
+			lastSemi := strings.LastIndex(remaining[:cutAt], ";")
+			if lastAmp > lastSemi {
+				cutAt = lastAmp
+			}
+		}
+
+		// 4. Fallback: if safety moved cutAt to 0, force progress.
+		if cutAt <= 0 {
+			cutAt = maxLen
+		}
+
+		chunks = append(chunks, strings.TrimRight(remaining[:cutAt], " \n"))
+		remaining = strings.TrimLeft(remaining[cutAt:], " \n")
+	}
+
+	return chunks
+}

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -382,8 +382,8 @@ func (h *Handler) handleCallback(cb *tgbotapi.CallbackQuery) {
 	h.approvalMu.Unlock()
 
 	if !ok {
-		edit := tgbotapi.NewEditMessageText(chatID, cb.Message.MessageID, "_(expired)_")
-		edit.ParseMode = "Markdown"
+		edit := tgbotapi.NewEditMessageText(chatID, cb.Message.MessageID, "<i>(expired)</i>")
+		edit.ParseMode = "HTML"
 		_, _ = h.bot.Send(edit)
 		return
 	}
@@ -420,13 +420,14 @@ func toolLabel(name, inputJSON string) string {
 	return name
 }
 
-// sendText sends a plain/markdown message and returns the message ID.
+// sendText converts markdown to Telegram HTML and sends the message.
 func (h *Handler) sendText(chatID int64, text string) int {
-	msg := tgbotapi.NewMessage(chatID, text)
-	msg.ParseMode = "Markdown"
+	html := markdownToTelegramHTML(text)
+	msg := tgbotapi.NewMessage(chatID, html)
+	msg.ParseMode = "HTML"
 	sent, err := h.bot.Send(msg)
 	if err != nil {
-		msg2 := tgbotapi.NewMessage(chatID, stripMarkdown(text))
+		msg2 := tgbotapi.NewMessage(chatID, stripHTML(html))
 		sent, err = h.bot.Send(msg2)
 		if err != nil {
 			log.Printf("sendText: %v", err)

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
@@ -126,7 +125,7 @@ func (s *Streamer) renderDisplay() string {
 	}
 
 	if assistantText == "" {
-		return "⏳ _Thinking..._"
+		return "⏳ <i>Thinking...</i>"
 	}
 
 	return assistantText
@@ -141,7 +140,7 @@ func (s *Streamer) toolStatusLine() string {
 	if s.toolCount > len(s.toolNames) {
 		names += fmt.Sprintf(" (+%d more)", s.toolCount-len(s.toolNames))
 	}
-	return fmt.Sprintf("🔧 _%s_", names)
+	return fmt.Sprintf("🔧 <i>%s</i>", names)
 }
 
 func (s *Streamer) sendText(text string) {
@@ -149,13 +148,16 @@ func (s *Streamer) sendText(text string) {
 		return
 	}
 
-	if utf8.RuneCountInString(text) <= maxTelegramMsg {
-		s.editCurrent(text)
+	// Convert markdown to Telegram HTML
+	html := markdownToTelegramHTML(text)
+
+	if len(html) <= maxTelegramMsg {
+		s.editCurrent(html)
 		return
 	}
 
-	// Smart split: respect paragraph boundaries and code fences
-	chunks := smartSplit(text, maxTelegramMsg)
+	// Split respecting HTML tag and entity boundaries
+	chunks := chunkHTML(html, maxTelegramMsg)
 	if len(chunks) == 0 {
 		return
 	}
@@ -166,10 +168,10 @@ func (s *Streamer) sendText(text string) {
 	// Send remaining chunks as new messages
 	for _, chunk := range chunks[1:] {
 		msg := tgbotapi.NewMessage(s.chatID, chunk)
-		msg.ParseMode = "Markdown"
+		msg.ParseMode = "HTML"
 		sent, err := s.bot.Send(msg)
 		if err != nil {
-			msg2 := tgbotapi.NewMessage(s.chatID, stripMarkdown(chunk))
+			msg2 := tgbotapi.NewMessage(s.chatID, stripHTML(chunk))
 			sent, err = s.bot.Send(msg2)
 		}
 		if err != nil {
@@ -192,10 +194,10 @@ func (s *Streamer) sendText(text string) {
 func (s *Streamer) editCurrent(text string) {
 	if s.messageID == 0 {
 		msg := tgbotapi.NewMessage(s.chatID, text)
-		msg.ParseMode = "Markdown"
+		msg.ParseMode = "HTML"
 		sent, err := s.bot.Send(msg)
 		if err != nil {
-			msg2 := tgbotapi.NewMessage(s.chatID, stripMarkdown(text))
+			msg2 := tgbotapi.NewMessage(s.chatID, stripHTML(text))
 			sent, err = s.bot.Send(msg2)
 		}
 		if err != nil {
@@ -209,10 +211,10 @@ func (s *Streamer) editCurrent(text string) {
 	}
 
 	edit := tgbotapi.NewEditMessageText(s.chatID, s.messageID, text)
-	edit.ParseMode = "Markdown"
+	edit.ParseMode = "HTML"
 	_, err := s.bot.Send(edit)
 	if err != nil {
-		edit2 := tgbotapi.NewEditMessageText(s.chatID, s.messageID, stripMarkdown(text))
+		edit2 := tgbotapi.NewEditMessageText(s.chatID, s.messageID, stripHTML(text))
 		edit2.ParseMode = ""
 		_, _ = s.bot.Send(edit2)
 	}
@@ -248,14 +250,16 @@ func (s *Streamer) SendPhoto(path string, caption string) {
 
 // SendRaw sends a new message (not an edit).
 func (s *Streamer) SendRaw(text string, markup *tgbotapi.InlineKeyboardMarkup) (int, error) {
-	msg := tgbotapi.NewMessage(s.chatID, text)
-	msg.ParseMode = "Markdown"
+	html := markdownToTelegramHTML(text)
+	msg := tgbotapi.NewMessage(s.chatID, html)
+	msg.ParseMode = "HTML"
 	if markup != nil {
 		msg.ReplyMarkup = markup
 	}
 	sent, err := s.bot.Send(msg)
 	if err != nil {
-		msg.ParseMode = ""
+		msg := tgbotapi.NewMessage(s.chatID, stripHTML(html))
+		msg.ReplyMarkup = markup
 		sent, err = s.bot.Send(msg)
 	}
 	return sent.MessageID, err
@@ -289,68 +293,6 @@ func filterContent(text string) string {
 	return text
 }
 
-// --- Smart chunking ---
-
-// smartSplit splits text at paragraph boundaries (\n\n), respecting code fences.
-func smartSplit(text string, limit int) []string {
-	if utf8.RuneCountInString(text) <= limit {
-		return []string{text}
-	}
-
-	var chunks []string
-	remaining := text
-
-	for utf8.RuneCountInString(remaining) > limit {
-		// Find the best split point within the limit
-		runes := []rune(remaining)
-		cutAt := limit
-
-		// Try splitting at paragraph boundary (\n\n)
-		searchRegion := string(runes[:cutAt])
-		lastParaBreak := strings.LastIndex(searchRegion, "\n\n")
-		if lastParaBreak > limit/4 { // don't split too early
-			cutAt = utf8.RuneCountInString(searchRegion[:lastParaBreak])
-		} else {
-			// Try splitting at single newline
-			lastNewline := strings.LastIndex(searchRegion, "\n")
-			if lastNewline > limit/4 {
-				cutAt = utf8.RuneCountInString(searchRegion[:lastNewline])
-			}
-		}
-
-		// Check if we're inside a code fence — if so, find the closing fence
-		chunk := string(runes[:cutAt])
-		if isInsideCodeFence(chunk) {
-			// Extend to include the closing fence
-			closingIdx := strings.Index(string(runes[cutAt:]), "```")
-			if closingIdx >= 0 && closingIdx < limit/2 {
-				cutAt += utf8.RuneCountInString(string(runes[cutAt:][:closingIdx+3]))
-			}
-		}
-
-		chunks = append(chunks, strings.TrimSpace(string(runes[:cutAt])))
-		remaining = strings.TrimSpace(string(runes[cutAt:]))
-	}
-
-	if remaining != "" {
-		chunks = append(chunks, remaining)
-	}
-
-	return chunks
-}
-
-// isInsideCodeFence checks if text ends with an unclosed ``` block.
-func isInsideCodeFence(text string) bool {
-	count := strings.Count(text, "```")
-	return count%2 != 0 // odd = unclosed
-}
-
-// --- Formatting helpers (kept for backward compat but simplified) ---
-
-func stripMarkdown(s string) string {
-	r := strings.NewReplacer("```", "", "`", "", "**", "", "__", "", "*", "", "_", "")
-	return r.Replace(s)
-}
 
 func truncate(s string, maxRunes int) string {
 	runes := []rune(s)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -546,8 +546,8 @@ func TestLive_FullRoundtrip(t *testing.T) {
 	t.Log("step 3: tool executor ready")
 
 	// --- Step 4: Send "thinking" placeholder ---
-	placeholder := tgbotapi.NewMessage(chatID, "⏳ _NanoClaw integration test — thinking..._")
-	placeholder.ParseMode = "Markdown"
+	placeholder := tgbotapi.NewMessage(chatID, "⏳ <i>NanoClaw integration test — thinking...</i>")
+	placeholder.ParseMode = "HTML"
 	placeholderMsg, err := bot.Send(placeholder)
 	if err != nil {
 		t.Fatalf("send placeholder: %v", err)
@@ -608,12 +608,12 @@ func TestLive_FullRoundtrip(t *testing.T) {
 	}
 
 	edit := tgbotapi.NewEditMessageText(chatID, placeholderMsg.MessageID,
-		fmt.Sprintf("🧪 *NanoClaw Full Roundtrip Test*\n\n%s\n\n_iterations: %d | tokens: %d in / %d out_",
+		fmt.Sprintf("🧪 <b>NanoClaw Full Roundtrip Test</b>\n\n%s\n\n<i>iterations: %d | tokens: %d in / %d out</i>",
 			finalText, result.Iterations, result.Usage.InputTokens, result.Usage.OutputTokens))
-	edit.ParseMode = "Markdown"
+	edit.ParseMode = "HTML"
 	_, err = bot.Send(edit)
 	if err != nil {
-		// Retry without markdown
+		// Retry without HTML formatting
 		edit2 := tgbotapi.NewEditMessageText(chatID, placeholderMsg.MessageID, finalText)
 		bot.Send(edit2)
 	}


### PR DESCRIPTION
Replace fragile ParseMode "Markdown" with "HTML" across all send paths. Add markdownToTelegramHTML() converter ported from goclaw (bold, italic, strikethrough, code blocks, links, blockquotes, @mention protection). Add tag/entity-safe HTML chunking that won't split inside <tags> or &entities;.