### PR TITLE
feat: add Telegram typing indicator (sendChatAction keepalive)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,9 @@ telegram:
     bot_name: ""            # leave empty to auto-detect via getMyName API
     frames: ["⏳", "⌛"]   # emoji frames for animation
     interval: 3             # seconds between frame rotations
+    use_chat_action: true   # show "typing..." under bot name via sendChatAction
+    chat_action_interval: 4 # seconds between keepalive calls (Telegram expires after ~5s)
+    chat_action_ttl: 120    # max seconds before auto-stop (prevents infinite typing)
 
 claude:
   api_key: ""      # set via ANTHROPIC_API_KEY env var

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -28,6 +28,7 @@ type Bot struct {
 	engine    *execution.Engine
 	queue     *msgqueue.Queue
 	indicator *NameIndicator
+	typing    *TypingIndicator
 }
 
 // New creates and initialises the bot.
@@ -54,6 +55,9 @@ func New(cfg *config.Config) (*Bot, error) {
 
 	// Name indicator (loading animation via setMyName)
 	indicator := NewNameIndicator(api, cfg.Telegram.Indicator)
+
+	// Typing indicator (sendChatAction keepalive loop per chat)
+	typing := NewTypingIndicator(api, cfg.Telegram.Indicator)
 
 	executor := tools.New(tools.ExecutorConfig{
 		ShellTimeout:   cfg.Tools.ShellTimeout,
@@ -109,6 +113,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		resolver:         resolver,
 		approvalRequests: make(map[string]chan bool),
 		indicator:        indicator,
+		typing:           typing,
 	}
 
 	// Message queue: debounce 800ms + collect while busy
@@ -123,6 +128,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		engine:    engine,
 		queue:     queue,
 		indicator: indicator,
+		typing:    typing,
 	}, nil
 }
 
@@ -142,6 +148,7 @@ func (b *Bot) Run() {
 
 // Shutdown performs graceful cleanup.
 func (b *Bot) Shutdown() {
+	b.typing.Close()
 	b.indicator.Close()
 	b.queue.Close()
 	b.engine.Close()

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -41,6 +41,7 @@ type Handler struct {
 	resolver   *models.Resolver
 	queue      *msgqueue.Queue // debounce + collect layer
 	indicator  *NameIndicator
+	typing     *TypingIndicator
 
 	// approvalRequests maps callbackData → channel to signal approval/cancel
 	approvalMu       sync.Mutex
@@ -254,7 +255,9 @@ func (h *Handler) handleMessage(msg *tgbotapi.Message) {
 // Called by the queue after debouncing and collection.
 func (h *Handler) executeMessage(chatID int64, text string) {
 	h.indicator.Start()
+	h.typing.Start(chatID)
 	defer h.indicator.Done()
+	defer h.typing.Stop(chatID)
 
 	sess := h.sessions.Get(chatID)
 

--- a/internal/bot/typing.go
+++ b/internal/bot/typing.go
@@ -1,0 +1,138 @@
+package bot
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/ngocp/goterm-control/internal/config"
+)
+
+// TypingIndicator sends Telegram "typing..." chat actions on a per-chat
+// keepalive loop. Telegram's typing indicator expires after ~5 seconds,
+// so we re-send every interval (default 4s) to keep it visible.
+type TypingIndicator struct {
+	bot      *tgbotapi.BotAPI
+	interval time.Duration
+	ttl      time.Duration
+
+	mu     sync.Mutex
+	active map[int64]chan struct{} // chatID → stop channel
+}
+
+// NewTypingIndicator creates a typing indicator. Returns nil if disabled.
+func NewTypingIndicator(bot *tgbotapi.BotAPI, cfg config.IndicatorConfig) *TypingIndicator {
+	if !cfg.UseChatAction {
+		return nil
+	}
+	interval := time.Duration(cfg.ChatActionInterval) * time.Second
+	ttl := time.Duration(cfg.ChatActionTTL) * time.Second
+	log.Printf("typing: enabled, interval=%s, ttl=%s", interval, ttl)
+	return &TypingIndicator{
+		bot:      bot,
+		interval: interval,
+		ttl:      ttl,
+		active:   make(map[int64]chan struct{}),
+	}
+}
+
+// Start begins sending typing actions for the given chat.
+// If a loop is already active for this chat, the old one is stopped first.
+func (t *TypingIndicator) Start(chatID int64) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	// Stop existing loop for this chat (duplicate guard)
+	if stopCh, ok := t.active[chatID]; ok {
+		close(stopCh)
+		delete(t.active, chatID)
+	}
+	stopCh := make(chan struct{})
+	t.active[chatID] = stopCh
+	t.mu.Unlock()
+
+	go t.loop(chatID, stopCh)
+}
+
+// Stop cancels the typing loop for the given chat.
+func (t *TypingIndicator) Stop(chatID int64) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	if stopCh, ok := t.active[chatID]; ok {
+		close(stopCh)
+		delete(t.active, chatID)
+	}
+	t.mu.Unlock()
+}
+
+// Close stops all active typing loops (used during shutdown).
+func (t *TypingIndicator) Close() {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	for chatID, stopCh := range t.active {
+		close(stopCh)
+		delete(t.active, chatID)
+	}
+	t.mu.Unlock()
+}
+
+// loop runs the keepalive loop: sends typing action immediately, then every
+// interval until stopped or TTL expires.
+func (t *TypingIndicator) loop(chatID int64, stopCh chan struct{}) {
+	// Send immediately on start
+	t.sendTyping(chatID)
+
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	ttlTimer := time.NewTimer(t.ttl)
+	defer ttlTimer.Stop()
+
+	var consecutiveErrors int
+	const maxErrors = 3
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ttlTimer.C:
+			log.Printf("typing: TTL expired for chat %d", chatID)
+			t.mu.Lock()
+			delete(t.active, chatID)
+			t.mu.Unlock()
+			return
+		case <-ticker.C:
+			if err := t.sendTyping(chatID); err != nil {
+				consecutiveErrors++
+				if consecutiveErrors >= maxErrors {
+					log.Printf("typing: circuit breaker for chat %d after %d errors", chatID, consecutiveErrors)
+					t.mu.Lock()
+					delete(t.active, chatID)
+					t.mu.Unlock()
+					return
+				}
+			} else {
+				consecutiveErrors = 0
+			}
+		}
+	}
+}
+
+// sendTyping sends a single "typing" chat action to Telegram.
+func (t *TypingIndicator) sendTyping(chatID int64) error {
+	action := tgbotapi.NewChatAction(chatID, tgbotapi.ChatTyping)
+	_, err := t.bot.Request(action)
+	if err != nil {
+		log.Printf("typing: sendChatAction error for chat %d: %v", chatID, err)
+	}
+	return err
+}

--- a/internal/bot/typing.go
+++ b/internal/bot/typing.go
@@ -129,6 +129,9 @@ func (t *TypingIndicator) loop(chatID int64, stopCh chan struct{}) {
 
 // sendTyping sends a single "typing" chat action to Telegram.
 func (t *TypingIndicator) sendTyping(chatID int64) error {
+	if t.bot == nil {
+		return nil
+	}
 	action := tgbotapi.NewChatAction(chatID, tgbotapi.ChatTyping)
 	_, err := t.bot.Request(action)
 	if err != nil {

--- a/internal/bot/typing_test.go
+++ b/internal/bot/typing_test.go
@@ -1,0 +1,145 @@
+package bot
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/config"
+)
+
+func TestTypingIndicator_NilSafe(t *testing.T) {
+	// All methods should be safe to call on nil (disabled indicator).
+	var ti *TypingIndicator
+	ti.Start(123)
+	ti.Stop(123)
+	ti.Close()
+}
+
+func TestTypingIndicator_StartStop(t *testing.T) {
+	ti := &TypingIndicator{
+		// bot is nil — sendTyping will fail, but the loop logic still works
+		interval: 50 * time.Millisecond,
+		ttl:      2 * time.Second,
+		active:   make(map[int64]chan struct{}),
+	}
+
+	ti.Start(100)
+
+	ti.mu.Lock()
+	_, active := ti.active[100]
+	ti.mu.Unlock()
+	if !active {
+		t.Fatal("expected chat 100 to be active after Start")
+	}
+
+	ti.Stop(100)
+
+	ti.mu.Lock()
+	_, active = ti.active[100]
+	ti.mu.Unlock()
+	if active {
+		t.Fatal("expected chat 100 to be inactive after Stop")
+	}
+}
+
+func TestTypingIndicator_DuplicateStart(t *testing.T) {
+	ti := &TypingIndicator{
+		interval: 50 * time.Millisecond,
+		ttl:      2 * time.Second,
+		active:   make(map[int64]chan struct{}),
+	}
+
+	ti.Start(200)
+	ti.Start(200) // should stop old loop, start new one
+
+	ti.mu.Lock()
+	count := len(ti.active)
+	ti.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("expected 1 active entry, got %d", count)
+	}
+
+	ti.Close()
+}
+
+func TestTypingIndicator_MultipleChats(t *testing.T) {
+	ti := &TypingIndicator{
+		interval: 50 * time.Millisecond,
+		ttl:      2 * time.Second,
+		active:   make(map[int64]chan struct{}),
+	}
+
+	ti.Start(301)
+	ti.Start(302)
+	ti.Start(303)
+
+	ti.mu.Lock()
+	count := len(ti.active)
+	ti.mu.Unlock()
+	if count != 3 {
+		t.Fatalf("expected 3 active chats, got %d", count)
+	}
+
+	ti.Close()
+
+	ti.mu.Lock()
+	count = len(ti.active)
+	ti.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected 0 active chats after Close, got %d", count)
+	}
+}
+
+func TestTypingIndicator_TTLExpiry(t *testing.T) {
+	ti := &TypingIndicator{
+		interval: 10 * time.Millisecond,
+		ttl:      80 * time.Millisecond,
+		active:   make(map[int64]chan struct{}),
+	}
+
+	ti.Start(400)
+	time.Sleep(200 * time.Millisecond)
+
+	ti.mu.Lock()
+	_, active := ti.active[400]
+	ti.mu.Unlock()
+	if active {
+		t.Fatal("expected chat 400 to expire after TTL")
+	}
+}
+
+func TestTypingIndicator_ConcurrentStartStop(t *testing.T) {
+	ti := &TypingIndicator{
+		interval: 10 * time.Millisecond,
+		ttl:      2 * time.Second,
+		active:   make(map[int64]chan struct{}),
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(chatID int64) {
+			defer wg.Done()
+			ti.Start(chatID)
+			time.Sleep(20 * time.Millisecond)
+			ti.Stop(chatID)
+		}(int64(500 + i))
+	}
+	wg.Wait()
+
+	ti.mu.Lock()
+	count := len(ti.active)
+	ti.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected 0 active after concurrent ops, got %d", count)
+	}
+}
+
+func TestNewTypingIndicator_Disabled(t *testing.T) {
+	cfg := config.IndicatorConfig{UseChatAction: false}
+	ti := NewTypingIndicator(nil, cfg)
+	if ti != nil {
+		t.Fatal("expected nil when UseChatAction is false")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,10 +41,13 @@ type TelegramConfig struct {
 }
 
 type IndicatorConfig struct {
-	Enabled  bool     `yaml:"enabled"`
-	BotName  string   `yaml:"bot_name"`
-	Frames   []string `yaml:"frames"`
-	Interval int      `yaml:"interval"`
+	Enabled            bool     `yaml:"enabled"`
+	BotName            string   `yaml:"bot_name"`
+	Frames             []string `yaml:"frames"`
+	Interval           int      `yaml:"interval"`
+	UseChatAction      bool     `yaml:"use_chat_action"`
+	ChatActionInterval int      `yaml:"chat_action_interval"` // seconds between sendChatAction calls
+	ChatActionTTL      int      `yaml:"chat_action_ttl"`      // max seconds before auto-stop
 }
 
 type SecurityConfig struct {
@@ -129,6 +132,14 @@ func Load(path string) (*Config, error) {
 		}
 		if cfg.Telegram.Indicator.Interval == 0 {
 			cfg.Telegram.Indicator.Interval = 3
+		}
+	}
+	if cfg.Telegram.Indicator.UseChatAction {
+		if cfg.Telegram.Indicator.ChatActionInterval == 0 {
+			cfg.Telegram.Indicator.ChatActionInterval = 4
+		}
+		if cfg.Telegram.Indicator.ChatActionTTL == 0 {
+			cfg.Telegram.Indicator.ChatActionTTL = 120
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Thêm `TypingIndicator` — per-chat keepalive loop gọi `sendChatAction("typing")` mỗi 4s để Telegram hiện "typing..." dưới tên bot
- Hoạt động song song với `NameIndicator` hiện tại, config flag `use_chat_action` để enable/disable
- Safety guards: TTL 120s auto-stop, circuit breaker sau 3 lỗi liên tiếp, duplicate start guard

## Changes
| File | Change |
|------|--------|
| `internal/bot/typing.go` | Create — TypingIndicator struct + keepalive loop |
| `internal/bot/typing_test.go` | Create — 7 unit tests (lifecycle, TTL, concurrency) |
| `internal/config/config.go` | Modify — thêm UseChatAction, ChatActionInterval, ChatActionTTL fields |
| `internal/bot/handler.go` | Modify — integrate typing.Start/Stop vào executeMessage |
| `internal/bot/bot.go` | Modify — wire TypingIndicator init + Shutdown cleanup |
| `config.yaml` | Modify — thêm typing indicator config |

## Implementation Steps
- [x] Step 1: Thêm config fields cho typing indicator
- [x] Step 2: Tạo TypingIndicator struct với keepalive loop
- [x] Step 3: Integrate vào Handler.executeMessage()
- [x] Step 4: Wire up trong Bot init + Shutdown
- [x] Step 5: Update config.yaml
- [x] Step 6: Unit tests

## Verification
- [x] `go build ./cmd/bomclaw/` passes
- [x] `go vet ./internal/bot/... ./internal/config/...` passes
- [x] `go test ./internal/bot/...` passes (7 new tests + existing)
- [ ] Manual: gửi tin nhắn → verify "typing..." hiện dưới tên bot

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)