### PR TITLE
fix: update source file and package counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ that you talk to from anywhere.
 **Philosophy:**
 - Full computer control — shell, files, processes, clipboard, browser, screenshots
 - Cross-platform — runs wherever Go compiles (Linux, macOS, Windows/WSL)
-- Small enough to understand (~45 source files, 14 packages)
+- Small enough to understand (~65 source files, 18 packages)
 - Built for one user — bespoke, not a framework
 - Customization = code changes, not config sprawl
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ layout: default
   <div class="container">
     <div class="stats">
       <div class="stat">
-        <div class="stat-value">~45</div>
+        <div class="stat-value">~65</div>
         <div class="stat-label">Source Files</div>
       </div>
       <div class="stat">
@@ -54,7 +54,7 @@ layout: default
         <div class="stat-label">Built-in Tools</div>
       </div>
       <div class="stat">
-        <div class="stat-value">14</div>
+        <div class="stat-value">18</div>
         <div class="stat-label">Packages</div>
       </div>
       <div class="stat">


### PR DESCRIPTION
## Summary
- Update stats from ~45 source files / 14 packages → ~65 source files / 18 packages
- Updated in both README.md and docs/index.md (GitHub Pages hero stats)

Counted: `find internal/ cmd/ -name '*.go' -not -name '*_test.go'` excluding bds/bdscrawler side project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)