### PR TITLE
feat: add daemon service management (systemd/launchd)

### DIFF
--- a/cmd/nanoclaw/main.go
+++ b/cmd/nanoclaw/main.go
@@ -15,14 +15,18 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"net"
+	"path/filepath"
+	"runtime"
+
 	anthropicClient "github.com/ngocp/goterm-control/internal/anthropic"
 	"github.com/ngocp/goterm-control/internal/agent"
 	"github.com/ngocp/goterm-control/internal/bot"
 	"github.com/ngocp/goterm-control/internal/channel"
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/config"
-	"path/filepath"
 	agentctx "github.com/ngocp/goterm-control/internal/context"
+	"github.com/ngocp/goterm-control/internal/daemon"
 	"github.com/ngocp/goterm-control/internal/gateway"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
@@ -64,6 +68,29 @@ func main() {
 
 	switch os.Args[1] {
 	case "gateway":
+		// Check for gateway subcommands (install, uninstall, start, stop, restart, status)
+		if len(os.Args) > 2 {
+			switch os.Args[2] {
+			case "install":
+				runGatewayInstall(os.Args[3:])
+				return
+			case "uninstall":
+				runGatewayUninstall(os.Args[3:])
+				return
+			case "start":
+				runGatewayStart(os.Args[3:])
+				return
+			case "stop":
+				runGatewayStop(os.Args[3:])
+				return
+			case "restart":
+				runGatewayRestart(os.Args[3:])
+				return
+			case "status":
+				runGatewayServiceStatus(os.Args[3:])
+				return
+			}
+		}
 		runGateway(os.Args[2:])
 	case "send":
 		runSend(os.Args[2:])
@@ -89,12 +116,18 @@ Usage:
   nanoclaw <command> [flags]
 
 Commands:
-  gateway   Start the gateway (Telegram + WebSocket RPC server)
-  send      Send a message to the agent via gateway
-  status    Show gateway status
-  models    List available models
-  chat      Interactive CLI chat with the agent (no gateway needed)
-  help      Show this help`)
+  gateway            Start the gateway in foreground
+  gateway install    Install as a background service (systemd/launchd)
+  gateway uninstall  Remove the background service
+  gateway start      Start the installed service
+  gateway stop       Stop the installed service
+  gateway restart    Restart the installed service
+  gateway status     Show service status and health
+  send               Send a message to the agent via gateway
+  status             Show gateway status (via WebSocket)
+  models             List available models
+  chat               Interactive CLI chat with the agent (no gateway needed)
+  help               Show this help`)
 }
 
 // --- gateway command ---
@@ -430,6 +463,273 @@ func buildToolDefs() []agent.ToolDef {
 		})
 	}
 	return defs
+}
+
+// --- gateway service commands ---
+
+func resolveAbsPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
+}
+
+func resolveBinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve executable: %w", err)
+	}
+	real, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe, nil
+	}
+	// Warn if binary is in a temp directory (e.g. go run)
+	if strings.Contains(real, "/tmp/") || strings.Contains(real, "/temp/") {
+		fmt.Fprintln(os.Stderr, "Warning: binary is in a temp directory — install from a stable path")
+	}
+	return real, nil
+}
+
+func buildInstallEnv(configPath, envPath string) map[string]string {
+	env := map[string]string{}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		env["HOME"] = home
+	}
+
+	// Load .env to capture API keys
+	if envPath != "" {
+		loadEnv(envPath)
+	}
+	// Load config to capture API keys
+	if configPath != "" {
+		cfg, err := config.Load(configPath)
+		if err == nil {
+			if cfg.Claude.APIKey != "" {
+				env["ANTHROPIC_API_KEY"] = cfg.Claude.APIKey
+			}
+			if cfg.Telegram.Token != "" {
+				env["TELEGRAM_TOKEN"] = cfg.Telegram.Token
+			}
+		}
+	}
+
+	// Also pick up from current env (env overrides config)
+	if v := os.Getenv("ANTHROPIC_API_KEY"); v != "" {
+		env["ANTHROPIC_API_KEY"] = v
+	}
+	if v := os.Getenv("TELEGRAM_TOKEN"); v != "" {
+		env["TELEGRAM_TOKEN"] = v
+	}
+
+	return env
+}
+
+func runGatewayInstall(args []string) {
+	fs := flag.NewFlagSet("gateway install", flag.ExitOnError)
+	port := fs.Int("port", 18789, "Gateway port")
+	bind := fs.String("bind", "127.0.0.1", "Bind address")
+	configPath := fs.String("config", "config.yaml", "Path to config file")
+	envPath := fs.String("env", ".env", "Path to .env file")
+	force := fs.Bool("force", false, "Force reinstall even if already installed")
+	fs.Parse(args)
+
+	svc, err := daemon.Resolve()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	// Check if already installed
+	if !*force {
+		installed, _ := svc.IsInstalled()
+		if installed {
+			fmt.Printf("Service already installed (%s). Use --force to reinstall.\n", svc.Label())
+			fmt.Printf("Unit: %s\n", svc.UnitPath())
+			return
+		}
+	}
+
+	binPath, err := resolveBinaryPath()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	absConfig := resolveAbsPath(*configPath)
+	absEnv := resolveAbsPath(*envPath)
+
+	installArgs := daemon.InstallArgs{
+		BinaryPath:  binPath,
+		Port:        *port,
+		Bind:        *bind,
+		ConfigPath:  absConfig,
+		EnvFile:     absEnv,
+		Environment: buildInstallEnv(absConfig, absEnv),
+		Description: "NanoClaw Gateway",
+		Force:       *force,
+	}
+
+	ctx := context.Background()
+	if err := svc.Install(ctx, installArgs); err != nil {
+		log.Fatalf("install failed: %v", err)
+	}
+
+	fmt.Printf("Service installed via %s\n", svc.Label())
+	fmt.Printf("Unit: %s\n", svc.UnitPath())
+
+	// Health check
+	fmt.Print("Waiting for gateway to become healthy...")
+	result, err := daemon.WaitForHealthy(ctx, *port, *bind, daemon.HealthOpts{})
+	if err != nil {
+		fmt.Printf(" timeout\n")
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Check logs: journalctl --user -u %s\n", "nanoclaw-gateway")
+	} else {
+		fmt.Printf(" ok (%s, %d attempts)\n", result.Elapsed.Round(time.Millisecond), result.Attempts)
+	}
+
+	// Linger check (Linux only)
+	if runtime.GOOS == "linux" {
+		daemon.PromptLinger()
+	}
+
+	fmt.Println()
+	fmt.Println("Manage with:")
+	fmt.Println("  nanoclaw gateway status   — check health")
+	fmt.Println("  nanoclaw gateway restart   — restart service")
+	fmt.Println("  nanoclaw gateway stop      — stop service")
+	fmt.Println("  nanoclaw gateway uninstall — remove service")
+}
+
+func runGatewayUninstall(_ []string) {
+	svc, err := daemon.Resolve()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	if err := svc.Uninstall(context.Background()); err != nil {
+		log.Fatalf("uninstall failed: %v", err)
+	}
+	fmt.Println("Service uninstalled.")
+}
+
+func runGatewayStart(_ []string) {
+	svc, err := daemon.Resolve()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	installed, _ := svc.IsInstalled()
+	if !installed {
+		fmt.Fprintln(os.Stderr, "Service not installed. Run: nanoclaw gateway install")
+		os.Exit(1)
+	}
+
+	if err := svc.Start(context.Background()); err != nil {
+		log.Fatalf("start failed: %v", err)
+	}
+	fmt.Println("Service started.")
+}
+
+func runGatewayStop(_ []string) {
+	svc, err := daemon.Resolve()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	if err := svc.Stop(context.Background()); err != nil {
+		log.Fatalf("stop failed: %v", err)
+	}
+	fmt.Println("Service stopped.")
+}
+
+func runGatewayRestart(args []string) {
+	fs := flag.NewFlagSet("gateway restart", flag.ExitOnError)
+	port := fs.Int("port", 18789, "Gateway port (for health check)")
+	bind := fs.String("bind", "127.0.0.1", "Bind address (for health check)")
+	fs.Parse(args)
+
+	svc, err := daemon.Resolve()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	installed, _ := svc.IsInstalled()
+	if !installed {
+		fmt.Fprintln(os.Stderr, "Service not installed. Run: nanoclaw gateway install")
+		os.Exit(1)
+	}
+
+	if err := svc.Restart(context.Background()); err != nil {
+		log.Fatalf("restart failed: %v", err)
+	}
+
+	fmt.Print("Waiting for gateway to become healthy...")
+	ctx := context.Background()
+	result, err := daemon.WaitForHealthy(ctx, *port, *bind, daemon.HealthOpts{})
+	if err != nil {
+		fmt.Printf(" timeout\n")
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	} else {
+		fmt.Printf(" ok (%s)\n", result.Elapsed.Round(time.Millisecond))
+	}
+}
+
+func runGatewayServiceStatus(args []string) {
+	fs := flag.NewFlagSet("gateway status", flag.ExitOnError)
+	port := fs.Int("port", 18789, "Gateway port (for health probe)")
+	bind := fs.String("bind", "127.0.0.1", "Bind address")
+	fs.Parse(args)
+
+	svc, err := daemon.Resolve()
+	if err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+
+	// Service installation check
+	installed, _ := svc.IsInstalled()
+	if !installed {
+		fmt.Printf("Service:   not installed\n")
+		fmt.Printf("Backend:   %s\n", svc.Label())
+		return
+	}
+
+	fmt.Printf("Service:   installed (%s)\n", svc.Label())
+	fmt.Printf("Unit:      %s\n", svc.UnitPath())
+
+	// Runtime status
+	rt, err := svc.ReadRuntime()
+	if err != nil {
+		fmt.Printf("Status:    error (%v)\n", err)
+	} else {
+		fmt.Printf("Status:    %s", rt.Status)
+		if rt.SubState != "" && rt.SubState != rt.Status {
+			fmt.Printf(" (%s)", rt.SubState)
+		}
+		fmt.Println()
+		if rt.PID > 0 {
+			fmt.Printf("PID:       %d\n", rt.PID)
+		}
+		if rt.Status == "failed" {
+			fmt.Printf("Exit:      %d (%s)\n", rt.ExitCode, rt.ExitReason)
+		}
+	}
+
+	// HTTP health probe
+	addr := net.JoinHostPort(*bind, fmt.Sprintf("%d", *port))
+	fmt.Printf("Endpoint:  http://%s/health\n", addr)
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		fmt.Printf("Health:    unreachable\n")
+	} else {
+		conn.Close()
+		fmt.Printf("Health:    port open\n")
+	}
 }
 
 func findToolSchema(name string) map[string]any {

--- a/internal/daemon/exec.go
+++ b/internal/daemon/exec.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// ExecResult holds the output of a subprocess execution.
+type ExecResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// execCommand runs a command and returns its output.
+func execCommand(ctx context.Context, name string, args ...string) (*ExecResult, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+
+	result := &ExecResult{
+		Stdout: outBuf.String(),
+		Stderr: errBuf.String(),
+	}
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				result.ExitCode = ws.ExitStatus()
+			} else {
+				result.ExitCode = 1
+			}
+			return result, nil // non-zero exit is not a Go error
+		}
+		return result, fmt.Errorf("exec %s: %w", name, err)
+	}
+
+	return result, nil
+}
+
+// commandExists checks if a command is available in PATH.
+func commandExists(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}

--- a/internal/daemon/health.go
+++ b/internal/daemon/health.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// HealthOpts configures health check polling behavior.
+type HealthOpts struct {
+	Interval    time.Duration // poll interval (default 500ms)
+	MaxAttempts int           // max poll attempts (default 120 = 60s)
+}
+
+// HealthResult holds the outcome of a health check.
+type HealthResult struct {
+	PortListening bool
+	HTTPHealthy   bool
+	Elapsed       time.Duration
+	Attempts      int
+}
+
+// WaitForHealthy polls the gateway until it responds or timeout.
+// Checks TCP port connectivity and HTTP /health endpoint.
+func WaitForHealthy(ctx context.Context, port int, bind string, opts HealthOpts) (*HealthResult, error) {
+	if opts.Interval == 0 {
+		opts.Interval = 500 * time.Millisecond
+	}
+	if opts.MaxAttempts == 0 {
+		opts.MaxAttempts = 120 // 60s total
+	}
+
+	addr := net.JoinHostPort(bind, fmt.Sprintf("%d", port))
+	healthURL := fmt.Sprintf("http://%s/health", addr)
+	start := time.Now()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	for i := 0; i < opts.MaxAttempts; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// Check TCP port
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err != nil {
+			time.Sleep(opts.Interval)
+			continue
+		}
+		conn.Close()
+
+		// Check HTTP /health
+		resp, err := client.Get(healthURL)
+		if err != nil {
+			time.Sleep(opts.Interval)
+			continue
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			return &HealthResult{
+				PortListening: true,
+				HTTPHealthy:   true,
+				Elapsed:       time.Since(start),
+				Attempts:      i + 1,
+			}, nil
+		}
+
+		time.Sleep(opts.Interval)
+	}
+
+	// Timeout — check final state
+	result := &HealthResult{
+		Elapsed:  time.Since(start),
+		Attempts: opts.MaxAttempts,
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err == nil {
+		conn.Close()
+		result.PortListening = true
+	}
+
+	return result, fmt.Errorf("health check timed out after %s (%d attempts)", result.Elapsed.Round(time.Second), result.Attempts)
+}

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -1,0 +1,203 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const launchdLabel = "com.nanoclaw.gateway"
+
+type launchdService struct {
+	label     string
+	plistPath string
+	logDir    string
+}
+
+func newLaunchdService() (*launchdService, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	return &launchdService{
+		label:     launchdLabel,
+		plistPath: filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist"),
+		logDir:    filepath.Join(home, ".goterm", "logs"),
+	}, nil
+}
+
+func (s *launchdService) Label() string { return "LaunchAgent" }
+
+func (s *launchdService) UnitPath() string { return s.plistPath }
+
+func (s *launchdService) Install(ctx context.Context, args InstallArgs) error {
+	// 1. Create directories
+	plistDir := filepath.Dir(s.plistPath)
+	if err := os.MkdirAll(plistDir, 0755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+	if err := os.MkdirAll(s.logDir, 0755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+
+	// 2. Build program arguments
+	progArgs := []string{args.BinaryPath, "gateway"}
+	if args.ConfigPath != "" {
+		progArgs = append(progArgs, "--config", args.ConfigPath)
+	}
+	if args.EnvFile != "" {
+		progArgs = append(progArgs, "--env", args.EnvFile)
+	}
+	if args.Bind != "" {
+		progArgs = append(progArgs, "--bind", args.Bind)
+	}
+	if args.Port > 0 {
+		progArgs = append(progArgs, "--port", fmt.Sprintf("%d", args.Port))
+	}
+
+	// 3. Generate plist
+	plist := buildPlist(plistArgs{
+		Label:       s.label,
+		ProgramArgs: progArgs,
+		Environment: args.Environment,
+		StdoutPath:  filepath.Join(s.logDir, "gateway.log"),
+		StderrPath:  filepath.Join(s.logDir, "gateway.err.log"),
+	})
+
+	// 4. Backup existing plist
+	if _, err := os.Stat(s.plistPath); err == nil {
+		bakPath := s.plistPath + ".bak"
+		data, _ := os.ReadFile(s.plistPath)
+		if len(data) > 0 {
+			_ = os.WriteFile(bakPath, data, 0644)
+		}
+	}
+
+	// 5. Write plist
+	if err := os.WriteFile(s.plistPath, []byte(plist), 0644); err != nil {
+		return fmt.Errorf("write plist: %w", err)
+	}
+	log.Printf("daemon: wrote %s", s.plistPath)
+
+	// 6. Try to bootout existing (ignore errors — may not be loaded)
+	domain := s.domain()
+	_ = launchctl(ctx, "bootout", domain+"/"+s.label)
+
+	// 7. Enable and bootstrap
+	if err := launchctl(ctx, "enable", domain+"/"+s.label); err != nil {
+		log.Printf("daemon: launchctl enable warning: %v", err)
+	}
+	if err := launchctl(ctx, "bootstrap", domain, s.plistPath); err != nil {
+		return fmt.Errorf("launchctl bootstrap: %w", err)
+	}
+
+	log.Printf("daemon: LaunchAgent %s installed and started", s.label)
+	return nil
+}
+
+func (s *launchdService) Uninstall(ctx context.Context) error {
+	domain := s.domain()
+	_ = launchctl(ctx, "bootout", domain+"/"+s.label)
+
+	if err := os.Remove(s.plistPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plist: %w", err)
+	}
+
+	log.Printf("daemon: LaunchAgent %s uninstalled", s.label)
+	return nil
+}
+
+func (s *launchdService) Start(ctx context.Context) error {
+	domain := s.domain()
+	return launchctl(ctx, "bootstrap", domain, s.plistPath)
+}
+
+func (s *launchdService) Stop(ctx context.Context) error {
+	domain := s.domain()
+	return launchctl(ctx, "bootout", domain+"/"+s.label)
+}
+
+func (s *launchdService) Restart(ctx context.Context) error {
+	domain := s.domain()
+	return launchctl(ctx, "kickstart", "-k", domain+"/"+s.label)
+}
+
+func (s *launchdService) IsInstalled() (bool, error) {
+	_, err := os.Stat(s.plistPath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Check if actually loaded
+	domain := s.domain()
+	err = launchctl(context.Background(), "print", domain+"/"+s.label)
+	return err == nil, nil
+}
+
+func (s *launchdService) ReadRuntime() (*ServiceRuntime, error) {
+	rt := &ServiceRuntime{Status: "unknown"}
+
+	domain := s.domain()
+	res, err := execCommand(context.Background(),
+		"launchctl", "print", domain+"/"+s.label,
+	)
+	if err != nil {
+		return rt, err
+	}
+	if res.ExitCode != 0 {
+		rt.Status = "stopped"
+		return rt, nil
+	}
+
+	// Parse output for pid and state
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "pid = ") {
+			pidStr := strings.TrimPrefix(line, "pid = ")
+			rt.PID, _ = strconv.Atoi(strings.TrimSpace(pidStr))
+		}
+		if strings.HasPrefix(line, "state = ") {
+			state := strings.TrimPrefix(line, "state = ")
+			state = strings.TrimSpace(state)
+			rt.SubState = state
+			if state == "running" {
+				rt.Status = "running"
+			} else if state == "waiting" {
+				rt.Status = "stopped"
+			} else {
+				rt.Status = state
+			}
+		}
+		if strings.HasPrefix(line, "last exit code = ") {
+			codeStr := strings.TrimPrefix(line, "last exit code = ")
+			rt.ExitCode, _ = strconv.Atoi(strings.TrimSpace(codeStr))
+		}
+	}
+
+	return rt, nil
+}
+
+// domain returns the launchd domain target for the current user.
+func (s *launchdService) domain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+// launchctl runs a launchctl command and returns an error if it fails.
+func launchctl(ctx context.Context, args ...string) error {
+	res, err := execCommand(ctx, "launchctl", args...)
+	if err != nil {
+		return fmt.Errorf("launchctl %s: %w", strings.Join(args, " "), err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("launchctl %s (exit %d): %s",
+			strings.Join(args, " "), res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}

--- a/internal/daemon/launchd_plist.go
+++ b/internal/daemon/launchd_plist.go
@@ -1,0 +1,79 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// xmlEscape escapes a string for use in an XML plist value.
+func xmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	return s
+}
+
+// plistArgs holds the parameters for generating a launchd plist.
+type plistArgs struct {
+	Label       string
+	ProgramArgs []string
+	Environment map[string]string
+	WorkingDir  string
+	StdoutPath  string
+	StderrPath  string
+}
+
+// buildPlist generates a launchd plist XML string.
+// Ported from openclaw src/daemon/launchd-plist.ts.
+func buildPlist(p plistArgs) string {
+	var b strings.Builder
+
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString("\n")
+	b.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">`)
+	b.WriteString("\n")
+	b.WriteString(`<plist version="1.0">`)
+	b.WriteString("\n<dict>\n")
+
+	// Label
+	fmt.Fprintf(&b, "\t<key>Label</key>\n\t<string>%s</string>\n", xmlEscape(p.Label))
+
+	// RunAtLoad + KeepAlive
+	b.WriteString("\t<key>RunAtLoad</key>\n\t<true/>\n")
+	b.WriteString("\t<key>KeepAlive</key>\n\t<true/>\n")
+	b.WriteString("\t<key>ThrottleInterval</key>\n\t<integer>1</integer>\n")
+
+	// ProgramArguments
+	b.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	for _, arg := range p.ProgramArgs {
+		fmt.Fprintf(&b, "\t\t<string>%s</string>\n", xmlEscape(arg))
+	}
+	b.WriteString("\t</array>\n")
+
+	// WorkingDirectory
+	if p.WorkingDir != "" {
+		fmt.Fprintf(&b, "\t<key>WorkingDirectory</key>\n\t<string>%s</string>\n", xmlEscape(p.WorkingDir))
+	}
+
+	// EnvironmentVariables
+	if len(p.Environment) > 0 {
+		b.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
+		for k, v := range p.Environment {
+			fmt.Fprintf(&b, "\t\t<key>%s</key>\n\t\t<string>%s</string>\n", xmlEscape(k), xmlEscape(v))
+		}
+		b.WriteString("\t</dict>\n")
+	}
+
+	// Log paths
+	if p.StdoutPath != "" {
+		fmt.Fprintf(&b, "\t<key>StandardOutPath</key>\n\t<string>%s</string>\n", xmlEscape(p.StdoutPath))
+	}
+	if p.StderrPath != "" {
+		fmt.Fprintf(&b, "\t<key>StandardErrorPath</key>\n\t<string>%s</string>\n", xmlEscape(p.StderrPath))
+	}
+
+	b.WriteString("</dict>\n</plist>\n")
+	return b.String()
+}

--- a/internal/daemon/launchd_plist_test.go
+++ b/internal/daemon/launchd_plist_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestXmlEscape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"a & b", "a &amp; b"},
+		{"<tag>", "&lt;tag&gt;"},
+		{`he said "hi"`, `he said &quot;hi&quot;`},
+		{"it's", "it&apos;s"},
+		{`a & "b" <c> 'd'`, `a &amp; &quot;b&quot; &lt;c&gt; &apos;d&apos;`},
+	}
+
+	for _, tt := range tests {
+		got := xmlEscape(tt.input)
+		if got != tt.want {
+			t.Errorf("xmlEscape(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildPlist(t *testing.T) {
+	p := plistArgs{
+		Label:       "com.nanoclaw.gateway",
+		ProgramArgs: []string{"/usr/local/bin/nanoclaw", "gateway", "--port", "18789"},
+		Environment: map[string]string{
+			"HOME":              "/Users/test",
+			"ANTHROPIC_API_KEY": "sk-test",
+		},
+		StdoutPath: "/Users/test/.goterm/logs/gateway.log",
+		StderrPath: "/Users/test/.goterm/logs/gateway.err.log",
+	}
+
+	plist := buildPlist(p)
+
+	checks := []string{
+		`<?xml version="1.0"`,
+		`<key>Label</key>`,
+		`<string>com.nanoclaw.gateway</string>`,
+		`<key>RunAtLoad</key>`,
+		`<true/>`,
+		`<key>KeepAlive</key>`,
+		`<key>ProgramArguments</key>`,
+		`<string>/usr/local/bin/nanoclaw</string>`,
+		`<string>gateway</string>`,
+		`<key>EnvironmentVariables</key>`,
+		`<key>HOME</key>`,
+		`<string>/Users/test</string>`,
+		`<key>StandardOutPath</key>`,
+		`<string>/Users/test/.goterm/logs/gateway.log</string>`,
+		`<key>StandardErrorPath</key>`,
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(plist, check) {
+			t.Errorf("plist missing %q\nGot:\n%s", check, plist)
+		}
+	}
+}
+
+func TestBuildPlistEscaping(t *testing.T) {
+	p := plistArgs{
+		Label:       "com.test",
+		ProgramArgs: []string{"/path/to/binary", "--flag=value with <special> & chars"},
+		Environment: map[string]string{
+			"KEY": `value "with" quotes & <brackets>`,
+		},
+	}
+
+	plist := buildPlist(p)
+
+	// Verify escaping
+	if strings.Contains(plist, `& chars`) && !strings.Contains(plist, `&amp; chars`) {
+		t.Error("unescaped & in program args")
+	}
+	if strings.Contains(plist, `<special>`) && !strings.Contains(plist, `&lt;special&gt;`) {
+		t.Error("unescaped < > in program args")
+	}
+}

--- a/internal/daemon/linger.go
+++ b/internal/daemon/linger.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/user"
+	"runtime"
+	"strings"
+)
+
+// IsLingerEnabled checks if loginctl linger is enabled for the given user.
+// Returns true if the user's services persist across logout.
+func IsLingerEnabled(username string) (bool, error) {
+	if runtime.GOOS != "linux" {
+		return true, nil // linger is a Linux-only concept
+	}
+
+	if !commandExists("loginctl") {
+		return false, fmt.Errorf("loginctl not found")
+	}
+
+	res, err := execCommand(context.Background(),
+		"loginctl", "show-user", username, "-p", "Linger",
+	)
+	if err != nil {
+		return false, err
+	}
+
+	// Output: "Linger=yes" or "Linger=no"
+	stdout := strings.TrimSpace(res.Stdout)
+	_, val, _ := strings.Cut(stdout, "=")
+	return strings.TrimSpace(val) == "yes", nil
+}
+
+// EnableLinger enables loginctl linger for the given user.
+// Tries without sudo first, then falls back to sudo.
+func EnableLinger(username string) error {
+	// Try without sudo first
+	res, err := execCommand(context.Background(),
+		"loginctl", "enable-linger", username,
+	)
+	if err == nil && res.ExitCode == 0 {
+		return nil
+	}
+
+	// Fallback: try with sudo -n (non-interactive)
+	res, err = execCommand(context.Background(),
+		"sudo", "-n", "loginctl", "enable-linger", username,
+	)
+	if err == nil && res.ExitCode == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("could not enable linger — run manually:\n  sudo loginctl enable-linger %s", username)
+}
+
+// PromptLinger checks linger status and prints instructions if not enabled.
+// This is called after service installation on Linux.
+func PromptLinger() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	u, err := user.Current()
+	if err != nil {
+		return
+	}
+
+	enabled, err := IsLingerEnabled(u.Username)
+	if err != nil {
+		log.Printf("daemon: could not check linger status: %v", err)
+		return
+	}
+
+	if enabled {
+		log.Printf("daemon: linger is enabled for %s — service will persist across logout", u.Username)
+		return
+	}
+
+	// Try to enable automatically
+	if err := EnableLinger(u.Username); err != nil {
+		fmt.Println()
+		fmt.Println("⚠️  Linger is NOT enabled — the service will stop when you log out.")
+		fmt.Println("   To keep it running permanently, run:")
+		fmt.Printf("   sudo loginctl enable-linger %s\n", u.Username)
+		fmt.Println()
+	} else {
+		log.Printf("daemon: linger enabled for %s", u.Username)
+	}
+}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+)
+
+// InstallArgs holds everything needed to write and activate a service.
+type InstallArgs struct {
+	BinaryPath  string            // absolute path to the nanoclaw binary
+	Port        int               // gateway port
+	Bind        string            // bind address
+	ConfigPath  string            // absolute path to config.yaml
+	EnvFile     string            // absolute path to .env (used as EnvironmentFile=)
+	Environment map[string]string // extra env vars (HOME, API keys)
+	Description string            // service description
+	Force       bool              // force reinstall
+}
+
+// ServiceRuntime holds the live state of a managed service.
+type ServiceRuntime struct {
+	Status     string // "running", "stopped", "failed", "unknown"
+	SubState   string // platform-specific detail (e.g. "running", "dead")
+	PID        int    // main process PID (0 if not running)
+	ExitCode   int    // last exit code
+	ExitReason string // last exit reason
+}
+
+// Service is the platform-agnostic interface for daemon lifecycle management.
+type Service interface {
+	// Label returns the human-readable backend name (e.g. "systemd", "LaunchAgent").
+	Label() string
+
+	// Install writes the service configuration and activates it.
+	Install(ctx context.Context, args InstallArgs) error
+
+	// Uninstall stops and removes the service.
+	Uninstall(ctx context.Context) error
+
+	// Start starts the service.
+	Start(ctx context.Context) error
+
+	// Stop stops the service.
+	Stop(ctx context.Context) error
+
+	// Restart restarts the service.
+	Restart(ctx context.Context) error
+
+	// IsInstalled returns true if the service is registered and enabled.
+	IsInstalled() (bool, error)
+
+	// ReadRuntime reads the live runtime state.
+	ReadRuntime() (*ServiceRuntime, error)
+
+	// UnitPath returns the path to the service definition file.
+	UnitPath() string
+}
+
+// Resolve returns the appropriate Service for the current platform.
+func Resolve() (Service, error) {
+	switch runtime.GOOS {
+	case "linux":
+		return newSystemdService()
+	case "darwin":
+		return newLaunchdService()
+	default:
+		return nil, fmt.Errorf("daemon service not supported on %s", runtime.GOOS)
+	}
+}

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -1,0 +1,216 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const systemdServiceName = "nanoclaw-gateway"
+
+type systemdService struct {
+	unitName string
+	unitDir  string
+	unitPath string
+}
+
+func newSystemdService() (*systemdService, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	unitName := systemdServiceName + ".service"
+	return &systemdService{
+		unitName: unitName,
+		unitDir:  unitDir,
+		unitPath: filepath.Join(unitDir, unitName),
+	}, nil
+}
+
+func (s *systemdService) Label() string { return "systemd" }
+
+func (s *systemdService) UnitPath() string { return s.unitPath }
+
+func (s *systemdService) Install(ctx context.Context, args InstallArgs) error {
+	// 1. Create unit directory
+	if err := os.MkdirAll(s.unitDir, 0755); err != nil {
+		return fmt.Errorf("create unit dir: %w", err)
+	}
+
+	// 2. Backup existing unit file
+	if _, err := os.Stat(s.unitPath); err == nil {
+		bakPath := s.unitPath + ".bak"
+		data, _ := os.ReadFile(s.unitPath)
+		if len(data) > 0 {
+			_ = os.WriteFile(bakPath, data, 0644)
+			log.Printf("daemon: backed up existing unit to %s", bakPath)
+		}
+	}
+
+	// 3. Generate and write unit file
+	unit := buildSystemdUnit(args)
+	if err := os.WriteFile(s.unitPath, []byte(unit), 0644); err != nil {
+		return fmt.Errorf("write unit file: %w", err)
+	}
+	log.Printf("daemon: wrote %s", s.unitPath)
+
+	// 4. Reload, enable, restart
+	if _, err := systemctlUser(ctx, "daemon-reload"); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
+	}
+	if _, err := systemctlUser(ctx, "enable", s.unitName); err != nil {
+		return fmt.Errorf("enable: %w", err)
+	}
+	if _, err := systemctlUser(ctx, "restart", s.unitName); err != nil {
+		return fmt.Errorf("restart: %w", err)
+	}
+
+	log.Printf("daemon: service %s installed and started", s.unitName)
+	return nil
+}
+
+func (s *systemdService) Uninstall(ctx context.Context) error {
+	// disable --now: disable + stop in one command
+	if _, err := systemctlUser(ctx, "disable", "--now", s.unitName); err != nil {
+		log.Printf("daemon: disable failed (may not be loaded): %v", err)
+	}
+
+	if err := os.Remove(s.unitPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove unit file: %w", err)
+	}
+
+	if _, err := systemctlUser(ctx, "daemon-reload"); err != nil {
+		log.Printf("daemon: daemon-reload after uninstall: %v", err)
+	}
+
+	log.Printf("daemon: service %s uninstalled", s.unitName)
+	return nil
+}
+
+func (s *systemdService) Start(ctx context.Context) error {
+	_, err := systemctlUser(ctx, "start", s.unitName)
+	return err
+}
+
+func (s *systemdService) Stop(ctx context.Context) error {
+	_, err := systemctlUser(ctx, "stop", s.unitName)
+	return err
+}
+
+func (s *systemdService) Restart(ctx context.Context) error {
+	_, err := systemctlUser(ctx, "restart", s.unitName)
+	return err
+}
+
+func (s *systemdService) IsInstalled() (bool, error) {
+	res, err := systemctlUser(context.Background(), "is-enabled", s.unitName)
+	if err != nil {
+		return false, err
+	}
+	stdout := strings.TrimSpace(res.Stdout)
+	// "enabled" or "enabled-runtime" means installed
+	return stdout == "enabled" || stdout == "enabled-runtime", nil
+}
+
+func (s *systemdService) ReadRuntime() (*ServiceRuntime, error) {
+	res, err := systemctlUser(context.Background(),
+		"show", s.unitName,
+		"--no-page",
+		"--property=ActiveState,SubState,MainPID,ExecMainStatus,ExecMainCode",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := &ServiceRuntime{Status: "unknown"}
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		v = strings.TrimSpace(v)
+		switch k {
+		case "ActiveState":
+			switch v {
+			case "active":
+				rt.Status = "running"
+			case "failed":
+				rt.Status = "failed"
+			case "inactive":
+				rt.Status = "stopped"
+			default:
+				rt.Status = v
+			}
+		case "SubState":
+			rt.SubState = v
+		case "MainPID":
+			rt.PID, _ = strconv.Atoi(v)
+		case "ExecMainStatus":
+			rt.ExitCode, _ = strconv.Atoi(v)
+		case "ExecMainCode":
+			rt.ExitReason = v
+		}
+	}
+
+	return rt, nil
+}
+
+// systemctlUser runs systemctl --user with fallback for sudo context.
+// Ported from openclaw's execSystemctlUser which handles SUDO_USER
+// and user bus unavailability.
+func systemctlUser(ctx context.Context, args ...string) (*ExecResult, error) {
+	if !commandExists("systemctl") {
+		return nil, fmt.Errorf("systemctl not found — is systemd installed?")
+	}
+
+	// Primary: systemctl --user <args>
+	fullArgs := append([]string{"--user"}, args...)
+	res, err := execCommand(ctx, "systemctl", fullArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for user bus unavailability (common in SSH/container contexts)
+	if res.ExitCode != 0 && isUserBusError(res.Stderr) {
+		// Fallback: try --machine <user>@ scope (works when XDG_RUNTIME_DIR is missing)
+		u, uErr := user.Current()
+		if uErr == nil {
+			machineArgs := append([]string{"--machine", u.Username + "@", "--user"}, args...)
+			res2, err2 := execCommand(ctx, "systemctl", machineArgs...)
+			if err2 == nil && res2.ExitCode == 0 {
+				return res2, nil
+			}
+		}
+		return res, fmt.Errorf(
+			"systemd user bus unavailable (exit %d).\n"+
+				"If via SSH, try: export XDG_RUNTIME_DIR=/run/user/$(id -u)\n"+
+				"If WSL, enable systemd in /etc/wsl.conf:\n"+
+				"  [boot]\n  systemd=true\n"+
+				"stderr: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+
+	if res.ExitCode != 0 {
+		// Non-zero exit is normal for is-enabled when disabled
+		if len(args) > 0 && args[0] == "is-enabled" {
+			return res, nil
+		}
+		return res, fmt.Errorf("systemctl %s failed (exit %d): %s",
+			strings.Join(args, " "), res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+
+	return res, nil
+}
+
+// isUserBusError detects systemd user bus/session unavailability from stderr.
+func isUserBusError(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "failed to connect to bus") ||
+		strings.Contains(s, "no such file or directory") && strings.Contains(s, "dbus") ||
+		strings.Contains(s, "xdg_runtime_dir")
+}

--- a/internal/daemon/systemd_unit.go
+++ b/internal/daemon/systemd_unit.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// systemdEscapeValue escapes a value for use in a systemd Environment= directive.
+// Ported from openclaw src/daemon/systemd-unit.ts.
+// Rules: if value contains space, quote, or backslash, wrap in quotes with
+// backslashes doubled and quotes escaped.
+func systemdEscapeValue(s string) string {
+	if s == "" {
+		return `""`
+	}
+	needsQuote := false
+	for _, c := range s {
+		if c == ' ' || c == '\t' || c == '"' || c == '\\' || c == '\n' {
+			needsQuote = true
+			break
+		}
+	}
+	if !needsQuote {
+		return s
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, c := range s {
+		switch c {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		default:
+			b.WriteRune(c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// systemdEscapeExecArg escapes a single argument for ExecStart=.
+// Systemd splits ExecStart on unquoted whitespace; arguments containing
+// spaces, quotes, or backslashes must be quoted.
+func systemdEscapeExecArg(s string) string {
+	return systemdEscapeValue(s)
+}
+
+// buildExecStart builds the ExecStart= line from program arguments.
+func buildExecStart(args []string) string {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = systemdEscapeExecArg(a)
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildEnvironmentLines generates Environment= directives for the unit file.
+func buildEnvironmentLines(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for k, v := range env {
+		if k == "" || strings.ContainsAny(k, "\n\r") {
+			continue
+		}
+		if strings.ContainsAny(v, "\n\r") {
+			continue // systemd doesn't allow CR/LF in env values
+		}
+		fmt.Fprintf(&b, "Environment=%s=%s\n", k, systemdEscapeValue(v))
+	}
+	return b.String()
+}
+
+// buildSystemdUnit generates a complete systemd user service unit file.
+func buildSystemdUnit(args InstallArgs) string {
+	description := args.Description
+	if description == "" {
+		description = "NanoClaw Gateway"
+	}
+
+	// Build ExecStart arguments
+	execArgs := []string{args.BinaryPath, "gateway"}
+	if args.ConfigPath != "" {
+		execArgs = append(execArgs, "--config", args.ConfigPath)
+	}
+	if args.EnvFile != "" {
+		execArgs = append(execArgs, "--env", args.EnvFile)
+	}
+	if args.Bind != "" {
+		execArgs = append(execArgs, "--bind", args.Bind)
+	}
+	if args.Port > 0 {
+		execArgs = append(execArgs, "--port", fmt.Sprintf("%d", args.Port))
+	}
+
+	var b strings.Builder
+
+	// [Unit]
+	b.WriteString("[Unit]\n")
+	fmt.Fprintf(&b, "Description=%s\n", description)
+	b.WriteString("After=network-online.target\n")
+	b.WriteString("Wants=network-online.target\n")
+	b.WriteString("\n")
+
+	// [Service]
+	b.WriteString("[Service]\n")
+	fmt.Fprintf(&b, "ExecStart=%s\n", buildExecStart(execArgs))
+	b.WriteString("Restart=always\n")
+	b.WriteString("RestartSec=5\n")
+	b.WriteString("TimeoutStopSec=30\n")
+	b.WriteString("TimeoutStartSec=30\n")
+	b.WriteString("SuccessExitStatus=0 143\n")
+	b.WriteString("KillMode=control-group\n")
+
+	// EnvironmentFile (optional, prefix with - so missing file is not an error)
+	if args.EnvFile != "" {
+		fmt.Fprintf(&b, "EnvironmentFile=-%s\n", args.EnvFile)
+	}
+
+	// Inline environment variables
+	b.WriteString(buildEnvironmentLines(args.Environment))
+	b.WriteString("\n")
+
+	// [Install]
+	b.WriteString("[Install]\n")
+	b.WriteString("WantedBy=default.target\n")
+
+	return b.String()
+}

--- a/internal/daemon/systemd_unit_test.go
+++ b/internal/daemon/systemd_unit_test.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemdEscapeValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"", `""`},
+		{"has space", `"has space"`},
+		{`has"quote`, `"has\"quote"`},
+		{`has\back`, `"has\\back"`},
+		{"has\nnewline", `"has\nnewline"`},
+		{"/usr/bin/node", "/usr/bin/node"},
+		{"sk-ant-api03-abc123", "sk-ant-api03-abc123"},
+		{`path with "quotes" and spaces`, `"path with \"quotes\" and spaces"`},
+		{`C:\Users\test`, `"C:\\Users\\test"`},
+	}
+
+	for _, tt := range tests {
+		got := systemdEscapeValue(tt.input)
+		if got != tt.want {
+			t.Errorf("systemdEscapeValue(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildExecStart(t *testing.T) {
+	args := []string{"/usr/local/bin/nanoclaw", "gateway", "--port", "18789"}
+	got := buildExecStart(args)
+	want := "/usr/local/bin/nanoclaw gateway --port 18789"
+	if got != want {
+		t.Errorf("buildExecStart = %q, want %q", got, want)
+	}
+
+	// With path containing spaces
+	args2 := []string{"/opt/my app/nanoclaw", "gateway"}
+	got2 := buildExecStart(args2)
+	if !strings.HasPrefix(got2, `"/opt/my app/nanoclaw"`) {
+		t.Errorf("buildExecStart with spaces = %q, expected quoted path", got2)
+	}
+}
+
+func TestBuildEnvironmentLines(t *testing.T) {
+	env := map[string]string{
+		"HOME":             "/home/user",
+		"ANTHROPIC_API_KEY": "sk-test-123",
+	}
+	got := buildEnvironmentLines(env)
+
+	if !strings.Contains(got, "Environment=HOME=/home/user") {
+		t.Errorf("missing HOME in env lines: %s", got)
+	}
+	if !strings.Contains(got, "Environment=ANTHROPIC_API_KEY=sk-test-123") {
+		t.Errorf("missing API key in env lines: %s", got)
+	}
+
+	// Should skip keys/values with newlines
+	envBad := map[string]string{"BAD": "has\nnewline"}
+	gotBad := buildEnvironmentLines(envBad)
+	if strings.Contains(gotBad, "BAD") {
+		t.Errorf("should skip env with newlines: %s", gotBad)
+	}
+}
+
+func TestBuildSystemdUnit(t *testing.T) {
+	args := InstallArgs{
+		BinaryPath:  "/usr/local/bin/nanoclaw",
+		Port:        18789,
+		Bind:        "127.0.0.1",
+		ConfigPath:  "/home/user/config.yaml",
+		EnvFile:     "/home/user/.env",
+		Description: "NanoClaw Gateway",
+		Environment: map[string]string{
+			"HOME": "/home/user",
+		},
+	}
+
+	unit := buildSystemdUnit(args)
+
+	checks := []string{
+		"[Unit]",
+		"Description=NanoClaw Gateway",
+		"After=network-online.target",
+		"[Service]",
+		"ExecStart=/usr/local/bin/nanoclaw gateway --config /home/user/config.yaml --env /home/user/.env --bind 127.0.0.1 --port 18789",
+		"Restart=always",
+		"RestartSec=5",
+		"SuccessExitStatus=0 143",
+		"KillMode=control-group",
+		"EnvironmentFile=-/home/user/.env",
+		"Environment=HOME=/home/user",
+		"[Install]",
+		"WantedBy=default.target",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(unit, check) {
+			t.Errorf("unit file missing %q\nGot:\n%s", check, unit)
+		}
+	}
+}


### PR DESCRIPTION
Add `internal/daemon/` package porting openclaw's daemon mechanism to Go. Enables `nanoclaw gateway install` to register as a systemd user service (Linux) or LaunchAgent (macOS) for production background deployment.

New CLI subcommands: gateway install/uninstall/start/stop/restart/status. Includes health polling, linger management, unit file generation with proper escaping, and platform abstraction.