### PR TITLE
feat: implement openclaw stream message architecture

### DIFF
--- a/internal/bot/format.go
+++ b/internal/bot/format.go
@@ -404,8 +404,27 @@ func chunkHTML(text string, maxLen int) []string {
 			cutAt = maxLen
 		}
 
-		chunks = append(chunks, strings.TrimRight(remaining[:cutAt], " \n"))
+		chunk := strings.TrimRight(remaining[:cutAt], " \n")
 		remaining = strings.TrimLeft(remaining[cutAt:], " \n")
+
+		// Markdown-safe chunking: if we cut inside a <pre><code> block,
+		// close it at the end of this chunk and reopen in the next chunk
+		// so each chunk is valid HTML. (openclaw pattern)
+		preOpens := strings.Count(chunk, "<pre>") + strings.Count(chunk, "<pre><code>")
+		preCloses := strings.Count(chunk, "</pre>") + strings.Count(chunk, "</code></pre>")
+		if preOpens > preCloses {
+			codeOpens := strings.Count(chunk, "<code>")
+			codeCloses := strings.Count(chunk, "</code>")
+			if codeOpens > codeCloses {
+				chunk += "</code></pre>"
+				remaining = "<pre><code>" + remaining
+			} else {
+				chunk += "</pre>"
+				remaining = "<pre>" + remaining
+			}
+		}
+
+		chunks = append(chunks, chunk)
 	}
 
 	return chunks

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	maxTelegramMsg = 4000 // Telegram limit is 4096, leave room for formatting
-	streamInterval = 800 * time.Millisecond
+	maxTelegramMsg   = 4000 // Telegram limit is 4096, leave room for formatting
+	streamInterval   = 800 * time.Millisecond
+	maxCoalesceChars = 1200 // force flush when buffer exceeds this (openclaw pattern)
+	minInitialChars  = 30   // hold first send until meaningful content
 )
 
 // Streamer manages real-time streaming of text to a Telegram message.
@@ -27,6 +29,9 @@ type Streamer struct {
 	mu    sync.Mutex
 	buf   strings.Builder
 	dirty bool
+
+	// Coalescing: hold first send until meaningful content (openclaw minInitialChars)
+	initialSent bool
 
 	// Tool progress tracking — shown as compact status, not full output
 	toolNames []string
@@ -73,9 +78,15 @@ func (s *Streamer) Write(chunk string) {
 		return
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.buf.WriteString(chunk)
 	s.dirty = true
+	bufLen := len([]rune(s.buf.String()))
+	s.mu.Unlock()
+
+	// Force flush at maxCoalesceChars to prevent excessive buffering
+	if bufLen >= maxCoalesceChars {
+		s.flush()
+	}
 }
 
 // NoteTool records a tool call as a compact progress indicator.
@@ -104,10 +115,21 @@ func (s *Streamer) flush() {
 	}
 	assistantText := strings.TrimSpace(s.buf.String())
 	toolLine := s.toolStatusLine()
+
+	// Hold first send until minInitialChars for meaningful push notification
+	if !s.initialSent && len([]rune(assistantText)) < minInitialChars && toolLine == "" {
+		s.mu.Unlock()
+		return
+	}
+
 	s.dirty = false
 	s.mu.Unlock()
 
 	s.sendFormatted(assistantText, toolLine)
+
+	s.mu.Lock()
+	s.initialSent = true
+	s.mu.Unlock()
 }
 
 // sendFormatted converts assistant markdown to Telegram HTML, appends the

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -30,6 +30,12 @@ type Streamer struct {
 	buf   strings.Builder
 	dirty bool
 
+	// Reasoning lane: separate message for thinking content (openclaw lane system)
+	reasonBuf   strings.Builder
+	reasonMsgID int
+	reasonDirty bool
+	thinkState  thinkingState
+
 	// Coalescing: hold first send until meaningful content (openclaw minInitialChars)
 	initialSent bool
 
@@ -79,20 +85,35 @@ func (s *Streamer) loop() {
 }
 
 // Write appends assistant text to the buffer.
+// Thinking tags are parsed and routed to the reasoning lane; answer text
+// goes to the main buffer. Tool markers and special tokens are stripped.
 func (s *Streamer) Write(chunk string) {
-	// Filter thinking tags and tool markers from streamed text
-	chunk = filterContent(chunk)
+	// Strip tool markers and special tokens (thinking tags handled by thinkState)
+	chunk = toolCallRe.ReplaceAllString(chunk, "")
+	chunk = specialRe.ReplaceAllString(chunk, "")
 	if chunk == "" {
 		return
 	}
+
+	var forceFlush bool
+
 	s.mu.Lock()
-	s.buf.WriteString(chunk)
-	s.dirty = true
-	bufLen := len([]rune(s.buf.String()))
+	thinkText, answerText := s.thinkState.processChunk(chunk)
+
+	if thinkText != "" {
+		s.reasonBuf.WriteString(thinkText)
+		s.reasonDirty = true
+	}
+	if answerText != "" {
+		s.buf.WriteString(answerText)
+		s.dirty = true
+		if len([]rune(s.buf.String())) >= maxCoalesceChars {
+			forceFlush = true
+		}
+	}
 	s.mu.Unlock()
 
-	// Force flush at maxCoalesceChars to prevent excessive buffering
-	if bufLen >= maxCoalesceChars {
+	if forceFlush {
 		s.flush()
 	}
 }
@@ -117,7 +138,7 @@ func (s *Streamer) Flush() {
 
 func (s *Streamer) flush() {
 	s.mu.Lock()
-	if !s.dirty {
+	if !s.dirty && !s.reasonDirty {
 		s.mu.Unlock()
 		return
 	}
@@ -129,19 +150,30 @@ func (s *Streamer) flush() {
 	}
 
 	assistantText := strings.TrimSpace(s.buf.String())
+	reasonText := strings.TrimSpace(s.reasonBuf.String())
 	toolLine := s.toolStatusLine()
 
 	// Hold first send until minInitialChars for meaningful push notification
-	if !s.initialSent && len([]rune(assistantText)) < minInitialChars && toolLine == "" {
+	totalChars := len([]rune(assistantText)) + len([]rune(reasonText))
+	if !s.initialSent && totalChars < minInitialChars && toolLine == "" {
 		s.mu.Unlock()
 		return
 	}
 
 	s.dirty = false
+	s.reasonDirty = false
 	s.inflight = true
 	s.mu.Unlock()
 
-	s.sendFormatted(assistantText, toolLine)
+	// Flush reasoning lane (thinking content → separate italic message)
+	if reasonText != "" {
+		s.flushReasonLane(reasonText)
+	}
+
+	// Flush answer lane
+	if assistantText != "" || toolLine != "" {
+		s.sendFormatted(assistantText, toolLine)
+	}
 
 	s.mu.Lock()
 	s.inflight = false
@@ -276,14 +308,39 @@ func (s *Streamer) editCurrent(text string) {
 func (s *Streamer) Finalize() {
 	s.ticker.Stop()
 
-	// Final flush with tool status stripped — show only clean assistant text
+	// Wait for any in-flight flush to complete
+	for {
+		s.mu.Lock()
+		if !s.inflight {
+			s.mu.Unlock()
+			break
+		}
+		s.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Flush any buffered partial thinking tag as text
 	s.mu.Lock()
+	if s.thinkState.tagBuf != "" {
+		if s.thinkState.inside {
+			s.reasonBuf.WriteString(s.thinkState.tagBuf)
+		} else {
+			s.buf.WriteString(s.thinkState.tagBuf)
+		}
+		s.thinkState.tagBuf = ""
+	}
 	finalText := strings.TrimSpace(s.buf.String())
+	reasonText := strings.TrimSpace(s.reasonBuf.String())
 	hasPendingTools := s.toolCount > 0 && finalText != ""
 	s.mu.Unlock()
 
-	if hasPendingTools {
-		// Re-render without tool status line for clean final message
+	// Final flush of reasoning lane
+	if reasonText != "" {
+		s.flushReasonLane(reasonText)
+	}
+
+	// Re-render answer without tool status line for clean final message
+	if hasPendingTools || finalText != "" {
 		s.sendFormatted(finalText, "")
 	}
 
@@ -329,21 +386,142 @@ func (s *Streamer) CurrentText() string {
 	return s.buf.String()
 }
 
-// --- Content filtering (openclaw pattern) ---
+// --- Reasoning lane (openclaw dual-lane pattern) ---
+
+// flushReasonLane updates the reasoning lane message with thinking content.
+// On first call, it takes over the placeholder message (⏳ Thinking...).
+// The answer lane then creates a new message when it has content.
+func (s *Streamer) flushReasonLane(text string) {
+	html := "💭 <i>" + markdownToTelegramHTML(text) + "</i>"
+	if len(html) > maxTelegramMsg {
+		runes := []rune(html)
+		if len(runes) > maxTelegramMsg-20 {
+			html = string(runes[:maxTelegramMsg-20]) + "...</i>"
+		}
+	}
+
+	s.mu.Lock()
+	msgID := s.reasonMsgID
+
+	// First reasoning flush: take over the placeholder message
+	if msgID == 0 && s.messageID != 0 {
+		s.reasonMsgID = s.messageID
+		s.messageID = 0 // answer lane will create a new message
+		msgID = s.reasonMsgID
+	}
+	s.mu.Unlock()
+
+	if msgID == 0 {
+		// No placeholder — send new message
+		msg := tgbotapi.NewMessage(s.chatID, html)
+		msg.ParseMode = "HTML"
+		sent, err := s.bot.Send(msg)
+		if err != nil {
+			msg2 := tgbotapi.NewMessage(s.chatID, stripHTML(html))
+			sent, err = s.bot.Send(msg2)
+		}
+		if err != nil {
+			log.Printf("streamer: reason lane send: %v", err)
+			return
+		}
+		s.mu.Lock()
+		s.reasonMsgID = sent.MessageID
+		s.mu.Unlock()
+		return
+	}
+
+	edit := tgbotapi.NewEditMessageText(s.chatID, msgID, html)
+	edit.ParseMode = "HTML"
+	if _, err := s.bot.Send(edit); err != nil {
+		edit2 := tgbotapi.NewEditMessageText(s.chatID, msgID, stripHTML(html))
+		edit2.ParseMode = ""
+		_, _ = s.bot.Send(edit2)
+	}
+}
+
+// --- Thinking tag parser (streaming state machine) ---
+
+// thinkingState tracks whether we're inside a thinking block during streaming.
+// Handles thinking tags that may be split across Write() chunks.
+type thinkingState struct {
+	inside bool   // currently inside a thinking block
+	tagBuf string // accumulates characters of a potential partial tag
+}
 
 var (
-	thinkingRe  = regexp.MustCompile(`(?s)<(?:think|thinking|thought)>.*?</(?:think|thinking|thought)>`)
-	toolCallRe  = regexp.MustCompile(`\[Tool (?:Call|Result)[^\]]*\]`)
-	specialRe   = regexp.MustCompile(`<\|[^|]*\|>`)
+	thinkOpenTags  = []string{"<thinking>", "<think>", "<thought>"}
+	thinkCloseTags = []string{"</thinking>", "</think>", "</thought>"}
 )
 
-// filterContent strips thinking tags, tool markers, and model special tokens.
-func filterContent(text string) string {
-	text = thinkingRe.ReplaceAllString(text, "")
-	text = toolCallRe.ReplaceAllString(text, "")
-	text = specialRe.ReplaceAllString(text, "")
-	return text
+// processChunk splits a text chunk into thinking and answer portions.
+func (t *thinkingState) processChunk(chunk string) (thinking, answer string) {
+	var thinkBuf, answerBuf strings.Builder
+
+	// Prepend any buffered partial tag from previous chunk
+	input := t.tagBuf + chunk
+	t.tagBuf = ""
+
+	i := 0
+	for i < len(input) {
+		if input[i] == '<' {
+			remaining := input[i:]
+
+			// Try to match complete thinking tags
+			if matched, tag := matchThinkTag(remaining, thinkOpenTags); matched {
+				t.inside = true
+				i += len(tag)
+				continue
+			}
+			if matched, tag := matchThinkTag(remaining, thinkCloseTags); matched {
+				t.inside = false
+				i += len(tag)
+				continue
+			}
+
+			// Check if this could be a partial thinking tag (split across chunks)
+			if couldBeThinkTag(remaining) {
+				t.tagBuf = remaining
+				break
+			}
+		}
+
+		if t.inside {
+			thinkBuf.WriteByte(input[i])
+		} else {
+			answerBuf.WriteByte(input[i])
+		}
+		i++
+	}
+
+	return thinkBuf.String(), answerBuf.String()
 }
+
+func matchThinkTag(s string, tags []string) (bool, string) {
+	for _, tag := range tags {
+		if strings.HasPrefix(s, tag) {
+			return true, tag
+		}
+	}
+	return false, ""
+}
+
+func couldBeThinkTag(s string) bool {
+	allTags := append(thinkOpenTags, thinkCloseTags...)
+	for _, tag := range allTags {
+		if len(s) < len(tag) && strings.HasPrefix(tag, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Content filtering ---
+
+var (
+	toolCallRe = regexp.MustCompile(`\[Tool (?:Call|Result)[^\]]*\]`)
+	specialRe  = regexp.MustCompile(`<\|[^|]*\|>`)
+)
+
 
 
 func truncate(s string, maxRunes int) string {

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -33,6 +33,10 @@ type Streamer struct {
 	// Coalescing: hold first send until meaningful content (openclaw minInitialChars)
 	initialSent bool
 
+	// Dedup and anti-regression guards (openclaw pattern)
+	lastSentHTML  string
+	lastAssistLen int
+
 	// Tool progress tracking — shown as compact status, not full output
 	toolNames []string
 	toolCount int
@@ -152,6 +156,23 @@ func (s *Streamer) sendFormatted(assistantText, toolLine string) {
 	if html == "" {
 		return
 	}
+
+	// Dedup: skip if identical to last sent (avoids pointless API calls)
+	// Anti-regression: skip if assistant text got shorter (openclaw pattern —
+	// prevents edits that make the message shrink during streaming)
+	assistLen := len([]rune(assistantText))
+	s.mu.Lock()
+	if html == s.lastSentHTML {
+		s.mu.Unlock()
+		return
+	}
+	if assistLen < s.lastAssistLen && s.lastAssistLen > 0 {
+		s.mu.Unlock()
+		return
+	}
+	s.lastSentHTML = html
+	s.lastAssistLen = assistLen
+	s.mu.Unlock()
 
 	if len(html) <= maxTelegramMsg {
 		s.editCurrent(html)

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -37,6 +37,10 @@ type Streamer struct {
 	lastSentHTML  string
 	lastAssistLen int
 
+	// In-flight tracking: prevent concurrent Telegram API calls (openclaw pattern)
+	inflight     bool
+	pendingFlush bool
+
 	// Tool progress tracking — shown as compact status, not full output
 	toolNames []string
 	toolCount int
@@ -117,6 +121,13 @@ func (s *Streamer) flush() {
 		s.mu.Unlock()
 		return
 	}
+	// In-flight guard: if a Telegram API call is active, defer this flush
+	if s.inflight {
+		s.pendingFlush = true
+		s.mu.Unlock()
+		return
+	}
+
 	assistantText := strings.TrimSpace(s.buf.String())
 	toolLine := s.toolStatusLine()
 
@@ -127,13 +138,22 @@ func (s *Streamer) flush() {
 	}
 
 	s.dirty = false
+	s.inflight = true
 	s.mu.Unlock()
 
 	s.sendFormatted(assistantText, toolLine)
 
 	s.mu.Lock()
+	s.inflight = false
 	s.initialSent = true
+	needsFlush := s.pendingFlush
+	s.pendingFlush = false
 	s.mu.Unlock()
+
+	// Drain: if another flush was requested while we were sending, do it now
+	if needsFlush {
+		s.flush()
+	}
 }
 
 // sendFormatted converts assistant markdown to Telegram HTML, appends the


### PR DESCRIPTION
## Summary
- Implement openclaw's 4-layer streaming patterns into goterm-control's streamer
- Add dual-lane system: reasoning (thinking) and answer as separate Telegram messages
- Improve streaming reliability with dedup, anti-regression, in-flight tracking, and code-fence-safe chunking

## Changes
- `internal/bot/streamer.go` — Core streaming improvements:
  - **Step 1**: Char-based coalescing (`maxCoalesceChars=1200`, `minInitialChars=30`)
  - **Step 2**: Dedup + anti-regression guards (skip identical edits, prevent text shrinking)
  - **Step 3**: In-flight request tracking (prevent concurrent Telegram API calls)
  - **Step 4**: Dual-lane system — thinking content in italic message, answer in separate message
- `internal/bot/format.go` — **Step 5**: Markdown-safe code fence chunking (auto close/reopen `<pre><code>` blocks at chunk boundaries)

## Plan Reference
Implementation of the plan from #9:
https://github.com/phanngoc/goterm-control/issues/9#issuecomment-4228161028

## Steps Implemented
- [x] Step 1: Char-based coalescing + minInitialChars
- [x] Step 2: Anti-regression + Dedup guards
- [x] Step 3: In-flight request tracking
- [x] Step 4: Lane system (reasoning/answer)
- [x] Step 5: Markdown-safe code fence chunking

## Test Plan
- [x] `go build ./internal/bot/` passes
- [x] `go vet ./internal/bot/` passes
- [x] `go test ./internal/bot/` passes
- [ ] Manual testing: send message that triggers thinking → verify 2 separate messages (italic reasoning + normal answer)
- [ ] Manual testing: send long response → verify code fence chunking renders correctly
- [ ] Manual testing: rapid messages → verify no duplicate edits

Refs #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)