### PR TITLE
feat: rolling window tool progress + configurable 20min timeout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,7 @@ claude:
   model: "claude-sonnet-4-6"   # default model (can also use models.default)
   max_tokens: 8192
   workspace: "~/goterm-workspace"  # working directory for Claude CLI (default: ~/goterm-workspace)
+  execution_timeout: 20            # max minutes per request (default: 20)
   system_prompt: |
     You are an AI assistant with full control over a Mac M1 computer. You help the user accomplish any task by:
     - Running shell commands and scripts (bash, python, node, etc.)

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -265,9 +265,10 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	// Cancel any in-flight request for this session
 	sess.Cancel()
 
-	// 10-minute timeout prevents a stuck Claude CLI from blocking the queue
+	// Configurable timeout prevents a stuck Claude CLI from blocking the queue
 	// lane forever. The user can still /cancel manually for shorter waits.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	execTimeout := time.Duration(h.cfg.Claude.ExecutionTimeout) * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
 	sess.SetCancel(cancel)
 
 	resolvedModel := h.resolver.Resolve(chatID)

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -47,9 +47,12 @@ type Streamer struct {
 	inflight     bool
 	pendingFlush bool
 
-	// Tool progress tracking — shown as compact status, not full output
-	toolNames []string
-	toolCount int
+	// Tool progress tracking — rolling window display.
+	// toolHead: first 8 tools (always shown).
+	// toolCheckpoints: 2 representative tools sampled every 10 after the head.
+	toolHead        []string
+	toolCheckpoints []string
+	toolCount       int
 
 	ticker *time.Ticker
 	done   chan struct{}
@@ -118,15 +121,27 @@ func (s *Streamer) Write(chunk string) {
 	}
 }
 
-// NoteTool records a tool call as a compact progress indicator.
-// Instead of showing full tool input/output, we show: 🔧 Tool1 → Tool2 → ...
+// NoteTool records a tool call as a compact rolling-window progress indicator.
+// The first 8 tools are always shown (head). After that, every batch of 10
+// tools contributes 2 "checkpoint" tools so the user sees recent activity:
+//   🔧 T1 → … → T8 → (+10 more) → Ta → Tb → (+10 more) → Tc → Td → (+5 more)
 func (s *Streamer) NoteTool(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.toolCount++
-	// Keep unique names, max 8 shown
-	if len(s.toolNames) < 8 {
-		s.toolNames = append(s.toolNames, name)
+
+	const headSize = 8
+	const batchSize = 10
+
+	if s.toolCount <= headSize {
+		s.toolHead = append(s.toolHead, name)
+	} else {
+		// Position within the current batch of 10 (1-indexed)
+		posInBatch := (s.toolCount - headSize - 1) % batchSize
+		// Sample the 2nd-to-last and last tool of each batch (positions 8 and 9)
+		if posInBatch == batchSize-2 || posInBatch == batchSize-1 {
+			s.toolCheckpoints = append(s.toolCheckpoints, name)
+		}
 	}
 	s.dirty = true
 }
@@ -263,16 +278,64 @@ func (s *Streamer) sendFormatted(assistantText, toolLine string) {
 	s.mu.Unlock()
 }
 
-// toolStatusLine returns a compact tool progress indicator.
+// toolStatusLine returns a compact rolling-window tool progress indicator.
+// Format: Head(8) → (+10 more) → Checkpoint1 → Checkpoint2 → (+10 more) → ...
 func (s *Streamer) toolStatusLine() string {
 	if s.toolCount == 0 {
 		return ""
 	}
-	names := strings.Join(s.toolNames, " → ")
-	if s.toolCount > len(s.toolNames) {
-		names += fmt.Sprintf(" (+%d more)", s.toolCount-len(s.toolNames))
+	return fmt.Sprintf("🔧 <i>%s</i>", buildToolStatusLine(s.toolHead, s.toolCheckpoints, s.toolCount))
+}
+
+// buildToolStatusLine is the pure logic for tool status formatting, separated
+// for testability. head has up to 8 items; checkpoints has 2 items per
+// completed batch of 10 tools after the head.
+func buildToolStatusLine(head, checkpoints []string, total int) string {
+	const headSize = 8
+	const batchSize = 10
+
+	var b strings.Builder
+	b.WriteString(strings.Join(head, " → "))
+
+	if total <= headSize {
+		return b.String()
 	}
-	return fmt.Sprintf("🔧 <i>%s</i>", names)
+
+	tail := total - headSize // tools after the head
+	cpIdx := 0              // index into checkpoints
+
+	for batch := 0; ; batch++ {
+		batchStart := batch * batchSize
+		if batchStart >= tail {
+			break
+		}
+		batchEnd := batchStart + batchSize
+		if batchEnd > tail {
+			batchEnd = tail
+		}
+		batchLen := batchEnd - batchStart
+
+		// How many non-checkpoint tools to skip in this batch?
+		cpInBatch := 0
+		if batchLen >= batchSize-1 {
+			cpInBatch = 1
+		}
+		if batchLen >= batchSize {
+			cpInBatch = 2
+		}
+		skipped := batchLen - cpInBatch
+
+		if skipped > 0 {
+			b.WriteString(fmt.Sprintf(" → (+%d more)", skipped))
+		}
+		for i := 0; i < cpInBatch && cpIdx < len(checkpoints); i++ {
+			b.WriteString(" → ")
+			b.WriteString(checkpoints[cpIdx])
+			cpIdx++
+		}
+	}
+
+	return b.String()
 }
 
 func (s *Streamer) editCurrent(text string) {

--- a/internal/bot/streamer_test.go
+++ b/internal/bot/streamer_test.go
@@ -1,0 +1,121 @@
+package bot
+
+import "testing"
+
+func TestBuildToolStatusLine_HeadOnly(t *testing.T) {
+	// 5 tools — all in head, no checkpoints
+	head := []string{"Bash(find)", "Read(main.go)", "Grep(foo)", "Edit(bar.go)", "Read(config)"}
+	got := buildToolStatusLine(head, nil, 5)
+	want := "Bash(find) → Read(main.go) → Grep(foo) → Edit(bar.go) → Read(config)"
+	if got != want {
+		t.Errorf("head-only:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildToolStatusLine_ExactHead(t *testing.T) {
+	// Exactly 8 tools — full head, no overflow
+	head := make([]string, 8)
+	for i := range head {
+		head[i] = "T" + string(rune('1'+i))
+	}
+	got := buildToolStatusLine(head, nil, 8)
+	want := "T1 → T2 → T3 → T4 → T5 → T6 → T7 → T8"
+	if got != want {
+		t.Errorf("exact-head:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildToolStatusLine_FirstBatchIncomplete(t *testing.T) {
+	// 15 tools: 8 head + 7 tail (no checkpoints yet — batch not at position 9/10)
+	head := []string{"T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"}
+	got := buildToolStatusLine(head, nil, 15)
+	want := "T1 → T2 → T3 → T4 → T5 → T6 → T7 → T8 → (+7 more)"
+	if got != want {
+		t.Errorf("first-batch-incomplete:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildToolStatusLine_OneBatchComplete(t *testing.T) {
+	// 18 tools: 8 head + 10 tail (1 complete batch, 2 checkpoints)
+	head := []string{"T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"}
+	checkpoints := []string{"Read(crypto)", "Cd(..)"}
+	got := buildToolStatusLine(head, checkpoints, 18)
+	want := "T1 → T2 → T3 → T4 → T5 → T6 → T7 → T8 → (+8 more) → Read(crypto) → Cd(..)"
+	if got != want {
+		t.Errorf("one-batch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildToolStatusLine_TwoBatchesComplete(t *testing.T) {
+	// 28 tools: 8 head + 20 tail (2 complete batches, 4 checkpoints)
+	head := []string{"T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"}
+	checkpoints := []string{"A9", "A10", "B9", "B10"}
+	got := buildToolStatusLine(head, checkpoints, 28)
+	want := "T1 → T2 → T3 → T4 → T5 → T6 → T7 → T8 → (+8 more) → A9 → A10 → (+8 more) → B9 → B10"
+	if got != want {
+		t.Errorf("two-batches:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildToolStatusLine_PartialLastBatch(t *testing.T) {
+	// 35 tools: 8 head + 27 tail (2 complete batches + 7 partial)
+	head := []string{"T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"}
+	checkpoints := []string{"A9", "A10", "B9", "B10"}
+	got := buildToolStatusLine(head, checkpoints, 35)
+	want := "T1 → T2 → T3 → T4 → T5 → T6 → T7 → T8 → (+8 more) → A9 → A10 → (+8 more) → B9 → B10 → (+7 more)"
+	if got != want {
+		t.Errorf("partial-last:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestNoteTool_RollingWindow(t *testing.T) {
+	// Simulate 25 tool calls through NoteTool and verify resulting fields
+	s := &Streamer{}
+	tools := make([]string, 25)
+	for i := range tools {
+		tools[i] = "T" + string(rune('A'+i%26))
+		s.NoteTool(tools[i])
+	}
+
+	if len(s.toolHead) != 8 {
+		t.Errorf("head size: got %d, want 8", len(s.toolHead))
+	}
+	if s.toolCount != 25 {
+		t.Errorf("toolCount: got %d, want 25", s.toolCount)
+	}
+
+	// After head (8), remaining 17 tools: batch of 10 produces checkpoints
+	// at positions 9 and 10 of the batch (tool #17 and #18 overall).
+	// Then partial batch of 7 — no checkpoints (positions 0-6, need 8 or 9).
+	if len(s.toolCheckpoints) != 2 {
+		t.Errorf("checkpoints: got %d, want 2 (tools at positions 17,18)", len(s.toolCheckpoints))
+	}
+}
+
+func TestNoteTool_ExactBoundary18(t *testing.T) {
+	s := &Streamer{}
+	for i := 1; i <= 18; i++ {
+		s.NoteTool("T" + string(rune('A'+i%26)))
+	}
+	if len(s.toolHead) != 8 {
+		t.Errorf("head: got %d, want 8", len(s.toolHead))
+	}
+	// 10 tools after head, positions 8 and 9 produce checkpoints
+	if len(s.toolCheckpoints) != 2 {
+		t.Errorf("checkpoints at 18: got %d, want 2", len(s.toolCheckpoints))
+	}
+}
+
+func TestNoteTool_ExactBoundary28(t *testing.T) {
+	s := &Streamer{}
+	for i := 1; i <= 28; i++ {
+		s.NoteTool("T" + string(rune('A'+i%26)))
+	}
+	if len(s.toolHead) != 8 {
+		t.Errorf("head: got %d, want 8", len(s.toolHead))
+	}
+	// 20 tools after head = 2 complete batches = 4 checkpoints
+	if len(s.toolCheckpoints) != 4 {
+		t.Errorf("checkpoints at 28: got %d, want 4", len(s.toolCheckpoints))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,11 +21,12 @@ type Config struct {
 
 // ClaudeConfig is kept for backward compatibility — the claude CLI subprocess config.
 type ClaudeConfig struct {
-	APIKey       string `yaml:"api_key"`
-	Model        string `yaml:"model"`         // default model ID
-	MaxTokens    int    `yaml:"max_tokens"`
-	SystemPrompt string `yaml:"system_prompt"`
-	Workspace    string `yaml:"workspace"`     // working directory for claude CLI subprocess
+	APIKey           string `yaml:"api_key"`
+	Model            string `yaml:"model"`             // default model ID
+	MaxTokens        int    `yaml:"max_tokens"`
+	SystemPrompt     string `yaml:"system_prompt"`
+	Workspace        string `yaml:"workspace"`         // working directory for claude CLI subprocess
+	ExecutionTimeout int    `yaml:"execution_timeout"` // minutes; max time for a single request (default: 20)
 }
 
 // ModelsConfig defines available models and custom providers.
@@ -109,6 +110,9 @@ func Load(path string) (*Config, error) {
 	} else if strings.HasPrefix(cfg.Claude.Workspace, "~/") {
 		home, _ := os.UserHomeDir()
 		cfg.Claude.Workspace = home + cfg.Claude.Workspace[1:]
+	}
+	if cfg.Claude.ExecutionTimeout == 0 {
+		cfg.Claude.ExecutionTimeout = 20
 	}
 	if cfg.Tools.ShellTimeout == 0 {
 		cfg.Tools.ShellTimeout = 60


### PR DESCRIPTION
## Summary
- Tool progress hiển thị rolling window thay vì chỉ 8 tool đầu rồi `(+N more)` tĩnh — user thấy bot đang call tool gì trong quá trình research dài
- Execution timeout configurable qua `config.yaml`, nâng default từ 10 lên 20 phút cho research task phức tạp

## Changes
| File | Change |
|------|--------|
| `internal/bot/streamer.go` | Rolling window: `toolHead` (8 đầu) + `toolCheckpoints` (2 tool/batch 10), refactor `NoteTool()` và `toolStatusLine()` |
| `internal/config/config.go` | Thêm `ExecutionTimeout` field vào `ClaudeConfig`, default 20 phút |
| `internal/bot/handler.go` | Dùng `cfg.Claude.ExecutionTimeout` thay hardcode `10*time.Minute` |
| `config.yaml` | Thêm `execution_timeout: 20` |
| `internal/bot/streamer_test.go` | 9 tests: head-only, exact boundary (8/18/28), partial batch, multi-batch |

## Implementation Steps
- [x] Step 1: Rolling window tool tracking trong `NoteTool()` + `toolStatusLine()`
- [x] Step 2: Thêm `ExecutionTimeout` vào config struct + default
- [x] Step 3: Handler dùng configurable timeout
- [x] Step 4: Update config.yaml
- [x] Step 5: Unit tests cho rolling window logic
- [x] Step 6: Build + vet + test verification

## Verification
- [x] `go build ./cmd/bomclaw/` passes
- [x] `go vet ./internal/bot/... ./internal/config/...` passes
- [x] `go test ./internal/...` passes (9/9 new tests pass)
- [ ] Manual test: gửi research message dài, verify tool status cập nhật rolling window

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)