### PR TITLE
docs: add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-seo-tag", "~> 2.8"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,26 @@
+title: NanoClaw
+description: Lean AI agent that gives Claude full control over your computer
+url: "https://phanngoc.github.io"
+baseurl: "/goterm-control"
+
+markdown: kramdown
+highlighter: rouge
+
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor
+
+plugins:
+  - jekyll-seo-tag

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} | {{ site.title }}</title>
+  <meta name="description" content="{{ page.description | default: site.description }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" id="navbar">
+    <div class="nav-inner">
+      <a href="{{ '/' | relative_url }}" class="nav-logo">
+        <span class="nav-logo-icon">&#x1F9BE;</span>
+        <span>NanoClaw</span>
+      </a>
+      <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+      <div class="nav-links" id="navLinks">
+        <a href="{{ '/' | relative_url }}" {% if page.url == '/' %}class="active"{% endif %}>Home</a>
+        <a href="{{ '/getting-started' | relative_url }}" {% if page.url == '/getting-started' %}class="active"{% endif %}>Getting Started</a>
+        <a href="{{ '/architecture' | relative_url }}" {% if page.url == '/architecture' %}class="active"{% endif %}>Architecture</a>
+        <a href="{{ '/features' | relative_url }}" {% if page.url == '/features' %}class="active"{% endif %}>Features</a>
+        <a href="{{ '/telegram-bot' | relative_url }}" {% if page.url == '/telegram-bot' %}class="active"{% endif %}>Telegram Bot</a>
+        <a href="{{ '/dashboard' | relative_url }}" {% if page.url == '/dashboard' %}class="active"{% endif %}>Dashboard</a>
+        <a href="{{ '/configuration' | relative_url }}" {% if page.url == '/configuration' %}class="active"{% endif %}>Config</a>
+        <a href="{{ '/api-reference' | relative_url }}" {% if page.url == '/api-reference' %}class="active"{% endif %}>API</a>
+        <a href="https://github.com/phanngoc/goterm-control" class="nav-github" target="_blank" rel="noopener">
+          <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Content -->
+  <main class="main">
+    {{ content }}
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <div class="footer-logo">
+            <span>&#x1F9BE;</span> NanoClaw
+          </div>
+          <p>Lean AI agent that gives Claude full control over your computer.</p>
+        </div>
+        <div class="footer-links">
+          <h4>Documentation</h4>
+          <a href="{{ '/getting-started' | relative_url }}">Getting Started</a>
+          <a href="{{ '/architecture' | relative_url }}">Architecture</a>
+          <a href="{{ '/features' | relative_url }}">Features & Tools</a>
+          <a href="{{ '/configuration' | relative_url }}">Configuration</a>
+        </div>
+        <div class="footer-links">
+          <h4>Guides</h4>
+          <a href="{{ '/telegram-bot' | relative_url }}">Telegram Bot</a>
+          <a href="{{ '/dashboard' | relative_url }}">Web Dashboard</a>
+          <a href="{{ '/api-reference' | relative_url }}">API Reference</a>
+        </div>
+        <div class="footer-links">
+          <h4>Community</h4>
+          <a href="https://github.com/phanngoc/goterm-control" target="_blank">GitHub</a>
+          <a href="https://github.com/phanngoc/goterm-control/issues" target="_blank">Issues</a>
+          <a href="https://github.com/phanngoc/goterm-control/blob/main/LICENSE" target="_blank">MIT License</a>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2024-2026 NanoClaw. Built with Go. Powered by Claude.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Mobile nav toggle
+    const toggle = document.getElementById('navToggle');
+    const links = document.getElementById('navLinks');
+    toggle.addEventListener('click', () => {
+      links.classList.toggle('open');
+      toggle.classList.toggle('open');
+    });
+
+    // Navbar scroll effect
+    window.addEventListener('scroll', () => {
+      document.getElementById('navbar').classList.toggle('scrolled', window.scrollY > 20);
+    });
+  </script>
+</body>
+</html>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,384 @@
+---
+title: API Reference
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# API Reference
+
+<p class="lead">WebSocket JSON-RPC API for programmatic control of the NanoClaw gateway.</p>
+
+## Connection
+
+Connect via WebSocket to the gateway:
+
+```
+ws://127.0.0.1:18789/ws
+```
+
+All messages use the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) protocol.
+
+## HTTP Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/health` | GET | Health check, returns `{"status": "ok"}` |
+| `/ws` | WebSocket | JSON-RPC WebSocket endpoint |
+| `/*` | GET | Serves dashboard static files |
+
+## JSON-RPC Methods
+
+### `status`
+
+Get gateway health and status.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "status"
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "status": "ok",
+    "uptime": "2h15m30s",
+    "sessions": 3
+  }
+}
+```
+
+### `models.list`
+
+List available models with pricing and aliases.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "models.list"
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "models": [
+      {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "aliases": ["opus", "o4"],
+        "context_window": 200000,
+        "input_price": 15.0,
+        "output_price": 75.0
+      }
+    ],
+    "default": "claude-sonnet-4-6"
+  }
+}
+```
+
+### `sessions.list`
+
+List all sessions.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "sessions.list"
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "sessions": [
+      {
+        "id": "chat_abc123",
+        "created_at": "2026-04-10T10:00:00Z",
+        "updated_at": "2026-04-10T10:15:00Z",
+        "message_count": 12,
+        "model": "claude-sonnet-4-6"
+      }
+    ]
+  }
+}
+```
+
+### `sessions.get`
+
+Get details for a specific session.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "sessions.get",
+  "params": {
+    "session_id": "chat_abc123"
+  }
+}
+```
+
+### `sessions.reset`
+
+Clear a session's conversation history.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "sessions.reset",
+  "params": {
+    "session_id": "chat_abc123"
+  }
+}
+```
+
+### `transcript.get`
+
+Load the full event transcript for a session.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "transcript.get",
+  "params": {
+    "session_id": "chat_abc123"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "events": [
+      {
+        "type": "user_message",
+        "timestamp": "2026-04-10T10:00:00Z",
+        "content": "Hello!"
+      },
+      {
+        "type": "assistant_text",
+        "timestamp": "2026-04-10T10:00:01Z",
+        "content": "Hi! How can I help?"
+      }
+    ]
+  }
+}
+```
+
+### `send`
+
+Send a message and receive a streaming response.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "send",
+  "params": {
+    "session_id": "chat_abc123",
+    "message": "List all files in the current directory",
+    "model": "opus"
+  }
+}
+```
+
+**Streaming events** (sent as separate messages with the same `id`):
+
+```json
+// Text chunk
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "stream.text",
+  "params": { "text": "I'll list the files " }
+}
+
+// Tool use
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "stream.tool_use",
+  "params": {
+    "tool": "run_shell",
+    "input": { "command": "ls -la" }
+  }
+}
+
+// Tool result
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "stream.tool_result",
+  "params": {
+    "tool": "run_shell",
+    "output": "total 48\ndrwxr-xr-x  12 user  staff  384 Apr 10 10:00 .\n..."
+  }
+}
+
+// Final response
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "status": "complete",
+    "tokens": { "input": 1250, "output": 340 }
+  }
+}
+```
+
+### `cancel`
+
+Cancel an in-flight request.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "cancel",
+  "params": {
+    "session_id": "chat_abc123"
+  }
+}
+```
+
+## Client Example
+
+### JavaScript/TypeScript
+
+```javascript
+const ws = new WebSocket('ws://127.0.0.1:18789/ws');
+let requestId = 0;
+
+ws.onopen = () => {
+  // Send a message
+  ws.send(JSON.stringify({
+    jsonrpc: '2.0',
+    id: ++requestId,
+    method: 'send',
+    params: {
+      session_id: 'my-session',
+      message: 'What files are in ~/Documents?'
+    }
+  }));
+};
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  
+  if (msg.method === 'stream.text') {
+    process.stdout.write(msg.params.text);
+  } else if (msg.method === 'stream.tool_use') {
+    console.log(`\n[Tool: ${msg.params.tool}]`);
+  } else if (msg.result) {
+    console.log('\n--- Complete ---');
+  }
+};
+```
+
+### Python
+
+```python
+import json
+import websocket
+
+ws = websocket.create_connection("ws://127.0.0.1:18789/ws")
+
+ws.send(json.dumps({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "send",
+    "params": {
+        "session_id": "my-session",
+        "message": "Hello, Claude!"
+    }
+}))
+
+while True:
+    msg = json.loads(ws.recv())
+    if "method" in msg and msg["method"] == "stream.text":
+        print(msg["params"]["text"], end="", flush=True)
+    elif "result" in msg:
+        print("\n--- Complete ---")
+        break
+
+ws.close()
+```
+
+### Go
+
+```go
+import (
+    "github.com/gorilla/websocket"
+    "encoding/json"
+)
+
+conn, _, _ := websocket.DefaultDialer.Dial("ws://127.0.0.1:18789/ws", nil)
+
+request := map[string]interface{}{
+    "jsonrpc": "2.0",
+    "id":      1,
+    "method":  "send",
+    "params": map[string]string{
+        "session_id": "my-session",
+        "message":    "Hello from Go!",
+    },
+}
+conn.WriteJSON(request)
+
+for {
+    _, msg, _ := conn.ReadMessage()
+    var resp map[string]interface{}
+    json.Unmarshal(msg, &resp)
+    
+    if method, ok := resp["method"]; ok && method == "stream.text" {
+        params := resp["params"].(map[string]interface{})
+        fmt.Print(params["text"])
+    }
+    if _, ok := resp["result"]; ok {
+        break
+    }
+}
+```
+
+<div class="doc-nav">
+  <a href="{{ '/configuration' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Configuration</div>
+  </a>
+  <a href="{{ '/' | relative_url }}" class="next">
+    <div class="label">Back to</div>
+    <div class="title">Home</div>
+  </a>
+</div>
+
+</div>
+</section>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,193 @@
+---
+title: Architecture
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Architecture
+
+<p class="lead">How NanoClaw is structured &mdash; channels, gateway, agent loop, and tools.</p>
+
+## Overview
+
+NanoClaw follows a simple layered architecture:
+
+1. **Channels** receive user messages (Telegram, Web, CLI)
+2. **Gateway** routes messages, manages sessions, resolves models
+3. **Agent Loop** streams model responses and executes tool calls
+4. **Tools** interact with the operating system and browser
+5. **Storage** persists sessions, transcripts, and cross-session memory
+
+```
+┌───────────┐  ┌──────────────┐  ┌───────────────┐
+│  Telegram  │  │ Web Dashboard│  │   CLI Chat    │
+│  Bot       │  │  (React SPA) │  │               │
+└─────┬──────┘  └──────┬───────┘  └───────┬───────┘
+      │           WebSocket          direct call
+      │               │                  │
+      ▼               ▼                  ▼
+┌─────────────────────────────────────────────────┐
+│              Gateway (JSON-RPC)                  │
+│         session mgmt · model resolver            │
+└──────────────────────┬──────────────────────────┘
+                       │
+              ┌─────────────────┐
+              │   Agent Loop    │  ← up to 50 iterations
+              │  stream + tool  │
+              │   call cycle    │
+              └────────┬────────┘
+                       │
+          ┌────────────┼────────────┐
+          ▼            ▼            ▼
+   ┌────────────┐ ┌──────────┐ ┌──────────┐
+   │ Claude CLI │ │  Direct  │ │   Tool   │
+   │  (OAuth2)  │ │   API    │ │ Executor │
+   └────────────┘ └──────────┘ └──────────┘
+```
+
+## The Agent Loop
+
+The heart of NanoClaw lives in `internal/agent/loop.go`. This is what makes it an *agent*, not just a chatbot:
+
+```
+user message
+  → assemble context (under token budget)
+  → stream model response
+  → if model calls tools:
+      → execute tools
+      → feed results back to model
+      → loop again (up to 50 iterations)
+  → if model says "end_turn":
+      → return final response
+  → if context overflow:
+      → compact (summarize old messages)
+      → retry
+  → if rate limited:
+      → exponential backoff → retry
+```
+
+The model can chain multiple tool calls in a single turn, read results, and keep working until the task is complete. This allows complex workflows like "find all TODO comments in the codebase, create a summary, and email it to me" to execute autonomously.
+
+## Packages
+
+| Package | Purpose |
+|---|---|
+| `agent/` | Core agentic loop with retry and tool execution |
+| `anthropic/` | Direct Anthropic Messages API client (streaming) |
+| `claude/` | Claude CLI subprocess provider (OAuth2 subscription) |
+| `browser/` | Chrome DevTools Protocol (CDP) client for browser automation |
+| `bot/` | Telegram bot with streaming message edits |
+| `channel/` | Channel abstraction (Telegram, CLI) |
+| `config/` | YAML config with env var overrides |
+| `context/` | Token counting, budget assembly, compaction |
+| `execution/` | Per-session FIFO queue (prevents concurrent calls) |
+| `gateway/` | WebSocket JSON-RPC server + static file serving (dashboard) |
+| `memory/` | Cross-session keyword memory |
+| `models/` | Model catalog with aliases and per-session override |
+| `session/` | Persistent session management |
+| `tools/` | System control tools (shell, files, screenshot, browser, ...) |
+| `transcript/` | JSONL event recording per session |
+
+## Project Structure
+
+```
+cmd/
+  nanoclaw/main.go          CLI entry point (gateway, chat, send, status, models)
+
+dashboard/                  React web dashboard (Vite + TailwindCSS)
+
+internal/
+  agent/                    Core agent loop + types
+  anthropic/                Direct Anthropic API client
+  bot/                      Telegram bot (handler, streamer)
+  browser/                  Chrome DevTools Protocol (CDP) client
+  channel/                  Channel interface + CLI implementation
+  claude/                   Claude CLI subprocess (OAuth2 provider)
+  config/                   YAML config loading
+  context/                  Context engine (tokens, assembly, compaction)
+  execution/                Per-session FIFO execution queue
+  gateway/                  WebSocket JSON-RPC server + dashboard hosting
+  memory/                   Cross-session keyword memory
+  models/                   Model catalog + resolver
+  session/                  Persistent session management
+  tools/                    System + browser control tools
+  transcript/               JSONL event recording
+```
+
+## Data Flow
+
+### Message Processing
+
+1. User sends a message via any channel (Telegram, Web, CLI)
+2. Gateway creates or retrieves the session
+3. Context engine assembles the prompt:
+   - System prompt
+   - Cross-session memory (keyword-matched, up to 5 entries)
+   - Session history (trimmed to fit token budget)
+   - New user message
+4. Agent loop streams the response from Claude
+5. If Claude calls tools, the executor runs them and feeds results back
+6. Response streams back to the user in real-time
+7. Transcript records all events as JSONL
+
+### Session Lifecycle
+
+- Sessions are created per Telegram chat ID or per WebSocket client
+- Each session has its own conversation history and token count
+- Sessions persist to disk as JSON metadata + JSONL transcripts
+- Idle sessions auto-reset after the configured timeout (default: 30 min)
+
+### Context Budget
+
+NanoClaw uses ~80% of the model's context window for assembled messages. When the budget is exceeded:
+
+1. Old messages are trimmed from the beginning of the conversation
+2. If still over budget, messages are compacted (summarized)
+3. The model always sees the system prompt + recent context + current message
+
+## Data Persistence
+
+All state lives under `~/.goterm/data/`:
+
+```
+~/.goterm/data/
+  sessions.json           # Session metadata (atomic writes)
+  transcripts/
+    chat_<id>.jsonl       # Per-session conversation log (append-only)
+  memory/
+    memory.jsonl          # Cross-session keyword memory
+```
+
+- **sessions.json** &mdash; Atomic writes via temp-file-then-rename to prevent corruption
+- **transcripts/** &mdash; Append-only JSONL, one event per line, never rewritten
+- **memory/** &mdash; Keyword-indexed entries for cross-session context injection
+
+## Compared to openclaw
+
+| | openclaw | NanoClaw |
+|---|---|---|
+| Language | TypeScript | Go |
+| Binary | Node.js + many deps | Single static binary (13MB) |
+| Source files | 1000+ | ~45 |
+| Auth | API keys only | Claude CLI OAuth2 or API key |
+| Providers | 40+ (plugin system) | Claude (CLI OAuth + direct API) |
+| Channels | 20+ (plugin system) | Telegram + Web Dashboard + CLI |
+| Memory | LanceDB + embeddings | JSONL + keyword search |
+| Config | ~200 fields | ~15 fields |
+| Target user | Teams, multi-tenant | Individual, single machine |
+
+<div class="doc-nav">
+  <a href="{{ '/getting-started' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Getting Started</div>
+  </a>
+  <a href="{{ '/features' | relative_url }}" class="next">
+    <div class="label">Next</div>
+    <div class="title">Features & Tools</div>
+  </a>
+</div>
+
+</div>
+</section>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,0 +1,356 @@
+/* ===== Reset & Variables ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0a0a0f;
+  --bg-card: #12121a;
+  --bg-code: #1a1a2e;
+  --bg-hover: #1e1e30;
+  --border: #2a2a3e;
+  --border-glow: #6366f1;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-dim: #64748b;
+  --accent: #818cf8;
+  --accent-bright: #a5b4fc;
+  --accent2: #34d399;
+  --accent3: #f472b6;
+  --accent4: #fbbf24;
+  --gradient-1: linear-gradient(135deg, #6366f1, #8b5cf6, #a855f7);
+  --gradient-2: linear-gradient(135deg, #34d399, #2dd4bf);
+  --gradient-text: linear-gradient(135deg, #818cf8, #a5b4fc, #c4b5fd);
+  --shadow: 0 4px 24px rgba(0,0,0,0.4);
+  --shadow-glow: 0 0 30px rgba(99,102,241,0.15);
+  --radius: 12px;
+  --radius-sm: 8px;
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --max-w: 1200px;
+  --nav-h: 64px;
+}
+
+html { scroll-behavior: smooth; }
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+a:hover { color: var(--accent-bright); }
+
+img { max-width: 100%; height: auto; }
+
+.container { max-width: var(--max-w); margin: 0 auto; padding: 0 24px; }
+
+/* ===== Navigation ===== */
+.nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+  background: rgba(10,10,15,0.8);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid transparent;
+  transition: all 0.3s;
+}
+.nav.scrolled { border-bottom-color: var(--border); background: rgba(10,10,15,0.95); }
+.nav-inner {
+  max-width: var(--max-w); margin: 0 auto; padding: 0 24px;
+  display: flex; align-items: center; justify-content: space-between;
+  height: var(--nav-h);
+}
+.nav-logo {
+  display: flex; align-items: center; gap: 8px;
+  font-weight: 700; font-size: 1.2rem; color: var(--text);
+}
+.nav-logo:hover { color: var(--accent-bright); }
+.nav-logo-icon { font-size: 1.5rem; }
+.nav-links {
+  display: flex; align-items: center; gap: 4px;
+}
+.nav-links a {
+  color: var(--text-muted); padding: 6px 12px; border-radius: var(--radius-sm);
+  font-size: 0.9rem; font-weight: 500; transition: all 0.2s;
+}
+.nav-links a:hover { color: var(--text); background: var(--bg-hover); }
+.nav-links a.active { color: var(--accent-bright); background: rgba(129,140,248,0.1); }
+.nav-github { display: flex; align-items: center; margin-left: 8px; }
+.nav-toggle { display: none; background: none; border: none; cursor: pointer; padding: 8px; }
+.nav-toggle span {
+  display: block; width: 22px; height: 2px; background: var(--text);
+  margin: 5px 0; transition: all 0.3s; border-radius: 2px;
+}
+.nav-toggle.open span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
+.nav-toggle.open span:nth-child(2) { opacity: 0; }
+.nav-toggle.open span:nth-child(3) { transform: rotate(-45deg) translate(5px, -5px); }
+
+/* ===== Main ===== */
+.main { margin-top: var(--nav-h); }
+
+/* ===== Hero ===== */
+.hero {
+  padding: 100px 24px 80px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.hero::before {
+  content: ''; position: absolute; top: -50%; left: -50%; right: -50%; bottom: -50%;
+  background: radial-gradient(ellipse at center, rgba(99,102,241,0.08) 0%, transparent 60%);
+  pointer-events: none;
+}
+.hero-badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 16px; border-radius: 999px;
+  background: rgba(99,102,241,0.1); border: 1px solid rgba(99,102,241,0.2);
+  font-size: 0.85rem; color: var(--accent); font-weight: 500;
+  margin-bottom: 24px;
+}
+.hero h1 {
+  font-size: clamp(2.5rem, 6vw, 4.5rem); font-weight: 800;
+  line-height: 1.1; margin-bottom: 20px;
+  background: var(--gradient-text); -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent; background-clip: text;
+}
+.hero-sub {
+  font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+  color: var(--text-muted); max-width: 640px; margin: 0 auto 40px;
+  line-height: 1.6;
+}
+.hero-actions { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 12px 28px; border-radius: var(--radius-sm);
+  font-weight: 600; font-size: 0.95rem; transition: all 0.2s;
+  border: none; cursor: pointer;
+}
+.btn-primary {
+  background: var(--gradient-1); color: white;
+  box-shadow: 0 4px 16px rgba(99,102,241,0.3);
+}
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 24px rgba(99,102,241,0.4); color: white; }
+.btn-outline {
+  background: transparent; color: var(--text);
+  border: 1px solid var(--border); padding: 11px 27px;
+}
+.btn-outline:hover { border-color: var(--accent); color: var(--accent); background: rgba(99,102,241,0.05); }
+
+.hero-code {
+  max-width: 600px; margin: 48px auto 0; text-align: left;
+  background: var(--bg-code); border: 1px solid var(--border);
+  border-radius: var(--radius); overflow: hidden;
+}
+.hero-code-header {
+  display: flex; align-items: center; gap: 6px;
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+  background: rgba(255,255,255,0.02);
+}
+.hero-code-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+}
+.hero-code-dot:nth-child(1) { background: #f87171; }
+.hero-code-dot:nth-child(2) { background: #fbbf24; }
+.hero-code-dot:nth-child(3) { background: #34d399; }
+.hero-code pre {
+  padding: 20px; margin: 0; overflow-x: auto;
+  font-family: var(--mono); font-size: 0.9rem; line-height: 1.8;
+  color: var(--text-muted);
+}
+.hero-code .cmd { color: var(--accent2); }
+.hero-code .comment { color: var(--text-dim); }
+.hero-code .flag { color: var(--accent4); }
+
+/* ===== Feature Cards ===== */
+.section { padding: 80px 24px; }
+.section-header {
+  text-align: center; margin-bottom: 56px;
+}
+.section-header h2 {
+  font-size: 2.2rem; font-weight: 700; margin-bottom: 12px;
+}
+.section-header p { color: var(--text-muted); font-size: 1.1rem; max-width: 560px; margin: 0 auto; }
+
+.features-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px; max-width: var(--max-w); margin: 0 auto;
+}
+.feature-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 32px;
+  transition: all 0.3s;
+}
+.feature-card:hover {
+  border-color: var(--border-glow); transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+.feature-icon {
+  width: 48px; height: 48px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.5rem; margin-bottom: 16px;
+}
+.feature-icon.purple { background: rgba(99,102,241,0.15); }
+.feature-icon.green { background: rgba(52,211,153,0.15); }
+.feature-icon.pink { background: rgba(244,114,182,0.15); }
+.feature-icon.yellow { background: rgba(251,191,36,0.15); }
+.feature-icon.blue { background: rgba(56,189,248,0.15); }
+.feature-icon.red { background: rgba(248,113,113,0.15); }
+.feature-card h3 { font-size: 1.15rem; font-weight: 600; margin-bottom: 8px; }
+.feature-card p { color: var(--text-muted); font-size: 0.95rem; line-height: 1.6; }
+
+/* ===== Architecture Diagram ===== */
+.arch-diagram {
+  background: var(--bg-code); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 32px;
+  max-width: 800px; margin: 0 auto;
+  overflow-x: auto;
+}
+.arch-diagram pre {
+  font-family: var(--mono); font-size: 0.85rem;
+  line-height: 1.5; color: var(--text-muted); margin: 0;
+}
+
+/* ===== Stats ===== */
+.stats {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 24px; max-width: 800px; margin: 0 auto; padding: 24px 0;
+}
+.stat { text-align: center; }
+.stat-value {
+  font-size: 2.5rem; font-weight: 800;
+  background: var(--gradient-text); -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.stat-label { color: var(--text-muted); font-size: 0.9rem; margin-top: 4px; }
+
+/* ===== CTA ===== */
+.cta {
+  text-align: center; padding: 80px 24px;
+  background: linear-gradient(180deg, transparent, rgba(99,102,241,0.05));
+}
+.cta h2 { font-size: 2rem; font-weight: 700; margin-bottom: 16px; }
+.cta p { color: var(--text-muted); margin-bottom: 32px; font-size: 1.1rem; }
+
+/* ===== Doc Pages ===== */
+.doc-page { padding: 48px 24px 80px; }
+.doc-content {
+  max-width: 800px; margin: 0 auto;
+}
+.doc-content h1 {
+  font-size: 2.2rem; font-weight: 700; margin-bottom: 8px;
+  background: var(--gradient-text); -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.doc-content .lead { color: var(--text-muted); font-size: 1.15rem; margin-bottom: 40px; }
+.doc-content h2 {
+  font-size: 1.5rem; font-weight: 600; margin: 48px 0 16px;
+  padding-bottom: 8px; border-bottom: 1px solid var(--border);
+}
+.doc-content h3 { font-size: 1.2rem; font-weight: 600; margin: 32px 0 12px; }
+.doc-content h4 { font-size: 1.05rem; font-weight: 600; margin: 24px 0 8px; color: var(--accent); }
+.doc-content p { margin-bottom: 16px; color: var(--text); }
+.doc-content ul, .doc-content ol { margin-bottom: 16px; padding-left: 24px; }
+.doc-content li { margin-bottom: 6px; color: var(--text); }
+.doc-content li::marker { color: var(--accent); }
+
+.doc-content code {
+  font-family: var(--mono); font-size: 0.88em;
+  background: var(--bg-code); padding: 2px 8px;
+  border-radius: 4px; border: 1px solid var(--border);
+  color: var(--accent-bright);
+}
+.doc-content pre {
+  background: var(--bg-code); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 20px;
+  margin-bottom: 24px; overflow-x: auto;
+  font-family: var(--mono); font-size: 0.88rem; line-height: 1.7;
+}
+.doc-content pre code {
+  background: none; border: none; padding: 0; color: var(--text-muted);
+}
+
+.doc-content table {
+  width: 100%; border-collapse: collapse; margin-bottom: 24px;
+  font-size: 0.92rem;
+}
+.doc-content th, .doc-content td {
+  text-align: left; padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.doc-content th {
+  font-weight: 600; color: var(--accent-bright);
+  background: var(--bg-code);
+}
+.doc-content tr:hover td { background: rgba(255,255,255,0.02); }
+
+.doc-content blockquote {
+  border-left: 3px solid var(--accent); padding: 12px 20px;
+  background: rgba(99,102,241,0.05); border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  margin-bottom: 24px; color: var(--text-muted);
+}
+
+/* Info/warning boxes */
+.info-box {
+  padding: 16px 20px; border-radius: var(--radius-sm);
+  margin-bottom: 24px; border-left: 3px solid;
+}
+.info-box.tip { background: rgba(52,211,153,0.08); border-color: var(--accent2); }
+.info-box.warn { background: rgba(251,191,36,0.08); border-color: var(--accent4); }
+.info-box.note { background: rgba(99,102,241,0.08); border-color: var(--accent); }
+
+/* Prev/Next navigation */
+.doc-nav {
+  display: flex; justify-content: space-between; gap: 16px;
+  margin-top: 64px; padding-top: 32px; border-top: 1px solid var(--border);
+}
+.doc-nav a {
+  padding: 16px 20px; border: 1px solid var(--border);
+  border-radius: var(--radius-sm); flex: 1; transition: all 0.2s;
+}
+.doc-nav a:hover { border-color: var(--accent); background: rgba(99,102,241,0.05); }
+.doc-nav .label { font-size: 0.8rem; color: var(--text-dim); text-transform: uppercase; }
+.doc-nav .title { font-weight: 600; color: var(--text); }
+.doc-nav .next { text-align: right; }
+
+/* ===== Comparison Table ===== */
+.comparison-table {
+  overflow-x: auto; margin-bottom: 24px;
+}
+
+/* ===== Footer ===== */
+.footer {
+  border-top: 1px solid var(--border); padding: 56px 24px 32px;
+  background: rgba(0,0,0,0.3);
+}
+.footer-grid {
+  display: grid; grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 40px; max-width: var(--max-w); margin: 0 auto;
+}
+.footer-logo { font-size: 1.2rem; font-weight: 700; margin-bottom: 12px; }
+.footer-brand p { color: var(--text-muted); font-size: 0.9rem; }
+.footer-links h4 { font-size: 0.85rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); margin-bottom: 12px; }
+.footer-links a { display: block; color: var(--text-muted); font-size: 0.9rem; padding: 4px 0; }
+.footer-links a:hover { color: var(--accent-bright); }
+.footer-bottom {
+  text-align: center; margin-top: 48px; padding-top: 24px;
+  border-top: 1px solid var(--border); color: var(--text-dim); font-size: 0.85rem;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .nav-toggle { display: block; }
+  .nav-links {
+    display: none; position: absolute; top: var(--nav-h); left: 0; right: 0;
+    background: rgba(10,10,15,0.98); backdrop-filter: blur(16px);
+    flex-direction: column; padding: 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-links.open { display: flex; }
+  .nav-links a { padding: 12px 16px; }
+
+  .hero { padding: 60px 16px 48px; }
+  .section { padding: 48px 16px; }
+  .features-grid { grid-template-columns: 1fr; }
+  .footer-grid { grid-template-columns: 1fr 1fr; gap: 24px; }
+  .stats { grid-template-columns: repeat(2, 1fr); }
+  .doc-nav { flex-direction: column; }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,163 @@
+---
+title: Configuration
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Configuration
+
+<p class="lead">NanoClaw is designed to work with minimal configuration. Most fields have sensible defaults.</p>
+
+## Configuration File
+
+Edit `config.yaml` in the project root:
+
+```yaml
+claude:
+  api_key: ""                    # Auto-detected from Claude CLI OAuth
+  model: "claude-sonnet-4-6"     # Default model
+  system_prompt: |
+    You are an AI assistant with full control over this computer...
+
+models:
+  default: ""                    # Override claude.model
+  # custom:                      # Add custom models
+  #   - id: "deepseek-r1"
+  #     name: "DeepSeek R1"
+  #     context_window: 128000
+  #     input_price: 0.55
+  #     output_price: 2.19
+
+session:
+  data_dir: ""                   # Default: ~/.goterm/data
+  idle_timeout: 30               # Minutes before auto-reset
+
+memory:
+  enabled: true
+  max_entries: 5                 # Memories injected per prompt
+
+security:
+  allowed_user_ids: []           # Telegram user whitelist (empty = all)
+
+tools:
+  shell_timeout: 60              # Seconds
+  max_output_bytes: 8192         # Truncation limit
+```
+
+## Configuration Reference
+
+### `claude`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | string | `""` | API key. Auto-detected from Claude CLI or `ANTHROPIC_API_KEY` env var. |
+| `model` | string | `"claude-sonnet-4-6"` | Default model for new sessions. |
+| `system_prompt` | string | (built-in) | System prompt sent with every request. |
+
+### `models`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `default` | string | `""` | Override `claude.model`. Takes precedence. |
+| `custom` | list | `[]` | Additional model definitions (id, name, context_window, pricing). |
+
+#### Custom Model Example
+
+```yaml
+models:
+  custom:
+    - id: "deepseek-r1"
+      name: "DeepSeek R1"
+      context_window: 128000
+      input_price: 0.55
+      output_price: 2.19
+      aliases:
+        - "deepseek"
+        - "ds"
+```
+
+### `session`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `data_dir` | string | `~/.goterm/data` | Directory for sessions, transcripts, and memory. |
+| `idle_timeout` | int | `30` | Minutes before a session auto-resets. |
+
+### `memory`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Enable cross-session keyword memory. |
+| `max_entries` | int | `5` | Maximum memories injected per prompt. |
+
+### `security`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `allowed_user_ids` | list | `[]` | Telegram user ID whitelist. Empty = allow everyone. |
+
+### `tools`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `shell_timeout` | int | `60` | Maximum seconds for shell command execution. |
+| `max_output_bytes` | int | `8192` | Maximum output bytes before truncation. |
+
+## Environment Variables
+
+Environment variables override `config.yaml` values:
+
+| Variable | Overrides | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | `claude.api_key` | Anthropic API key for direct API access |
+| `TELEGRAM_TOKEN` | N/A | Telegram bot token (required for Telegram) |
+
+## Data Directory
+
+All persistent data is stored under the configured `session.data_dir` (default: `~/.goterm/data/`):
+
+```
+~/.goterm/data/
+  sessions.json           # Session metadata (atomic writes)
+  transcripts/
+    chat_<id>.jsonl       # Per-session conversation log
+  memory/
+    memory.jsonl          # Cross-session keyword memory
+```
+
+> **Tip:** Back up `~/.goterm/data/` to preserve your conversation history and memories across reinstalls.
+
+## Gateway Options
+
+Command-line flags for the `gateway` command:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | `18789` | Port to listen on |
+| `--bind` | `127.0.0.1` | Address to bind to |
+
+```bash
+# Default: localhost only
+./nanoclaw gateway
+
+# Expose to local network
+./nanoclaw gateway --bind 0.0.0.0 --port 9000
+```
+
+> **Warning:** Binding to `0.0.0.0` exposes NanoClaw to your entire network. Only do this on trusted networks, and always configure `security.allowed_user_ids`.
+
+<div class="doc-nav">
+  <a href="{{ '/dashboard' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Dashboard</div>
+  </a>
+  <a href="{{ '/api-reference' | relative_url }}" class="next">
+    <div class="label">Next</div>
+    <div class="title">API Reference</div>
+  </a>
+</div>
+
+</div>
+</section>

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,153 @@
+---
+title: Web Dashboard
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Web Dashboard
+
+<p class="lead">A real-time React web interface for managing sessions and chatting with your agent.</p>
+
+## Overview
+
+The NanoClaw dashboard is a React SPA built with Vite and TailwindCSS. It connects to the gateway via WebSocket and provides:
+
+- **Session management** &mdash; Create, view, reset, and delete sessions
+- **Real-time chat** &mdash; Stream responses as Claude generates them
+- **Tool visibility** &mdash; See which tools Claude is using in real-time
+- **Status monitoring** &mdash; Gateway health, uptime, and active sessions
+
+## Accessing the Dashboard
+
+The dashboard is automatically served by the gateway. After starting:
+
+```bash
+./nanoclaw gateway --port 18789
+```
+
+Open your browser to:
+
+```
+http://localhost:18789
+```
+
+## Building the Dashboard
+
+If you need to rebuild the dashboard from source:
+
+```bash
+cd dashboard
+npm install
+npm run build
+```
+
+The build output goes to `dashboard/dist/`, which the gateway serves automatically.
+
+For development with hot reload:
+
+```bash
+cd dashboard
+npm run dev
+```
+
+## Pages
+
+### Sessions
+
+The sessions page lists all active and past sessions with:
+
+- Session ID
+- Creation time
+- Last update time
+- Message count
+
+Click a session to open its chat view, or create a new session.
+
+### Chat
+
+The chat view provides a full conversation interface:
+
+- **Message history** &mdash; All previous messages in the session
+- **Streaming responses** &mdash; Real-time token-by-token updates
+- **Tool badges** &mdash; Compact badges showing which tools were used (grouped, max 5 shown)
+- **Model selector** &mdash; Dropdown to switch models per-session
+- **Message input** &mdash; Send new messages to Claude
+
+### Status
+
+The status page shows:
+
+- Gateway health and uptime
+- Number of active sessions
+- Connection status
+
+## URL Routing
+
+The dashboard uses client-side routing:
+
+| Path | Page |
+|---|---|
+| `/` | Sessions list |
+| `/chat/{session_id}` | Chat view for a specific session |
+| `/status` | Status and health |
+
+The gateway handles SPA fallback &mdash; all unmatched routes return `index.html`.
+
+## Tech Stack
+
+| Technology | Version | Purpose |
+|---|---|---|
+| React | 19 | UI framework |
+| Vite | 6 | Build tool and dev server |
+| TailwindCSS | 4 | Utility-first styling |
+| Zustand | Latest | State management |
+| React Markdown | Latest | Message rendering |
+| TypeScript | Latest | Type safety |
+
+## WebSocket Protocol
+
+The dashboard communicates with the gateway using JSON-RPC over WebSocket:
+
+```json
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "send",
+  "params": {
+    "session_id": "abc123",
+    "message": "Hello, Claude!"
+  }
+}
+
+// Streaming response events
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "stream.text",
+  "params": { "text": "Hello! " }
+}
+
+// Final response
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": { "status": "complete" }
+}
+```
+
+<div class="doc-nav">
+  <a href="{{ '/telegram-bot' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Telegram Bot</div>
+  </a>
+  <a href="{{ '/configuration' | relative_url }}" class="next">
+    <div class="label">Next</div>
+    <div class="title">Configuration</div>
+  </a>
+</div>
+
+</div>
+</section>

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,148 @@
+---
+title: Features & Tools
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Features & Tools
+
+<p class="lead">25 built-in tools give Claude full control over your machine.</p>
+
+## Core Features
+
+### Agentic Loop
+
+NanoClaw runs an agentic loop that allows Claude to:
+
+- Call tools, read results, and decide what to do next
+- Chain up to **50 iterations** per request
+- Handle complex, multi-step tasks autonomously
+- Auto-retry on rate limits with exponential backoff
+- Auto-compact context on overflow
+
+### Multi-Channel Access
+
+Interact with your agent through three channels, all backed by the same gateway:
+
+- **Telegram Bot** &mdash; Chat from anywhere on your phone
+- **Web Dashboard** &mdash; Real-time React SPA with session management
+- **CLI Chat** &mdash; Direct terminal interaction, no gateway needed
+
+### Cross-Session Memory
+
+NanoClaw maintains a keyword-based memory system:
+
+- Memories persist across sessions in JSONL format
+- Up to 5 relevant memories injected per prompt
+- Keyword matching for contextual relevance
+- Stored at `~/.goterm/data/memory/memory.jsonl`
+
+### Streaming Responses
+
+All channels support real-time streaming:
+
+- Telegram: messages update live as Claude generates text
+- Dashboard: WebSocket streaming with partial updates
+- CLI: Token-by-token terminal output
+
+## System Tools
+
+| Tool | Description |
+|---|---|
+| `run_shell` | Execute any bash command with configurable timeout |
+| `read_file` | Read file contents from disk |
+| `write_file` | Write or append to files |
+| `list_dir` | List directory contents (recursive, hidden files) |
+| `search_files` | Search by filename or content with regex support |
+| `take_screenshot` | Capture the current screen |
+| `get_clipboard` | Read clipboard contents |
+| `set_clipboard` | Write to clipboard |
+| `run_applescript` | Control macOS apps via AppleScript |
+| `open_app` | Open applications or files (`open`/`xdg-open`) |
+| `get_system_info` | Hardware, OS, CPU, memory, disk information |
+| `list_processes` | List running processes with filter and sort |
+| `kill_process` | Kill process by PID or name (TERM/KILL) |
+| `browse_url` | Fetch URL content or open in default browser |
+
+## Browser Automation Tools
+
+NanoClaw includes a native Chrome DevTools Protocol (CDP) client &mdash; no Puppeteer or Playwright dependency needed.
+
+| Tool | Description |
+|---|---|
+| `browser_navigate` | Navigate to a URL (auto-launches Chrome if needed) |
+| `browser_snapshot` | DOM snapshot with interactive element refs |
+| `browser_click` | Click an element by reference |
+| `browser_fill` | Clear and type into an input field |
+| `browser_type` | Append text to an input field |
+| `browser_select` | Select a dropdown option |
+| `browser_scroll` | Scroll the page in any direction |
+| `browser_screenshot` | Screenshot the current browser page |
+| `browser_get_text` | Get text, HTML, value, or URL from elements |
+| `browser_eval` | Execute JavaScript in the browser context |
+| `browser_wait` | Wait for an element, text, or timeout |
+
+### How Browser Automation Works
+
+1. When a browser tool is called, NanoClaw auto-launches Chrome with remote debugging enabled
+2. It connects via the Chrome DevTools Protocol (raw WebSocket, no libraries)
+3. The `browser_snapshot` tool returns a structured DOM with numbered element references
+4. Other tools use these references to interact with specific elements
+5. This allows Claude to browse the web, fill forms, scrape data, and automate workflows
+
+### Example: Web Scraping Workflow
+
+```
+User: "Go to Hacker News and summarize the top 5 stories"
+
+Claude's tool calls:
+  1. browser_navigate("https://news.ycombinator.com")
+  2. browser_snapshot()              → sees DOM with element refs
+  3. browser_get_text(refs=[1,2,3,4,5])  → extracts headlines
+  4. (generates summary from extracted text)
+```
+
+## Token Budget Management
+
+NanoClaw intelligently manages the model's context window:
+
+- Uses ~80% of available context for assembled messages
+- Automatically trims old messages when budget is exceeded
+- Compacts (summarizes) conversation history as a last resort
+- System prompt + memory always included
+- Token counting per model (different tokenizers)
+
+## Per-Session Model Switching
+
+Switch models on the fly without restarting:
+
+- Telegram: `/model opus` or `/model haiku`
+- Dashboard: Model selector dropdown
+- CLI: `--model` flag
+- Each session maintains its own model override
+- Use aliases for convenience: `opus`, `sonnet`, `haiku`, `o4`, `s4`, `h4`
+
+## FIFO Execution Queue
+
+Each session has a FIFO execution queue that:
+
+- Prevents concurrent API calls to Claude
+- Queues messages that arrive while a request is in-flight
+- Processes queued messages in order after completion
+- Ensures consistent conversation state
+
+<div class="doc-nav">
+  <a href="{{ '/architecture' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Architecture</div>
+  </a>
+  <a href="{{ '/telegram-bot' | relative_url }}" class="next">
+    <div class="label">Next</div>
+    <div class="title">Telegram Bot</div>
+  </a>
+</div>
+
+</div>
+</section>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,150 @@
+---
+title: Getting Started
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Getting Started
+
+<p class="lead">Get NanoClaw running on your machine in under a minute.</p>
+
+## Prerequisites
+
+- **Go 1.22+** &mdash; [Download Go](https://go.dev/dl/)
+- **Claude CLI** &mdash; installed and logged in ([docs](https://docs.anthropic.com/en/docs/claude-code))
+- **Telegram bot token** (optional) &mdash; from [@BotFather](https://t.me/BotFather)
+- **Chrome/Chromium** (optional) &mdash; for browser automation tools
+
+## Quick Start
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/phanngoc/goterm-control.git
+cd goterm-control
+```
+
+### 2. Authenticate with Claude
+
+```bash
+claude login
+```
+
+This uses your Claude Pro/Max subscription via OAuth2 &mdash; no API key needed.
+
+Alternatively, for direct API access, set your key in `.env`:
+
+```bash
+cp .env.example .env
+# Edit .env and add: ANTHROPIC_API_KEY=sk-ant-api03-...
+```
+
+### 3. Set up Telegram (optional)
+
+If you want Telegram access, add your bot token to `.env`:
+
+```bash
+# In .env
+TELEGRAM_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+```
+
+### 4. Build
+
+```bash
+go build -o nanoclaw ./cmd/nanoclaw/
+```
+
+### 5. Run
+
+**Interactive CLI chat** (simplest way to start):
+
+```bash
+./nanoclaw chat
+```
+
+**Full gateway** (Telegram bot + Web Dashboard + WebSocket RPC):
+
+```bash
+./nanoclaw gateway
+```
+
+That's it! You now have a personal AI agent with full computer control.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `nanoclaw gateway` | Start gateway (Telegram bot + WebSocket RPC + Dashboard) |
+| `nanoclaw chat` | Interactive CLI chat (direct, no gateway needed) |
+| `nanoclaw send "<msg>"` | Send a message to the running gateway |
+| `nanoclaw status` | Show gateway health and session info |
+| `nanoclaw models` | List available models |
+
+### Examples
+
+```bash
+# Chat with a specific model
+./nanoclaw chat --model opus
+
+# Start gateway on a custom port
+./nanoclaw gateway --port 9000 --bind 0.0.0.0
+
+# Send a message to the running gateway
+./nanoclaw send "list all running docker containers"
+
+# Quick task with a fast model
+./nanoclaw send --model haiku "what time is it"
+
+# Check gateway health
+./nanoclaw status
+```
+
+## Authentication Modes
+
+NanoClaw auto-detects your authentication method at startup:
+
+| Mode | Token prefix | How it works |
+|---|---|---|
+| **Claude CLI** (recommended) | `sk-ant-oat...` | Uses `claude` subprocess with your Pro/Max subscription. No per-token cost. |
+| **Direct API** | `sk-ant-api03...` | Calls Anthropic Messages API directly. Pay-per-use. |
+
+> **Tip:** Claude CLI OAuth is recommended for most users. It uses your existing subscription, so there's no additional cost per token.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | No | Anthropic API key (only if not using Claude CLI OAuth) |
+| `TELEGRAM_TOKEN` | For Telegram | Telegram bot token from @BotFather |
+
+## Supported Platforms
+
+NanoClaw runs anywhere Go compiles:
+
+- **Linux** &mdash; Full support (x86_64, ARM64)
+- **macOS** &mdash; Full support (Intel, Apple Silicon) + AppleScript tools
+- **Windows** &mdash; Via WSL (Windows Subsystem for Linux)
+
+## Next Steps
+
+- [Architecture]({{ '/architecture' | relative_url }}) &mdash; Understand how NanoClaw works
+- [Features & Tools]({{ '/features' | relative_url }}) &mdash; See all 25 tools
+- [Telegram Bot]({{ '/telegram-bot' | relative_url }}) &mdash; Set up your Telegram bot
+- [Web Dashboard]({{ '/dashboard' | relative_url }}) &mdash; Use the React web UI
+- [Configuration]({{ '/configuration' | relative_url }}) &mdash; Customize your setup
+
+<div class="doc-nav">
+  <a href="{{ '/' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Home</div>
+  </a>
+  <a href="{{ '/architecture' | relative_url }}" class="next">
+    <div class="label">Next</div>
+    <div class="title">Architecture</div>
+  </a>
+</div>
+
+</div>
+</section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,194 @@
+---
+title: Home
+layout: default
+---
+
+<section class="hero">
+  <div class="container">
+    <div class="hero-badge">Open Source &middot; MIT License</div>
+    <h1>Your Computer,<br>Claude's Brain</h1>
+    <p class="hero-sub">
+      NanoClaw is a lean, self-hosted AI agent that gives Claude full control over your computer.
+      One binary, one process, no microservices. Command it from Telegram, the web, or your terminal.
+    </p>
+    <div class="hero-actions">
+      <a href="{{ '/getting-started' | relative_url }}" class="btn btn-primary">Get Started</a>
+      <a href="https://github.com/phanngoc/goterm-control" class="btn btn-outline" target="_blank">View on GitHub</a>
+    </div>
+    <div class="hero-code">
+      <div class="hero-code-header">
+        <span class="hero-code-dot"></span>
+        <span class="hero-code-dot"></span>
+        <span class="hero-code-dot"></span>
+      </div>
+<pre><span class="comment"># Build</span>
+<span class="cmd">go build</span> <span class="flag">-o nanoclaw</span> ./cmd/nanoclaw/
+
+<span class="comment"># Start chatting</span>
+<span class="cmd">./nanoclaw</span> chat
+
+<span class="comment"># Or launch the full gateway</span>
+<span class="cmd">./nanoclaw</span> gateway <span class="flag">--port 18789</span></pre>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="stats">
+      <div class="stat">
+        <div class="stat-value">~45</div>
+        <div class="stat-label">Source Files</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">25</div>
+        <div class="stat-label">Built-in Tools</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">14</div>
+        <div class="stat-label">Packages</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">13MB</div>
+        <div class="stat-label">Binary Size</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-header">
+      <h2>Why NanoClaw?</h2>
+      <p>Everything you need to turn your machine into an AI-powered workstation.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F916;</div>
+        <h3>Agentic Loop</h3>
+        <p>The model calls tools, sees results, and keeps working &mdash; up to 50 iterations per request. It doesn't just answer; it <em>does</em>.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F310;</div>
+        <h3>Multi-Channel Access</h3>
+        <p>Talk to your agent from a Telegram bot, a React web dashboard, or an interactive CLI. All channels share the same gateway.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon pink">&#x1F5A5;&#xFE0F;</div>
+        <h3>Full Computer Control</h3>
+        <p>Shell commands, file I/O, screenshots, clipboard, processes, and native Chrome DevTools Protocol for browser automation.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F9E0;</div>
+        <h3>Persistent Memory</h3>
+        <p>Cross-session keyword memory automatically injects relevant context into every conversation. Your agent remembers across chats.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x26A1;</div>
+        <h3>Single Binary</h3>
+        <p>One Go binary (~13MB), one process, zero dependencies. No Docker, no Node.js, no microservices. Just build and run.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon red">&#x1F512;</div>
+        <h3>Your Machine, Your Data</h3>
+        <p>Self-hosted and single-user. Data stays in JSONL files on your disk. Gateway binds to localhost by default.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-header">
+      <h2>Architecture</h2>
+      <p>Clean separation of channels, gateway, agent loop, and tools.</p>
+    </div>
+    <div class="arch-diagram">
+<pre>
+┌───────────┐  ┌──────────────┐  ┌───────────────┐
+│  Telegram  │  │ Web Dashboard│  │   CLI Chat    │
+│  Bot       │  │  (React SPA) │  │               │
+└─────┬──────┘  └──────┬───────┘  └───────┬───────┘
+      │           WebSocket          direct call
+      │               │                  │
+      ▼               ▼                  ▼
+┌─────────────────────────────────────────────────┐
+│              Gateway (JSON-RPC)                  │
+│         session mgmt · model resolver            │
+└──────────────────────┬──────────────────────────┘
+                       │
+              ┌─────────────────┐
+              │   Agent Loop    │  ← up to 50 iterations
+              │  stream + tool  │
+              │   call cycle    │
+              └────────┬────────┘
+                       │
+          ┌────────────┼────────────┐
+          ▼            ▼            ▼
+   ┌────────────┐ ┌──────────┐ ┌──────────┐
+   │ Claude CLI │ │  Direct  │ │   Tool   │
+   │  (OAuth2)  │ │   API    │ │ Executor │
+   └────────────┘ └──────────┘ └──────────┘
+                                    │
+                       ┌────────────┼────────────┐
+                       ▼            ▼            ▼
+                  ┌─────────┐ ┌─────────┐ ┌──────────┐
+                  │ Context │ │ Memory  │ │Transcript│
+                  └─────────┘ └─────────┘ └──────────┘
+</pre>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-header">
+      <h2>Flexible Authentication</h2>
+      <p>Use your Claude Pro/Max subscription or a direct API key.</p>
+    </div>
+    <div class="features-grid" style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));">
+      <div class="feature-card">
+        <h3>Claude CLI (Recommended)</h3>
+        <p>Uses your existing Claude Pro/Max subscription via OAuth2. No per-token billing. Just run <code>claude login</code> and go.</p>
+        <p style="margin-top:12px;"><code>Token: sk-ant-oat...</code></p>
+      </div>
+      <div class="feature-card">
+        <h3>Direct Anthropic API</h3>
+        <p>Pay-per-use with your Anthropic API key. Set <code>ANTHROPIC_API_KEY</code> in your <code>.env</code> file.</p>
+        <p style="margin-top:12px;"><code>Token: sk-ant-api03...</code></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-header">
+      <h2>Three Built-in Models</h2>
+      <p>Switch models per-session with simple aliases.</p>
+    </div>
+    <div class="doc-content" style="margin:0 auto;">
+      <table>
+        <thead>
+          <tr><th>Model</th><th>Aliases</th><th>Context</th><th>Input / Output (per 1M)</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Claude Opus 4.6</td><td><code>opus</code>, <code>o4</code></td><td>200k</td><td>$15 / $75</td></tr>
+          <tr><td>Claude Sonnet 4.6</td><td><code>sonnet</code>, <code>s4</code></td><td>200k</td><td>$3 / $15</td></tr>
+          <tr><td>Claude Haiku 4.5</td><td><code>haiku</code>, <code>h4</code></td><td>200k</td><td>$0.80 / $4</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section class="cta">
+  <div class="container">
+    <h2>Ready to get started?</h2>
+    <p>Clone, build, and start chatting in under a minute.</p>
+    <div class="hero-actions">
+      <a href="{{ '/getting-started' | relative_url }}" class="btn btn-primary">Installation Guide</a>
+      <a href="{{ '/features' | relative_url }}" class="btn btn-outline">Explore Features</a>
+    </div>
+  </div>
+</section>

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,0 +1,139 @@
+---
+title: Telegram Bot
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Telegram Bot
+
+<p class="lead">Control your AI agent from anywhere using Telegram.</p>
+
+## Setup
+
+### 1. Create a bot with BotFather
+
+1. Open Telegram and search for [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts
+3. Copy the bot token (looks like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`)
+
+### 2. Configure NanoClaw
+
+Add your token to `.env`:
+
+```bash
+TELEGRAM_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+```
+
+### 3. Start the gateway
+
+```bash
+./nanoclaw gateway
+```
+
+The bot starts polling Telegram automatically when a token is configured.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/start` | Show welcome message and help |
+| `/models` | List available models with pricing |
+| `/model <name>` | Switch model for this session |
+| `/model default` | Reset to the default model |
+| `/status` | Show session info, token usage, queue depth |
+| `/reset` | Clear conversation history |
+| `/cancel` | Cancel the current in-flight request |
+
+### Model Switching
+
+Switch models per-session without restarting the gateway:
+
+```
+/model opus     → Switch to Claude Opus 4.6
+/model sonnet   → Switch to Claude Sonnet 4.6
+/model haiku    → Switch to Claude Haiku 4.5
+/model default  → Reset to configured default
+```
+
+Aliases are supported: `opus`, `o4`, `sonnet`, `s4`, `haiku`, `h4`.
+
+### Status Information
+
+The `/status` command shows:
+
+- Current session ID
+- Active model
+- Messages in conversation
+- Total tokens used (input + output)
+- Queue depth (pending messages)
+- Session age
+
+## How It Works
+
+1. The bot uses **long-polling** to receive updates from Telegram
+2. Each Telegram chat ID gets its own session with separate history
+3. Messages are routed through the gateway's agent loop
+4. Responses **stream back in real-time** via Telegram message edits
+5. Tool calls execute on your machine and results feed back to Claude
+6. All events are recorded in per-session JSONL transcripts
+
+### Streaming Updates
+
+NanoClaw streams Claude's responses to Telegram by editing the message as new tokens arrive. This means you see the response being generated in real-time, just like in the Claude web interface.
+
+### Message Queue
+
+If you send a message while Claude is still processing a previous one, it enters a FIFO queue. Messages are processed in order after the current request completes.
+
+## Security
+
+### Restricting Access
+
+By default, anyone who finds your bot can use it. To restrict access to specific Telegram users:
+
+```yaml
+# config.yaml
+security:
+  allowed_user_ids:
+    - 123456789    # Your Telegram user ID
+    - 987654321    # Another authorized user
+```
+
+To find your Telegram user ID, send a message to [@userinfobot](https://t.me/userinfobot).
+
+> **Important:** NanoClaw gives Claude full access to your machine (shell, files, browser). Always restrict bot access to trusted users.
+
+### What the Bot Can Do
+
+When someone sends a message to your bot, Claude can:
+
+- Run any shell command on your machine
+- Read, write, and delete files
+- Take screenshots
+- Control your browser
+- Manage processes
+
+This is powerful but carries security implications. Keep your bot token secret and whitelist authorized users.
+
+## Tips
+
+- **Long tasks:** Claude can chain up to 50 tool calls per message, so complex tasks work well
+- **Cancel:** Use `/cancel` if a task is taking too long or going in the wrong direction
+- **Reset:** Use `/reset` to start a fresh conversation if context gets cluttered
+- **Model switching:** Use `/model haiku` for quick, cheap queries and `/model opus` for complex tasks
+
+<div class="doc-nav">
+  <a href="{{ '/features' | relative_url }}">
+    <div class="label">Previous</div>
+    <div class="title">Features & Tools</div>
+  </a>
+  <a href="{{ '/dashboard' | relative_url }}" class="next">
+    <div class="label">Next</div>
+    <div class="title">Dashboard</div>
+  </a>
+</div>
+
+</div>
+</section>


### PR DESCRIPTION
Jekyll-based docs site with custom dark theme, 7 pages covering getting started, architecture, features/tools, Telegram bot, web dashboard, configuration, and API reference. Includes GitHub Actions workflow for auto-deployment.