### PR TITLE
fix: inject conversation history khi session idle-reset để giữ context

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -26,6 +26,7 @@ import (
 // MessageStore is an optional interface for persisting conversation messages to SQLite.
 type MessageStore interface {
 	Append(sessionID string, msg agent.Message) error
+	LoadHistory(sessionID string, limit int) ([]agent.Message, error)
 }
 
 // Handler processes Telegram updates.
@@ -285,6 +286,13 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	memoryContext := ""
 	if h.memory != nil {
 		memoryContext = memory.BuildMemoryContext(h.memory, text, h.cfg.Memory.MaxEntries)
+	}
+
+	// Inject recent conversation history when starting a fresh session
+	// (e.g. after idle timeout reset) so Claude has context for follow-ups
+	// like "Run lại thử" after a previous "push crypto-radar" message.
+	if sess.GetSessionID() == "" {
+		memoryContext += h.buildHistoryContext(sess.ID, 8)
 	}
 
 	_, err := h.engine.Enqueue(ctx, chatID, func(ctx context.Context) (*execution.RunResult, error) {
@@ -597,4 +605,37 @@ func (h *Handler) sendText(chatID int64, text string) int {
 		}
 	}
 	return sent.MessageID
+}
+
+// buildHistoryContext loads recent messages from the store and formats them
+// as a conversation summary for context injection into new sessions.
+// This ensures follow-up messages like "Run lại thử" retain context from
+// previous turns even after an idle-timeout session reset.
+func (h *Handler) buildHistoryContext(sessionID string, limit int) string {
+	if h.messages == nil {
+		return ""
+	}
+	msgs, err := h.messages.LoadHistory(sessionID, limit)
+	if err != nil || len(msgs) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n\n## Recent Conversation History\n")
+	sb.WriteString("(Context from previous messages in this chat — use to understand follow-up references)\n\n")
+
+	for _, m := range msgs {
+		role := "User"
+		if m.Role == "assistant" {
+			role = "Assistant"
+		}
+		content := m.Content
+		r := []rune(content)
+		if len(r) > 200 {
+			content = string(r[:200]) + "..."
+		}
+		sb.WriteString(fmt.Sprintf("**%s**: %s\n", role, content))
+	}
+
+	return sb.String()
 }

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -1,7 +1,10 @@
 package bot
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/ngocp/goterm-control/internal/agent"
 )
 
 func TestShortenBashCommand(t *testing.T) {
@@ -199,5 +202,86 @@ func TestShortenPath(t *testing.T) {
 					tt.input, tt.maxRunes, got, tt.want)
 			}
 		})
+	}
+}
+
+// mockMessageStore implements MessageStore for testing.
+type mockMessageStore struct {
+	messages []agent.Message
+}
+
+func (m *mockMessageStore) Append(_ string, msg agent.Message) error {
+	m.messages = append(m.messages, msg)
+	return nil
+}
+
+func (m *mockMessageStore) LoadHistory(_ string, limit int) ([]agent.Message, error) {
+	if limit > 0 && len(m.messages) > limit {
+		return m.messages[len(m.messages)-limit:], nil
+	}
+	return m.messages, nil
+}
+
+func TestBuildHistoryContext_WithMessages(t *testing.T) {
+	store := &mockMessageStore{
+		messages: []agent.Message{
+			{Role: "user", Content: "push repo crypto-radar lên github"},
+			{Role: "assistant", Content: "Đã push thành công repo crypto-radar lên GitHub."},
+		},
+	}
+	h := &Handler{messages: store}
+
+	ctx := h.buildHistoryContext("chat_123", 8)
+	if ctx == "" {
+		t.Fatal("expected non-empty history context")
+	}
+	if !strings.Contains(ctx, "crypto-radar") {
+		t.Errorf("expected history to contain 'crypto-radar', got:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "Recent Conversation History") {
+		t.Error("expected history header")
+	}
+	if !strings.Contains(ctx, "**User**:") {
+		t.Error("expected User role label")
+	}
+	if !strings.Contains(ctx, "**Assistant**:") {
+		t.Error("expected Assistant role label")
+	}
+}
+
+func TestBuildHistoryContext_Empty(t *testing.T) {
+	store := &mockMessageStore{}
+	h := &Handler{messages: store}
+
+	ctx := h.buildHistoryContext("chat_123", 8)
+	if ctx != "" {
+		t.Errorf("expected empty context for no messages, got:\n%s", ctx)
+	}
+}
+
+func TestBuildHistoryContext_NilStore(t *testing.T) {
+	h := &Handler{messages: nil}
+
+	ctx := h.buildHistoryContext("chat_123", 8)
+	if ctx != "" {
+		t.Errorf("expected empty context for nil store, got:\n%s", ctx)
+	}
+}
+
+func TestBuildHistoryContext_TruncatesLongMessages(t *testing.T) {
+	longContent := strings.Repeat("x", 300)
+	store := &mockMessageStore{
+		messages: []agent.Message{
+			{Role: "user", Content: longContent},
+		},
+	}
+	h := &Handler{messages: store}
+
+	ctx := h.buildHistoryContext("chat_123", 8)
+	if strings.Contains(ctx, longContent) {
+		t.Error("expected long message to be truncated")
+	}
+	if !strings.Contains(ctx, "...") {
+		t.Error("expected truncation indicator '...'")
 	}
 }


### PR DESCRIPTION
## Summary
- Khi session bị idle-reset (30 phút), load 8 messages gần nhất từ SQLite message store và inject vào system prompt
- Claude có đủ context để hiểu follow-up messages ("Run lại thử" → biết refer đến crypto-radar)
- Extend `MessageStore` interface thêm `LoadHistory()` (SQLiteMessageStore đã implement sẵn)

## Changes
| File | Change |
|------|--------|
| `internal/bot/handler.go` | Extend `MessageStore` interface, thêm `buildHistoryContext()`, inject vào `executeMessage()` khi `isNewSession` |
| `internal/bot/handler_test.go` | 4 tests: messages có context, empty store, nil store, truncate messages dài |

## Implementation Steps
- [x] Step 1: Extend MessageStore interface với `LoadHistory()`
- [x] Step 2: Thêm `buildHistoryContext()` — load + format recent messages
- [x] Step 3: Inject history vào `executeMessage()` khi `sess.GetSessionID() == ""`
- [x] Step 4: Unit tests + build verification

## Verification
- [x] `go build ./cmd/bomclaw/` passes
- [x] `go vet ./internal/bot/...` passes
- [x] `go test ./internal/bot/...` passes (4 new + existing tests)
- [ ] Manual: gửi tin nhắn → chờ idle reset hoặc `/reset` → gửi "Run lại thử" → verify bot hiểu context

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)