### PR TITLE
fix: skip network-mounted directories during filepath.Walk

### DIFF
--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -197,9 +197,13 @@ func (t *FileSystemTool) listFlat(path string, showHidden bool) (string, error) 
 
 func (t *FileSystemTool) listRecursive(root string, showHidden bool) (string, error) {
 	var lines []string
+	wf := newWalkFilter(root)
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
+		}
+		if info.IsDir() && path != root && wf.shouldSkip(path, info) {
+			return filepath.SkipDir
 		}
 		rel, _ := filepath.Rel(root, path)
 		if rel == "." {
@@ -265,9 +269,13 @@ func (t *FileSystemTool) SearchFiles(ctx context.Context, raw json.RawMessage) (
 
 	// Search by filename
 	var matches []string
+	wf := newWalkFilter(searchPath)
 	err := filepath.Walk(searchPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
+		}
+		if info.IsDir() && path != searchPath && wf.shouldSkip(path, info) {
+			return filepath.SkipDir
 		}
 		if strings.Contains(strings.ToLower(info.Name()), strings.ToLower(inp.Pattern)) {
 			rel, _ := filepath.Rel(searchPath, path)

--- a/internal/tools/skipdir_darwin.go
+++ b/internal/tools/skipdir_darwin.go
@@ -1,0 +1,89 @@
+//go:build darwin
+
+package tools
+
+import (
+	"os"
+	"syscall"
+)
+
+// networkFSTypes lists macOS filesystem types that indicate network or
+// virtual mounts. Traversing these triggers permission dialogs.
+var networkFSTypes = map[string]bool{
+	"nfs":      true, // NFS (standard, OrbStack)
+	"smbfs":    true, // SMB/CIFS
+	"afpfs":    true, // Apple Filing Protocol
+	"webdavfs": true, // WebDAV
+	"virtiofs": true, // VirtIO FS (OrbStack, Lima)
+	"fuse":     true, // Generic FUSE (sshfs, etc.)
+	"osxfuse":  true, // macFUSE v3
+	"macfuse":  true, // macFUSE v4
+}
+
+// walkFilter detects network-mounted directories during filepath.Walk
+// using device IDs to minimize syscalls.
+type walkFilter struct {
+	rootDev int32
+	cache   map[int32]bool // device ID → is network mount
+}
+
+func newWalkFilter(root string) *walkFilter {
+	wf := &walkFilter{cache: make(map[int32]bool)}
+	var stat syscall.Stat_t
+	if err := syscall.Stat(root, &stat); err == nil {
+		wf.rootDev = stat.Dev
+		wf.cache[stat.Dev] = false // root filesystem is safe
+	}
+	return wf
+}
+
+// shouldSkip returns true if the directory at path is on a network filesystem.
+// It uses the device ID from info.Sys() to avoid redundant syscalls.
+func (wf *walkFilter) shouldSkip(path string, info os.FileInfo) bool {
+	sys := info.Sys()
+	if sys == nil {
+		return false
+	}
+	st, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+
+	// Same device as walk root → same filesystem → safe
+	if st.Dev == wf.rootDev {
+		return false
+	}
+
+	// Check cache for this device ID
+	if result, ok := wf.cache[st.Dev]; ok {
+		return result
+	}
+
+	// New device encountered — Statfs to check filesystem type
+	result := isNetworkMount(path)
+	wf.cache[st.Dev] = result
+	return result
+}
+
+// isNetworkMount uses syscall.Statfs to check whether path is on a
+// network or virtual filesystem.
+func isNetworkMount(path string) bool {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return true // can't stat → skip to be safe
+	}
+	fstype := int8ArrayToString(stat.Fstypename[:])
+	return networkFSTypes[fstype]
+}
+
+// int8ArrayToString converts a C-style null-terminated int8 array to a Go string.
+func int8ArrayToString(arr []int8) string {
+	buf := make([]byte, 0, len(arr))
+	for _, b := range arr {
+		if b == 0 {
+			break
+		}
+		buf = append(buf, byte(b))
+	}
+	return string(buf)
+}

--- a/internal/tools/skipdir_darwin_test.go
+++ b/internal/tools/skipdir_darwin_test.go
@@ -1,0 +1,71 @@
+//go:build darwin
+
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInt8ArrayToString(t *testing.T) {
+	// Simulate "nfs\0" as int8 array
+	arr := [16]int8{110, 102, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	got := int8ArrayToString(arr[:])
+	if got != "nfs" {
+		t.Errorf("expected 'nfs', got %q", got)
+	}
+}
+
+func TestInt8ArrayToString_Empty(t *testing.T) {
+	arr := [16]int8{}
+	got := int8ArrayToString(arr[:])
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestIsNetworkMount_LocalPath(t *testing.T) {
+	// /tmp should be on a local filesystem (apfs or hfs)
+	if isNetworkMount("/tmp") {
+		t.Error("expected /tmp to not be detected as network mount")
+	}
+}
+
+func TestWalkFilter_LocalDir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	os.Mkdir(sub, 0755)
+
+	wf := newWalkFilter(dir)
+	info, err := os.Stat(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if wf.shouldSkip(sub, info) {
+		t.Error("expected local subdirectory to not be skipped")
+	}
+}
+
+func TestWalkFilter_CachesDeviceID(t *testing.T) {
+	dir := t.TempDir()
+	sub1 := filepath.Join(dir, "a")
+	sub2 := filepath.Join(dir, "b")
+	os.Mkdir(sub1, 0755)
+	os.Mkdir(sub2, 0755)
+
+	wf := newWalkFilter(dir)
+
+	info1, _ := os.Stat(sub1)
+	info2, _ := os.Stat(sub2)
+
+	// Both should be on the same device as root — fast path, no Statfs needed
+	wf.shouldSkip(sub1, info1)
+	wf.shouldSkip(sub2, info2)
+
+	// Cache should have exactly 1 entry (the root device)
+	if len(wf.cache) != 1 {
+		t.Errorf("expected 1 cache entry (root device), got %d", len(wf.cache))
+	}
+}

--- a/internal/tools/skipdir_other.go
+++ b/internal/tools/skipdir_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin
+
+package tools
+
+import "os"
+
+// walkFilter is a no-op on non-macOS platforms.
+// The macOS permission dialog issue does not apply.
+type walkFilter struct{}
+
+func newWalkFilter(_ string) *walkFilter {
+	return &walkFilter{}
+}
+
+func (wf *walkFilter) shouldSkip(_ string, _ os.FileInfo) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- Thêm `walkFilter` dùng device-ID + `syscall.Statfs` để phát hiện và skip network-mounted directories (OrbStack/virtiofs, NFS, SMB, AFP, FUSE) trong `filepath.Walk`
- Ngăn macOS hiện dialog "nanoclaw would like to access files on a network volume" khi AI agent dùng `list_dir` hoặc `search_files` trên broad paths
- Platform-specific qua build tags — no-op trên non-darwin

## Changes
- `internal/tools/skipdir_darwin.go` (new) — macOS: `walkFilter` struct, `isNetworkMount()`, device-ID caching
- `internal/tools/skipdir_other.go` (new) — non-darwin no-op stub
- `internal/tools/skipdir_darwin_test.go` (new) — unit tests
- `internal/tools/filesystem.go` — add `walkFilter` check in `listRecursive` and `SearchFiles`

## How it works
1. `newWalkFilter(root)` stats the walk root to get its device ID
2. During Walk, each directory's device ID is compared to root's
3. Same device → same filesystem → safe (no syscall needed)
4. Different device → call `Statfs` once, check `Fstypename` against known network FS types
5. Network FS → `filepath.SkipDir`

Statfs is called at most once per unique mount point (typically 1-3 calls total).

## Test plan
- [x] `go build ./internal/tools/...` passes
- [x] `go vet ./internal/tools/...` passes
- [x] `go test ./internal/tools/...` — 5 tests pass
- [ ] Manual: `nanoclaw chat` → `list_dir ~ recursive:true` — no macOS dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)