### PR TITLE
fix: show subpath in Bash tool labels instead of head-truncated path

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -470,6 +470,8 @@ func toolLabel(name, inputJSON string) string {
 			}
 			if pathKeys[key] {
 				s = shortenPath(s, 25)
+			} else if key == "command" {
+				s = shortenBashCommand(s, 25)
 			} else {
 				r := []rune(s)
 				if len(r) > 20 {
@@ -480,6 +482,69 @@ func toolLabel(name, inputJSON string) string {
 		}
 	}
 	return name
+}
+
+// shortenBashCommand extracts the first segment of a shell command (before
+// &&, ||, |, ;) and shortens any path-like argument while keeping the
+// command prefix (cd, ls, grep, etc.).
+//
+//	"cd /Users/ngocp/Documents/projects/meClaw/goterm-control" → "cd ../goterm-control"
+//	"ls -la /very/long/path/to/dir"                            → "ls ../dir"
+//	"echo hello world"                                         → "echo hello world"
+func shortenBashCommand(s string, maxRunes int) string {
+	if len([]rune(s)) <= maxRunes {
+		return s
+	}
+
+	// Take the first command segment (before &&, ||, |, ;).
+	seg := s
+	for _, sep := range []string{" && ", " || ", " | ", "; "} {
+		if idx := strings.Index(seg, sep); idx >= 0 {
+			seg = seg[:idx]
+		}
+	}
+
+	// Split into tokens; find the command prefix and the first path argument.
+	tokens := strings.Fields(seg)
+	if len(tokens) == 0 {
+		return headTruncate(s, maxRunes)
+	}
+
+	cmd := tokens[0] // e.g. "cd", "ls", "grep"
+	var pathIdx int   // index of the first path-like token
+	var foundPath bool
+	for i := 1; i < len(tokens); i++ {
+		t := tokens[i]
+		if strings.HasPrefix(t, "/") || strings.HasPrefix(t, "./") ||
+			strings.HasPrefix(t, "~/") || strings.HasPrefix(t, "../") {
+			pathIdx = i
+			foundPath = true
+			break
+		}
+	}
+
+	if !foundPath {
+		return headTruncate(s, maxRunes)
+	}
+
+	// Budget for the path: maxRunes minus "cmd " prefix.
+	prefix := cmd
+	pathBudget := maxRunes - len([]rune(prefix)) - 1 // -1 for space
+	if pathBudget < 6 {
+		return headTruncate(s, maxRunes)
+	}
+
+	shortened := shortenPath(tokens[pathIdx], pathBudget)
+	return prefix + " " + shortened
+}
+
+// headTruncate keeps the first maxRunes runes of s.
+func headTruncate(s string, maxRunes int) string {
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:maxRunes])
 }
 
 // shortenPath keeps the last path components that fit within maxRunes,

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -1,0 +1,203 @@
+package bot
+
+import (
+	"testing"
+)
+
+func TestShortenBashCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxRunes int
+		want     string
+	}{
+		{
+			name:     "cd with long path",
+			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control",
+			maxRunes: 25,
+			want:     "cd ../goterm-control",
+		},
+		{
+			name:     "ls with long path and subdir",
+			input:    "ls /Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot",
+			maxRunes: 25,
+			want:     "ls ../internal/bot",
+		},
+		{
+			name:     "cd short path unchanged",
+			input:    "cd /tmp",
+			maxRunes: 25,
+			want:     "cd /tmp",
+		},
+		{
+			name:     "ls with flags no path",
+			input:    "ls -la",
+			maxRunes: 25,
+			want:     "ls -la",
+		},
+		{
+			name:     "multi-command takes first segment",
+			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control && ls",
+			maxRunes: 25,
+			want:     "cd ../goterm-control",
+		},
+		{
+			name:     "no path fallback to head truncate",
+			input:    "echo hello world this is a very long command string",
+			maxRunes: 25,
+			want:     "echo hello world this is ",
+		},
+		{
+			name:     "flags before path",
+			input:    "ls -la /Users/ngocp/Documents/projects/meClaw/goterm-control/internal",
+			maxRunes: 25,
+			want:     "ls ../internal",
+		},
+		{
+			name:     "grep with path",
+			input:    "grep -r pattern /Users/ngocp/Documents/projects/meClaw/goterm-control",
+			maxRunes: 25,
+			want:     "grep ../goterm-control",
+		},
+		{
+			name:     "pipe separator",
+			input:    "cat /Users/ngocp/Documents/projects/long/path/file.go | head -20",
+			maxRunes: 25,
+			want:     "cat ../long/path/file.go",
+		},
+		{
+			name:     "relative path with ./",
+			input:    "cat ./very/long/nested/deep/directory/structure/file.txt",
+			maxRunes: 25,
+			want:     "cat ../structure/file.txt",
+		},
+		{
+			name:     "tilde path",
+			input:    "ls ~/Documents/projects/meClaw/goterm-control/internal/bot/handler.go",
+			maxRunes: 25,
+			want:     "ls ../bot/handler.go",
+		},
+		{
+			name:     "already short enough",
+			input:    "cd /tmp && ls -la",
+			maxRunes: 25,
+			want:     "cd /tmp && ls -la",
+		},
+		{
+			name:     "semicolon separator",
+			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control; ls",
+			maxRunes: 25,
+			want:     "cd ../goterm-control",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortenBashCommand(tt.input, tt.maxRunes)
+			if got != tt.want {
+				t.Errorf("shortenBashCommand(%q, %d)\n  got  %q\n  want %q",
+					tt.input, tt.maxRunes, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToolLabel_BashCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		inputJSON string
+		want      string
+	}{
+		{
+			name:      "bash cd long path",
+			toolName:  "Bash",
+			inputJSON: `{"command":"cd /Users/ngocp/Documents/projects/meClaw/goterm-control"}`,
+			want:      "Bash(cd ../goterm-control)",
+		},
+		{
+			name:      "bash ls short",
+			toolName:  "Bash",
+			inputJSON: `{"command":"ls -la"}`,
+			want:      "Bash(ls -la)",
+		},
+		{
+			name:      "read file_path shortened",
+			toolName:  "Read",
+			inputJSON: `{"file_path":"/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go"}`,
+			want:      "Read(../bot/handler.go)",
+		},
+		{
+			name:      "edit path key shortened",
+			toolName:  "Edit",
+			inputJSON: `{"path":"/Users/ngocp/Documents/projects/meClaw/goterm-control/config.yaml"}`,
+			want:      "Edit(../config.yaml)",
+		},
+		{
+			name:      "empty json returns name only",
+			toolName:  "Bash",
+			inputJSON: `{}`,
+			want:      "Bash",
+		},
+		{
+			name:      "invalid json returns name only",
+			toolName:  "Bash",
+			inputJSON: `not json`,
+			want:      "Bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toolLabel(tt.toolName, tt.inputJSON)
+			if got != tt.want {
+				t.Errorf("toolLabel(%q, %q)\n  got  %q\n  want %q",
+					tt.toolName, tt.inputJSON, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShortenPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxRunes int
+		want     string
+	}{
+		{
+			name:     "long absolute path",
+			input:    "/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go",
+			maxRunes: 25,
+			want:     "../bot/handler.go",
+		},
+		{
+			name:     "short path unchanged",
+			input:    "/tmp/file.txt",
+			maxRunes: 25,
+			want:     "/tmp/file.txt",
+		},
+		{
+			name:     "exact budget",
+			input:    "exactly-twenty-five-rune",
+			maxRunes: 25,
+			want:     "exactly-twenty-five-rune",
+		},
+		{
+			name:     "single deep file",
+			input:    "/a/b/c/d/e/f/g/handler.go",
+			maxRunes: 20,
+			want:     "../e/f/g/handler.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortenPath(tt.input, tt.maxRunes)
+			if got != tt.want {
+				t.Errorf("shortenPath(%q, %d)\n  got  %q\n  want %q",
+					tt.input, tt.maxRunes, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Thêm `shortenBashCommand()` — tách command prefix (cd, ls, grep) và `shortenPath()` chỉ phần path argument
- Fix Bash tool labels từ `Bash(cd /Users/ngocp/Doc)` → `Bash(cd ../goterm-control)` 
- Không ảnh hưởng Read/Edit labels (vẫn dùng `shortenPath()` trực tiếp cho path/file_path keys)

## Changes
| File | Change |
|------|--------|
| `internal/bot/handler.go` | Thêm `shortenBashCommand()`, `headTruncate()`, sửa `toolLabel()` dùng cho `"command"` key |
| `internal/bot/handler_test.go` | Tạo mới — 23 tests: 13 shortenBashCommand + 6 toolLabel + 4 shortenPath |

## Implementation Steps
- [x] Step 1: Thêm `shortenBashCommand()` — extract command prefix + shortenPath path argument
- [x] Step 2: Integrate vào `toolLabel()` — route `"command"` key qua `shortenBashCommand()`
- [x] Step 3: Unit tests — 23 test cases covering all scenarios
- [x] Step 4: Build + vet + full test suite passes

## Verification
- [x] `go build ./cmd/bomclaw/` passes
- [x] `go vet ./internal/bot/...` passes
- [x] `go test ./internal/bot/...` passes (23 new + 15 existing tests)
- [ ] Manual: deploy → gửi message cần `cd`/`ls` → verify label ngắn gọn

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)