### PR TITLE
docs: remove API key setup step from getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,13 +34,6 @@ claude login
 
 This uses your Claude Pro/Max subscription via OAuth2 &mdash; no API key needed.
 
-Alternatively, for direct API access, set your key in `.env`:
-
-```bash
-cp .env.example .env
-# Edit .env and add: ANTHROPIC_API_KEY=sk-ant-api03-...
-```
-
 ### 3. Set up Telegram (optional)
 
 If you want Telegram access, add your bot token to `.env`:


### PR DESCRIPTION
## Summary
- Remove the "Alternatively, for direct API access..." block from the Getting Started page
- `claude login` (OAuth) is the only recommended path now
- Direct API key option is still documented in the Authentication Modes table lower on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)