### PR TITLE
fix: typing indicator TTL + placeholder heartbeat

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ telegram:
     interval: 3             # seconds between frame rotations
     use_chat_action: true   # show "typing..." under bot name via sendChatAction
     chat_action_interval: 4 # seconds between keepalive calls (Telegram expires after ~5s)
-    chat_action_ttl: 120    # max seconds before auto-stop (prevents infinite typing)
+    # chat_action_ttl: 0    # max seconds; 0 = auto-match execution_timeout (recommended)
 
 claude:
   api_key: ""      # set via ANTHROPIC_API_KEY env var

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -57,7 +57,8 @@ func New(cfg *config.Config) (*Bot, error) {
 	indicator := NewNameIndicator(api, cfg.Telegram.Indicator)
 
 	// Typing indicator (sendChatAction keepalive loop per chat)
-	typing := NewTypingIndicator(api, cfg.Telegram.Indicator)
+	execTTL := time.Duration(cfg.Claude.ExecutionTimeout) * time.Minute
+	typing := NewTypingIndicator(api, cfg.Telegram.Indicator, execTTL)
 
 	executor := tools.New(tools.ExecutorConfig{
 		ShellTimeout:   cfg.Tools.ShellTimeout,

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -181,9 +181,15 @@ func (s *Streamer) flush() {
 	if !s.initialSent && totalChars < minInitialChars && toolLine == "" {
 		elapsed := time.Since(s.startTime).Truncate(time.Second)
 		if elapsed >= 2*time.Second {
+			heartbeatHTML := fmt.Sprintf("⏳ <i>Thinking... (%s)</i>", elapsed)
+			if heartbeatHTML == s.lastSentHTML {
+				s.mu.Unlock()
+				return
+			}
+			s.lastSentHTML = heartbeatHTML
 			s.inflight = true
 			s.mu.Unlock()
-			s.editCurrent(fmt.Sprintf("⏳ <i>Thinking... (%s)</i>", elapsed))
+			s.editCurrent(heartbeatHTML)
 			s.mu.Lock()
 			s.inflight = false
 			needsFlush := s.pendingFlush

--- a/internal/bot/streamer.go
+++ b/internal/bot/streamer.go
@@ -54,6 +54,8 @@ type Streamer struct {
 	toolCheckpoints []string
 	toolCount       int
 
+	startTime time.Time // for heartbeat elapsed display
+
 	ticker *time.Ticker
 	done   chan struct{}
 	wg     sync.WaitGroup
@@ -66,6 +68,7 @@ func NewStreamer(bot *tgbotapi.BotAPI, chatID int64, messageID int) *Streamer {
 		bot:       bot,
 		chatID:    chatID,
 		messageID: messageID,
+		startTime: time.Now(),
 		ticker:    time.NewTicker(streamInterval),
 		done:      make(chan struct{}),
 	}
@@ -153,7 +156,10 @@ func (s *Streamer) Flush() {
 
 func (s *Streamer) flush() {
 	s.mu.Lock()
-	if !s.dirty && !s.reasonDirty {
+	// Allow heartbeat ticks even when no new content has arrived,
+	// so the user sees "Thinking... (Xs)" updating during Claude's thinking phase.
+	needsHeartbeat := !s.initialSent && time.Since(s.startTime) >= 2*time.Second
+	if !s.dirty && !s.reasonDirty && !needsHeartbeat {
 		s.mu.Unlock()
 		return
 	}
@@ -168,9 +174,26 @@ func (s *Streamer) flush() {
 	reasonText := strings.TrimSpace(s.reasonBuf.String())
 	toolLine := s.toolStatusLine()
 
-	// Hold first send until minInitialChars for meaningful push notification
+	// Hold first send until minInitialChars for meaningful push notification.
+	// While waiting, send a heartbeat with elapsed time so the user sees
+	// the bot is alive (instead of a frozen "⏳ Thinking..." placeholder).
 	totalChars := len([]rune(assistantText)) + len([]rune(reasonText))
 	if !s.initialSent && totalChars < minInitialChars && toolLine == "" {
+		elapsed := time.Since(s.startTime).Truncate(time.Second)
+		if elapsed >= 2*time.Second {
+			s.inflight = true
+			s.mu.Unlock()
+			s.editCurrent(fmt.Sprintf("⏳ <i>Thinking... (%s)</i>", elapsed))
+			s.mu.Lock()
+			s.inflight = false
+			needsFlush := s.pendingFlush
+			s.pendingFlush = false
+			s.mu.Unlock()
+			if needsFlush {
+				s.flush()
+			}
+			return
+		}
 		s.mu.Unlock()
 		return
 	}

--- a/internal/bot/streamer_test.go
+++ b/internal/bot/streamer_test.go
@@ -1,6 +1,9 @@
 package bot
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestBuildToolStatusLine_HeadOnly(t *testing.T) {
 	// 5 tools — all in head, no checkpoints
@@ -117,5 +120,42 @@ func TestNoteTool_ExactBoundary28(t *testing.T) {
 	// 20 tools after head = 2 complete batches = 4 checkpoints
 	if len(s.toolCheckpoints) != 4 {
 		t.Errorf("checkpoints at 28: got %d, want 4", len(s.toolCheckpoints))
+	}
+}
+
+func TestFlush_HeartbeatAllowed(t *testing.T) {
+	// Verify the heartbeat logic: when startTime is old enough and no content,
+	// flush should NOT return early at the dirty guard.
+	s := &Streamer{
+		startTime: time.Now().Add(-5 * time.Second), // started 5s ago
+	}
+	// No dirty, no reasonDirty — normally flush would return immediately.
+	// With heartbeat, it should pass the guard because initialSent=false and elapsed >= 2s.
+	needsHeartbeat := !s.initialSent && time.Since(s.startTime) >= 2*time.Second
+	if !needsHeartbeat {
+		t.Fatal("expected needsHeartbeat=true when startTime is 5s ago and initialSent=false")
+	}
+}
+
+func TestFlush_NoHeartbeatAfterInitialSent(t *testing.T) {
+	// After initialSent=true, heartbeat should stop (real content takes over).
+	s := &Streamer{
+		startTime:   time.Now().Add(-5 * time.Second),
+		initialSent: true,
+	}
+	needsHeartbeat := !s.initialSent && time.Since(s.startTime) >= 2*time.Second
+	if needsHeartbeat {
+		t.Fatal("expected needsHeartbeat=false when initialSent=true")
+	}
+}
+
+func TestFlush_NoHeartbeatBeforeTwoSeconds(t *testing.T) {
+	// Before 2 seconds, no heartbeat even if no content.
+	s := &Streamer{
+		startTime: time.Now(), // just started
+	}
+	needsHeartbeat := !s.initialSent && time.Since(s.startTime) >= 2*time.Second
+	if needsHeartbeat {
+		t.Fatal("expected needsHeartbeat=false when just started")
 	}
 }

--- a/internal/bot/typing.go
+++ b/internal/bot/typing.go
@@ -22,12 +22,20 @@ type TypingIndicator struct {
 }
 
 // NewTypingIndicator creates a typing indicator. Returns nil if disabled.
-func NewTypingIndicator(bot *tgbotapi.BotAPI, cfg config.IndicatorConfig) *TypingIndicator {
+// execTTL is the execution timeout — typing TTL will be at least this long
+// so the indicator stays visible for the full duration of a request.
+func NewTypingIndicator(bot *tgbotapi.BotAPI, cfg config.IndicatorConfig, execTTL time.Duration) *TypingIndicator {
 	if !cfg.UseChatAction {
 		return nil
 	}
 	interval := time.Duration(cfg.ChatActionInterval) * time.Second
-	ttl := time.Duration(cfg.ChatActionTTL) * time.Second
+	ttl := execTTL
+	if cfg.ChatActionTTL > 0 {
+		cfgTTL := time.Duration(cfg.ChatActionTTL) * time.Second
+		if cfgTTL > ttl {
+			ttl = cfgTTL
+		}
+	}
 	log.Printf("typing: enabled, interval=%s, ttl=%s", interval, ttl)
 	return &TypingIndicator{
 		bot:      bot,

--- a/internal/bot/typing_test.go
+++ b/internal/bot/typing_test.go
@@ -138,8 +138,58 @@ func TestTypingIndicator_ConcurrentStartStop(t *testing.T) {
 
 func TestNewTypingIndicator_Disabled(t *testing.T) {
 	cfg := config.IndicatorConfig{UseChatAction: false}
-	ti := NewTypingIndicator(nil, cfg)
+	ti := NewTypingIndicator(nil, cfg, 20*time.Minute)
 	if ti != nil {
 		t.Fatal("expected nil when UseChatAction is false")
+	}
+}
+
+func TestNewTypingIndicator_TTLMatchesExecTimeout(t *testing.T) {
+	cfg := config.IndicatorConfig{
+		UseChatAction:      true,
+		ChatActionInterval: 4,
+		ChatActionTTL:      120, // 2 minutes — shorter than exec timeout
+	}
+	execTTL := 20 * time.Minute
+	ti := NewTypingIndicator(nil, cfg, execTTL)
+	if ti == nil {
+		t.Fatal("expected non-nil")
+	}
+	// TTL should be at least execution timeout, not the shorter config value
+	if ti.ttl < execTTL {
+		t.Errorf("ttl=%s, want >= %s", ti.ttl, execTTL)
+	}
+}
+
+func TestNewTypingIndicator_ConfigTTLOverridesWhenLarger(t *testing.T) {
+	cfg := config.IndicatorConfig{
+		UseChatAction:      true,
+		ChatActionInterval: 4,
+		ChatActionTTL:      3600, // 1 hour — longer than exec timeout
+	}
+	execTTL := 20 * time.Minute
+	ti := NewTypingIndicator(nil, cfg, execTTL)
+	if ti == nil {
+		t.Fatal("expected non-nil")
+	}
+	// Config TTL (1h) is larger than exec timeout (20m), so it wins
+	if ti.ttl != time.Hour {
+		t.Errorf("ttl=%s, want %s", ti.ttl, time.Hour)
+	}
+}
+
+func TestNewTypingIndicator_ZeroConfigTTL(t *testing.T) {
+	cfg := config.IndicatorConfig{
+		UseChatAction:      true,
+		ChatActionInterval: 4,
+		ChatActionTTL:      0, // not set — should use exec timeout
+	}
+	execTTL := 20 * time.Minute
+	ti := NewTypingIndicator(nil, cfg, execTTL)
+	if ti == nil {
+		t.Fatal("expected non-nil")
+	}
+	if ti.ttl != execTTL {
+		t.Errorf("ttl=%s, want %s", ti.ttl, execTTL)
 	}
 }


### PR DESCRIPTION
## Summary
- Typing indicator TTL tự động khớp execution timeout (20 phút) thay vì hardcode 120s — không còn tắt sớm
- Streamer gửi heartbeat `⏳ Thinking... (5s)` update mỗi 800ms khi Claude đang thinking — user luôn thấy bot đang hoạt động
- Config `chat_action_ttl` commented out, TTL auto-match `execution_timeout`

## Changes
| File | Change |
|------|--------|
| `internal/bot/typing.go` | `NewTypingIndicator()` nhận `execTTL`, TTL = max(config, execTTL) |
| `internal/bot/bot.go` | Truyền `execTTL` khi tạo TypingIndicator |
| `internal/bot/streamer.go` | Thêm `startTime`, heartbeat trong `flush()` khi chưa có content |
| `config.yaml` | Comment out `chat_action_ttl`, auto-match execution_timeout |
| `internal/bot/typing_test.go` | 3 tests: TTL matching, config override, zero config |
| `internal/bot/streamer_test.go` | 3 tests: heartbeat allowed, disabled after content, disabled before 2s |

## Implementation Steps
- [x] Step 1: Typing TTL auto-match execution timeout
- [x] Step 2: Update config.yaml
- [x] Steps 3-4: Streamer heartbeat với elapsed time
- [x] Step 5: Tests (6 new tests, 22 total pass)
- [x] Step 6: Full build + vet + test verification

## Verification
- [x] `go build ./cmd/bomclaw/` passes
- [x] `go vet ./internal/bot/... ./internal/config/...` passes
- [x] `go test ./internal/...` passes (22 tests in bot package)
- [ ] Manual test: gửi message, thấy "Thinking... (5s)" update liên tục
- [ ] Manual test: typing indicator không tắt sau 2 phút

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)