### PR TITLE
fix: streamer resilience, queue-bypass status, tool label paths

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ claude:
   api_key: ""      # set via ANTHROPIC_API_KEY env var
   model: "claude-sonnet-4-6"   # default model (can also use models.default)
   max_tokens: 8192
+  workspace: "~/goterm-workspace"  # working directory for Claude CLI (default: ~/goterm-workspace)
   system_prompt: |
     You are an AI assistant with full control over a Mac M1 computer. You help the user accomplish any task by:
     - Running shell commands and scripts (bash, python, node, etc.)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -84,6 +84,7 @@ func New(cfg *config.Config) (*Bot, error) {
 	}
 
 	claudeClient := claude.New(cfg.Claude.SystemPrompt, executor)
+	claudeClient.SetWorkspace(cfg.Claude.Workspace)
 
 	// Message store (SQLite — conversation history)
 	messageStore := storage.NewMessageStore(db)

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -97,6 +97,19 @@ func (h *Handler) Handle(update tgbotapi.Update) {
 		return
 	}
 
+	// Allow "status" / "cancel" as plain text (no "/" prefix) so they
+	// work even when the agent is busy and the queue would block them.
+	switch strings.ToLower(strings.TrimSpace(msg.Text)) {
+	case "status":
+		h.showStatus(msg.Chat.ID)
+		return
+	case "cancel":
+		sess := h.sessions.Get(msg.Chat.ID)
+		sess.Cancel()
+		h.sendText(msg.Chat.ID, "🛑 Request cancelled.")
+		return
+	}
+
 	// Regular message → Claude (via execution queue)
 	if msg.Text != "" {
 		h.handleMessage(msg)
@@ -126,30 +139,7 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 		h.sendText(chatID, "🔄 Conversation history cleared.")
 
 	case "status":
-		sess := h.sessions.Get(chatID)
-		sessionID := sess.GetSessionID()
-		if sessionID == "" {
-			sessionID = "none"
-		} else if len(sessionID) > 8 {
-			sessionID = sessionID[:8] + "..."
-		}
-		m := h.resolver.Resolve(chatID)
-		modelName := "unknown"
-		if m != nil {
-			modelName = m.ID
-		}
-		h.sendText(chatID, fmt.Sprintf(
-			"📊 *Session Status*\n\n"+
-				"Chat ID: `%d`\n"+
-				"Turns: %d\n"+
-				"Session: `%s`\n"+
-				"Model: `%s`\n"+
-				"Tokens: %d in / %d out\n"+
-				"Queue: %d pending",
-			chatID, sess.GetMessageCount(), sessionID, modelName,
-			sess.InputTokens, sess.OutputTokens,
-			h.engine.QueueDepth(chatID),
-		))
+		h.showStatus(chatID)
 
 	case "models":
 		h.handleModelsCommand(chatID)
@@ -165,6 +155,33 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 	default:
 		h.sendText(chatID, fmt.Sprintf("Unknown command: /%s\n\nTry /start for help.", msg.Command()))
 	}
+}
+
+func (h *Handler) showStatus(chatID int64) {
+	sess := h.sessions.Get(chatID)
+	sessionID := sess.GetSessionID()
+	if sessionID == "" {
+		sessionID = "none"
+	} else if len(sessionID) > 8 {
+		sessionID = sessionID[:8] + "..."
+	}
+	m := h.resolver.Resolve(chatID)
+	modelName := "unknown"
+	if m != nil {
+		modelName = m.ID
+	}
+	h.sendText(chatID, fmt.Sprintf(
+		"📊 *Session Status*\n\n"+
+			"Chat ID: `%d`\n"+
+			"Turns: %d\n"+
+			"Session: `%s`\n"+
+			"Model: `%s`\n"+
+			"Tokens: %d in / %d out\n"+
+			"Queue: %d pending",
+		chatID, sess.GetMessageCount(), sessionID, modelName,
+		sess.InputTokens, sess.OutputTokens,
+		h.engine.QueueDepth(chatID),
+	))
 }
 
 func (h *Handler) handleModelsCommand(chatID int64) {
@@ -240,7 +257,9 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	// Cancel any in-flight request for this session
 	sess.Cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// 10-minute timeout prevents a stuck Claude CLI from blocking the queue
+	// lane forever. The user can still /cancel manually for shorter waits.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	sess.SetCancel(cancel)
 
 	resolvedModel := h.resolver.Resolve(chatID)
@@ -337,6 +356,9 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 
 	if err := h.claude.SendMessage(ctx, sess, modelID, userText, memoryContext, cb); err != nil {
 		if ctx.Err() != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				streamer.Write("\n\n⏰ Task timed out (10 min limit).")
+			}
 			result.Status = execution.RunCanceled
 			streamer.Finalize()
 			return result, nil
@@ -423,25 +445,69 @@ func (h *Handler) handleCallback(cb *tgbotapi.CallbackQuery) {
 	_, _ = h.bot.Send(edit)
 }
 
-// toolLabel creates a short label like Bash(cd stock_d) or Read(main.go)
+// toolLabel creates a short label like Bash(cd stock_d) or Read(bot/handler.go)
 func toolLabel(name, inputJSON string) string {
 	var m map[string]any
 	if json.Unmarshal([]byte(inputJSON), &m) != nil {
 		return name
 	}
+
+	// Path keys get tail-truncated (show meaningful end); others get head-truncated.
+	pathKeys := map[string]bool{"path": true, "file_path": true}
+
 	for _, key := range []string{"command", "path", "file_path", "url", "query", "pattern", "script", "expression", "name", "ref", "text", "glob", "regex"} {
 		if v, ok := m[key]; ok {
 			s := fmt.Sprintf("%v", v)
-			if s != "" {
-				r := []rune(s)
-				if len(r) > 15 {
-					s = string(r[:15])
-				}
-				return name + "(" + s + ")"
+			if s == "" {
+				continue
 			}
+			if pathKeys[key] {
+				s = shortenPath(s, 25)
+			} else {
+				r := []rune(s)
+				if len(r) > 20 {
+					s = string(r[:20])
+				}
+			}
+			return name + "(" + s + ")"
 		}
 	}
 	return name
+}
+
+// shortenPath keeps the last path components that fit within maxRunes,
+// so "/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go"
+// becomes "../bot/handler.go" instead of the useless "/Users/ngocp/Do".
+func shortenPath(s string, maxRunes int) string {
+	if len([]rune(s)) <= maxRunes {
+		return s
+	}
+	parts := strings.Split(s, "/")
+	// Build from the tail, accumulating components.
+	var tail string
+	for i := len(parts) - 1; i >= 0; i-- {
+		candidate := parts[i]
+		if tail != "" {
+			candidate = parts[i] + "/" + tail
+		}
+		if len([]rune(candidate))+3 > maxRunes { // +3 for "../"
+			break
+		}
+		tail = candidate
+	}
+	if tail == "" {
+		// Filename alone exceeds budget — truncate the filename.
+		r := []rune(parts[len(parts)-1])
+		if len(r) > maxRunes-3 {
+			tail = string(r[:maxRunes-3])
+		} else {
+			tail = string(r)
+		}
+	}
+	if tail == s {
+		return s
+	}
+	return "../" + tail
 }
 
 // sendText converts markdown to Telegram HTML and sends the message.

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -331,7 +331,7 @@ func (s *Streamer) Finalize() {
 	}
 	finalText := strings.TrimSpace(s.buf.String())
 	reasonText := strings.TrimSpace(s.reasonBuf.String())
-	hasPendingTools := s.toolCount > 0 && finalText != ""
+	hadTools := s.toolCount > 0
 	s.mu.Unlock()
 
 	// Final flush of reasoning lane
@@ -339,9 +339,13 @@ func (s *Streamer) Finalize() {
 		s.flushReasonLane(reasonText)
 	}
 
-	// Re-render answer without tool status line for clean final message
-	if hasPendingTools || finalText != "" {
+	// Re-render answer without tool status line for clean final message.
+	// If Claude was interrupted mid-tool-calls with no assistant text,
+	// send a notice so the user isn't stuck on a stale tool progress line.
+	if finalText != "" {
 		s.sendFormatted(finalText, "")
+	} else if hadTools {
+		s.editCurrent("⚠️ <i>Task interrupted — no final response received.</i>")
 	}
 
 	close(s.done)

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -35,15 +35,23 @@ type StreamCallbacks struct {
 // Client wraps the claude CLI subprocess.
 type Client struct {
 	systemPrompt string
+	workspace    string // working directory for the CLI subprocess
 }
 
 // New creates a Claude client backed by the claude CLI subprocess.
 // The CLI manages its own auth and tools; we only need the system prompt.
+// workspace sets the CLI's working directory so created files land in the
+// right place instead of the bot's own source directory.
 func New(systemPrompt string, executor *tools.Executor) *Client {
 	log.Printf("claude: subprocess client initialized")
 	return &Client{
 		systemPrompt: systemPrompt,
 	}
+}
+
+// SetWorkspace sets the working directory for spawned CLI processes.
+func (c *Client) SetWorkspace(dir string) {
+	c.workspace = dir
 }
 
 // --- stream-json event types from claude CLI ---
@@ -97,6 +105,13 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	args := buildArgs(modelID, sessionID, isNewSession, systemPrompt)
 
 	cmd := exec.CommandContext(ctx, claudeBin, args...)
+
+	// Set working directory so Claude creates files in the workspace,
+	// not in the bot's own source directory.
+	if c.workspace != "" {
+		_ = os.MkdirAll(c.workspace, 0755)
+		cmd.Dir = c.workspace
+	}
 
 	// Pass user message via stdin (safe for arbitrary text).
 	cmd.Stdin = strings.NewReader(userText)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ngocp/goterm-control/internal/models"
 	"gopkg.in/yaml.v3"
@@ -24,6 +25,7 @@ type ClaudeConfig struct {
 	Model        string `yaml:"model"`         // default model ID
 	MaxTokens    int    `yaml:"max_tokens"`
 	SystemPrompt string `yaml:"system_prompt"`
+	Workspace    string `yaml:"workspace"`     // working directory for claude CLI subprocess
 }
 
 // ModelsConfig defines available models and custom providers.
@@ -89,6 +91,13 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Claude.MaxTokens == 0 {
 		cfg.Claude.MaxTokens = 8192
+	}
+	if cfg.Claude.Workspace == "" {
+		home, _ := os.UserHomeDir()
+		cfg.Claude.Workspace = home + "/goterm-workspace"
+	} else if strings.HasPrefix(cfg.Claude.Workspace, "~/") {
+		home, _ := os.UserHomeDir()
+		cfg.Claude.Workspace = home + cfg.Claude.Workspace[1:]
 	}
 	if cfg.Tools.ShellTimeout == 0 {
 		cfg.Tools.ShellTimeout = 60


### PR DESCRIPTION
## Summary
- **Finalize always notifies**: When Claude is interrupted mid-tool-calls with no assistant text, the streamer now sends "⚠️ Task interrupted" instead of leaving the user stuck on a stale tool progress line
- **"status"/"cancel" bypass queue**: Plain text `status` and `cancel` (without `/`) are now recognized and handled immediately, even when the agent is busy processing a long task
- **10-minute CLI timeout**: Prevents a stuck Claude CLI subprocess from blocking the queue lane forever; sends "⏰ Task timed out" notification on expiry
- **Smarter tool labels**: File paths show meaningful tail components (`Read(../bot/handler.go)`) instead of useless prefix truncation (`Read(/Users/ngocp/Do)`)

## Test plan
- [ ] Send a long-running task, then type `status` (no slash) — should get session info immediately
- [ ] Send a long-running task, then type `cancel` — should cancel and show notice
- [ ] Kill the Claude CLI process mid-task — user should see "Task interrupted" message
- [ ] Verify tool progress line shows readable paths during multi-file operations
- [ ] Verify `/status` command still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)