### PR TITLE
feat: bot name loading indicator via setMyName

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,11 @@
 telegram:
   token: ""        # set via TELEGRAM_TOKEN env var
   timeout: 60      # polling timeout in seconds
+  indicator:
+    enabled: false          # set to true to show loading emoji in bot name
+    bot_name: ""            # leave empty to auto-detect via getMyName API
+    frames: ["⏳", "⌛"]   # emoji frames for animation
+    interval: 3             # seconds between frame rotations
 
 claude:
   api_key: ""      # set via ANTHROPIC_API_KEY env var

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -21,12 +21,13 @@ import (
 
 // Bot is the top-level Telegram bot.
 type Bot struct {
-	api      *tgbotapi.BotAPI
-	handler  *Handler
-	cfg      *config.Config
-	sessions *session.Manager
-	engine   *execution.Engine
-	queue    *msgqueue.Queue
+	api       *tgbotapi.BotAPI
+	handler   *Handler
+	cfg       *config.Config
+	sessions  *session.Manager
+	engine    *execution.Engine
+	queue     *msgqueue.Queue
+	indicator *NameIndicator
 }
 
 // New creates and initialises the bot.
@@ -50,6 +51,9 @@ func New(cfg *config.Config) (*Bot, error) {
 	if _, err := api.Request(commands); err != nil {
 		log.Printf("bot: warning: failed to set commands menu: %v", err)
 	}
+
+	// Name indicator (loading animation via setMyName)
+	indicator := NewNameIndicator(api, cfg.Telegram.Indicator)
 
 	executor := tools.New(tools.ExecutorConfig{
 		ShellTimeout:   cfg.Tools.ShellTimeout,
@@ -104,6 +108,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		messages:         messageStore,
 		resolver:         resolver,
 		approvalRequests: make(map[string]chan bool),
+		indicator:        indicator,
 	}
 
 	// Message queue: debounce 800ms + collect while busy
@@ -111,12 +116,13 @@ func New(cfg *config.Config) (*Bot, error) {
 	handler.queue = queue
 
 	return &Bot{
-		api:      api,
-		handler:  handler,
-		cfg:      cfg,
-		sessions: sessions,
-		engine:   engine,
-		queue:    queue,
+		api:       api,
+		handler:   handler,
+		cfg:       cfg,
+		sessions:  sessions,
+		engine:    engine,
+		queue:     queue,
+		indicator: indicator,
 	}, nil
 }
 
@@ -136,6 +142,7 @@ func (b *Bot) Run() {
 
 // Shutdown performs graceful cleanup.
 func (b *Bot) Shutdown() {
+	b.indicator.Close()
 	b.queue.Close()
 	b.engine.Close()
 	b.sessions.SaveNow()

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -40,6 +40,7 @@ type Handler struct {
 	messages   MessageStore // optional SQLite message store
 	resolver   *models.Resolver
 	queue      *msgqueue.Queue // debounce + collect layer
+	indicator  *NameIndicator
 
 	// approvalRequests maps callbackData → channel to signal approval/cancel
 	approvalMu       sync.Mutex
@@ -252,6 +253,9 @@ func (h *Handler) handleMessage(msg *tgbotapi.Message) {
 // executeMessage is the Queue callback that runs the full Claude pipeline.
 // Called by the queue after debouncing and collection.
 func (h *Handler) executeMessage(chatID int64, text string) {
+	h.indicator.Start()
+	defer h.indicator.Done()
+
 	sess := h.sessions.Get(chatID)
 
 	// Cancel any in-flight request for this session

--- a/internal/bot/indicator.go
+++ b/internal/bot/indicator.go
@@ -1,0 +1,195 @@
+package bot
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/ngocp/goterm-control/internal/config"
+)
+
+// NameIndicator changes the bot's display name to show a loading animation
+// while processing requests. Tracks active request count so the original name
+// is only restored when all concurrent requests finish.
+type NameIndicator struct {
+	bot *tgbotapi.BotAPI
+	cfg config.IndicatorConfig
+
+	mu          sync.Mutex
+	baseName    string
+	activeCount int
+	frameIdx    int
+	ticker      *time.Ticker
+	stopCh      chan struct{}
+	lastSet     time.Time
+	minInterval time.Duration
+}
+
+// NewNameIndicator creates an indicator. Returns nil if disabled.
+func NewNameIndicator(bot *tgbotapi.BotAPI, cfg config.IndicatorConfig) *NameIndicator {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	n := &NameIndicator{
+		bot:         bot,
+		cfg:         cfg,
+		minInterval: 3 * time.Second,
+	}
+
+	// Resolve base name
+	if cfg.BotName != "" {
+		n.baseName = cfg.BotName
+	} else {
+		n.baseName = fetchBotName(bot)
+	}
+
+	// Strip stale emoji prefix (e.g. bot crashed while "thinking")
+	for _, frame := range cfg.Frames {
+		if strings.HasPrefix(n.baseName, frame+" ") {
+			n.baseName = strings.TrimPrefix(n.baseName, frame+" ")
+			break
+		}
+	}
+
+	if n.baseName == "" {
+		n.baseName = bot.Self.UserName
+	}
+
+	log.Printf("indicator: enabled, base name=%q, frames=%v, interval=%ds", n.baseName, cfg.Frames, cfg.Interval)
+	return n
+}
+
+// fetchBotName calls getMyName to get the current display name.
+func fetchBotName(bot *tgbotapi.BotAPI) string {
+	resp, err := bot.MakeRequest("getMyName", nil)
+	if err != nil {
+		log.Printf("indicator: getMyName error: %v", err)
+		return ""
+	}
+	var result struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		log.Printf("indicator: getMyName parse error: %v", err)
+		return ""
+	}
+	return result.Name
+}
+
+// Start signals that a request has begun processing.
+func (n *NameIndicator) Start() {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	n.activeCount++
+	shouldStart := n.activeCount == 1
+	n.mu.Unlock()
+
+	if shouldStart {
+		n.setThinkingName()
+		n.startAnimation()
+	}
+}
+
+// Done signals that a request has finished processing.
+func (n *NameIndicator) Done() {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	n.activeCount--
+	if n.activeCount < 0 {
+		n.activeCount = 0
+	}
+	shouldRestore := n.activeCount == 0
+	n.mu.Unlock()
+
+	if shouldRestore {
+		n.stopAnimation()
+		n.restoreName()
+	}
+}
+
+// Close stops the animation and restores the original name.
+func (n *NameIndicator) Close() {
+	if n == nil {
+		return
+	}
+	n.stopAnimation()
+	n.restoreName()
+}
+
+func (n *NameIndicator) startAnimation() {
+	if len(n.cfg.Frames) < 2 {
+		return // no animation needed with single frame
+	}
+
+	interval := time.Duration(n.cfg.Interval) * time.Second
+	n.mu.Lock()
+	n.frameIdx = 0
+	n.ticker = time.NewTicker(interval)
+	n.stopCh = make(chan struct{})
+	n.mu.Unlock()
+
+	go func() {
+		for {
+			select {
+			case <-n.ticker.C:
+				n.advanceFrame()
+			case <-n.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (n *NameIndicator) stopAnimation() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.ticker != nil {
+		n.ticker.Stop()
+		close(n.stopCh)
+		n.ticker = nil
+	}
+}
+
+func (n *NameIndicator) advanceFrame() {
+	n.mu.Lock()
+	n.frameIdx = (n.frameIdx + 1) % len(n.cfg.Frames)
+	n.mu.Unlock()
+	n.setThinkingName()
+}
+
+func (n *NameIndicator) setThinkingName() {
+	n.mu.Lock()
+	frame := n.cfg.Frames[n.frameIdx]
+	name := frame + " " + n.baseName
+	n.mu.Unlock()
+	n.setName(name)
+}
+
+func (n *NameIndicator) restoreName() {
+	n.setName(n.baseName)
+}
+
+func (n *NameIndicator) setName(name string) {
+	n.mu.Lock()
+	elapsed := time.Since(n.lastSet)
+	if elapsed < n.minInterval {
+		wait := n.minInterval - elapsed
+		n.mu.Unlock()
+		time.Sleep(wait)
+		n.mu.Lock()
+	}
+	n.lastSet = time.Now()
+	n.mu.Unlock()
+
+	if _, err := n.bot.MakeRequest("setMyName", tgbotapi.Params{"name": name}); err != nil {
+		log.Printf("indicator: setMyName(%q) error: %v", name, err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,16 @@ type ModelsConfig struct {
 }
 
 type TelegramConfig struct {
-	Token   string `yaml:"token"`
-	Timeout int    `yaml:"timeout"`
+	Token     string          `yaml:"token"`
+	Timeout   int             `yaml:"timeout"`
+	Indicator IndicatorConfig `yaml:"indicator"`
+}
+
+type IndicatorConfig struct {
+	Enabled  bool     `yaml:"enabled"`
+	BotName  string   `yaml:"bot_name"`
+	Frames   []string `yaml:"frames"`
+	Interval int      `yaml:"interval"`
 }
 
 type SecurityConfig struct {
@@ -114,6 +122,14 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Memory.MaxEntries == 0 {
 		cfg.Memory.MaxEntries = 5
+	}
+	if cfg.Telegram.Indicator.Enabled {
+		if len(cfg.Telegram.Indicator.Frames) == 0 {
+			cfg.Telegram.Indicator.Frames = []string{"⏳", "⌛"}
+		}
+		if cfg.Telegram.Indicator.Interval == 0 {
+			cfg.Telegram.Indicator.Interval = 3
+		}
 	}
 
 	// Resolve default model: models.default takes priority over claude.model


### PR DESCRIPTION
## Summary
- Add `NameIndicator` component that changes the bot's display name to show loading emoji (⏳/⌛) while processing requests
- Auto-detects bot name on startup via `getMyName` API, restores it when done
- Rate-limited (min 3s between API calls), concurrency-safe (tracks active request count), nil-safe (no-op when disabled)
- Configurable via `telegram.indicator` in config.yaml — disabled by default

## Test plan
- [ ] Enable `telegram.indicator.enabled: true` in config
- [ ] Send a message — verify bot name changes to "⏳ BotName" while processing
- [ ] Verify name restores to original after response completes
- [ ] Send two rapid messages — verify name only restores after both finish
- [ ] Verify `go build ./cmd/nanoclaw/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)