### PR TITLE
chore: add Claude Code project config and commands

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,154 @@
+---
+allowed-tools: Bash(gh issue create*), Bash(gh issue list*), Bash(gh issue view*), Bash(gh label*), Bash(gh project*), Bash(gh api*), Bash(gh repo view*), Bash(cd *), Bash(git *), Agent, Read, Glob, Grep
+description: "Analyze codebase, create implementation plan, create issue, move to In Progress"
+---
+
+# /create-issue — Analyze → Plan → Create Issue → In Progress
+
+You receive a short feature/task description. You analyze the codebase to understand how it should be implemented, write a detailed implementation plan, create a GitHub issue with that plan, and move it to "In Progress" on the project board.
+
+## Usage
+
+```
+/create-issue <description>
+```
+
+**Examples**:
+- `/create-issue "implement memory sqlite"`
+- `/create-issue "add rate limiting to gateway"`
+- `/create-issue "refactor streamer to support multiple output formats"`
+
+## Arguments: $ARGUMENTS
+
+## Phase 1: Detect Repo
+
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+Store as `TARGET_REPO`. Default project board: `https://github.com/users/phanngoc/projects/2` (project number `2`).
+
+## Phase 2: Analyze Codebase
+
+Based on `$ARGUMENTS`, explore the codebase to understand:
+
+1. **What exists** — find related files, functions, patterns using Glob/Grep/Read
+2. **What's missing** — identify gaps the feature would fill
+3. **How it fits** — understand the architecture and where changes belong
+4. **Dependencies** — what packages/modules are affected
+5. **Risks** — what could break, edge cases
+
+Use Agent(subagent_type="Explore") for broad exploration. Use Grep/Glob for targeted searches.
+
+Gather enough context to write a concrete, file-level implementation plan — not vague recommendations.
+
+## Phase 3: Write Implementation Plan
+
+From the analysis, create a step-by-step plan with:
+
+- **Specific files** to create or modify (with paths)
+- **Specific functions/structs** to add or change
+- **Code patterns** to follow (reference existing code)
+- **Migration/data** changes if applicable
+- **Test strategy**
+
+The plan should be detailed enough that a developer (or `/implement-issue`) can execute it without further research.
+
+## Phase 4: Create Issue
+
+Create the issue directly (no duplicate check needed — the user knows what they want):
+```bash
+gh issue create -R TARGET_REPO \
+  --title "<imperative title>" \
+  --body "$(cat <<'ISSUE_EOF'
+## Goal
+<1-2 sentences: what this achieves>
+
+## Analysis
+
+### Current State
+<what exists in the codebase relevant to this feature>
+
+### Architecture Fit
+<where this belongs in the codebase, which packages are affected>
+
+## Implementation Plan
+
+### Step 1: <title>
+**Files**: `path/to/file.go`
+**Changes**: <what to add/modify>
+<code snippets if helpful>
+
+### Step 2: <title>
+**Files**: `path/to/file.go`
+**Changes**: <what to add/modify>
+
+...
+
+### Step N: Verification
+**Tests**: <what to test>
+**Build**: `go build ./cmd/bomclaw/`
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] `go build` passes
+- [ ] Manual verification: <how to test>
+
+## Files Affected
+| File | Change |
+|------|--------|
+| `path/to/file.go` | Add/Modify/Create |
+
+## References
+- Related code: `path/to/relevant.go`
+ISSUE_EOF
+)" \
+  --label "<labels>"
+```
+
+Labels: pick from `enhancement`, `bug`, `refactor`, `architecture`, `performance`, `documentation`.
+Create missing labels with `gh label create -R TARGET_REPO` if needed.
+
+Store the created issue number as `ISSUE_NUMBER`.
+
+## Phase 5: Move to In Progress on Project Board
+
+Move the issue to "In Progress" on project board #2:
+
+```bash
+# 1. Get project ID
+PROJECT_ID=$(gh project list --owner phanngoc --format json | jq -r '.projects[] | select(.number == 2) | .id')
+
+# 2. Add issue to project (if not already there)
+ITEM_ID=$(gh project item-add $PROJECT_ID --owner phanngoc --url "https://github.com/TARGET_REPO/issues/ISSUE_NUMBER" --format json | jq -r '.id')
+
+# 3. Get Status field ID and "In Progress" option ID
+STATUS_FIELD=$(gh project field-list $PROJECT_ID --owner phanngoc --format json | jq -r '.fields[] | select(.name == "Status")')
+FIELD_ID=$(echo $STATUS_FIELD | jq -r '.id')
+IN_PROGRESS_ID=$(echo $STATUS_FIELD | jq -r '.options[] | select(.name == "In Progress") | .id')
+
+# 4. Set status to In Progress
+gh project item-edit --project-id $PROJECT_ID --id $ITEM_ID --field-id $FIELD_ID --single-select-option-id $IN_PROGRESS_ID
+```
+
+If the `gh` token lacks project scopes, show:
+> Run: `! gh auth refresh -h github.com -s read:project,project`
+Then skip this phase and continue.
+
+## Phase 6: Report
+
+Show:
+- Issue URL
+- Issue title
+- Number of implementation steps
+- Project board status
+- Suggest: `Run /implement-issue #<number> to start coding`
+
+## Rules
+
+- ALWAYS analyze the codebase BEFORE writing the plan — don't guess
+- ALWAYS reference specific file paths and function names in the plan
+- ALWAYS use `gh issue create -R <TARGET_REPO>`
+- Write in the same language as the user (Vietnamese if user writes Vietnamese)
+- The plan must be concrete enough for `/implement-issue` to execute
+- Do NOT ask for confirmation — analyze, plan, create, move. Report at the end.

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,82 @@
+---
+allowed-tools: Bash(go build *), Bash(git *), Bash(launchctl *), Bash(pgrep *), Bash(pkill *), Bash(kill *), Bash(curl *), Bash(sleep *), Bash(tail *), Bash(cat *), Read
+description: "Checkout main, pull latest, build bomclaw, and reload the macOS gateway service"
+---
+
+# /deploy — Pull, Build & Reload Gateway
+
+Checkout main, pull latest code, build the bomclaw binary, and restart the launchd gateway service on macOS.
+
+## Steps
+
+1. **Checkout main & pull latest**:
+   ```bash
+   cd /Users/ngocp/Documents/projects/meClaw/goterm-control
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Build** the binary:
+   ```bash
+   cd /Users/ngocp/Documents/projects/meClaw/goterm-control
+   go build -o bomclaw ./cmd/bomclaw/
+   ```
+
+3. **Stop** the running gateway service:
+   ```bash
+   launchctl stop com.nanoclaw.gateway
+   ```
+
+4. **Kill stale processes** — any leftover bomclaw/nanoclaw or claude subprocesses:
+   ```bash
+   sleep 1
+   pkill -f "bomclaw gateway" 2>/dev/null || true
+   pkill -f "nanoclaw gateway" 2>/dev/null || true
+   pkill -f "./goterm" 2>/dev/null || true
+   pkill -f "claude.*--resume" 2>/dev/null || true
+   sleep 1
+   ```
+   Verify no stale processes remain:
+   ```bash
+   pgrep -lf "bomclaw|nanoclaw|goterm" || echo "clean — no stale processes"
+   ```
+
+5. **Start** the gateway service:
+   ```bash
+   launchctl start com.nanoclaw.gateway
+   ```
+
+6. **Verify** the service is running:
+   ```bash
+   sleep 2
+   pgrep -lf bomclaw
+   ```
+
+7. **Health check** — confirm the gateway responds:
+   ```bash
+   curl -s http://127.0.0.1:18789/health
+   ```
+
+8. **Show recent logs** if health check fails:
+   ```bash
+   tail -20 ~/.goterm/logs/gateway.log
+   tail -10 ~/.goterm/logs/gateway.err.log
+   ```
+
+## Expected output
+
+Report:
+- Git: branch, commit hash, pull result
+- Build status (success/fail)
+- Stale processes killed (if any)
+- New PID
+- Health check result
+- If anything failed, show the relevant logs
+
+## Notes
+
+- The launchd service label is `com.nanoclaw.gateway` (will migrate to `com.bomclaw.gateway` after reinstall)
+- Binary output path: `/Users/ngocp/Documents/projects/meClaw/goterm-control/bomclaw`
+- Config: `/Users/ngocp/Documents/projects/meClaw/goterm-control/config.yaml`
+- Logs: `~/.goterm/logs/gateway.log` and `gateway.err.log`
+- Stale claude subprocesses (from `client.go` spawning `claude -p --resume`) are also killed to prevent Telegram polling conflicts

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,160 @@
+---
+allowed-tools: Bash(gh issue view*), Bash(gh issue list*), Bash(gh issue comment*), Bash(gh pr create*), Bash(gh project*), Bash(gh api*), Bash(git *), Bash(go *), Bash(npm *), Bash(pgrep *), Bash(pkill *), Bash(launchctl *), Bash(curl *), Bash(sleep *), Bash(tail *), Agent, Read, Write, Edit, Glob, Grep
+description: "Read issue, analyze plan, implement code, create PR linked to the issue"
+---
+
+# /implement-issue — Read Issue → Implement → Create PR
+
+You receive a GitHub issue number. You read the issue (which contains an implementation plan from `/create-issue`), implement all steps, and create a PR that closes the issue.
+
+## Usage
+
+```
+/implement-issue <issue-number>
+```
+
+**Examples**:
+- `/implement-issue 27`
+- `/implement-issue #27`
+
+## Arguments: $ARGUMENTS
+
+## Phase 1: Read Issue
+
+Parse `$ARGUMENTS` — extract the issue number (strip `#` if present).
+
+Detect repo:
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+Store as `TARGET_REPO`.
+
+Fetch the issue:
+```bash
+gh issue view <number> -R TARGET_REPO --json title,body,labels,comments
+```
+
+Extract from the issue body:
+1. **Goal** — what this issue achieves
+2. **Implementation Plan** — the numbered steps with file paths and changes
+3. **Acceptance Criteria** — how to verify
+4. **Files Affected** — the list of files to create/modify
+
+If the issue has no implementation plan, analyze the issue description and the codebase yourself to create one before proceeding.
+
+## Phase 2: Setup Branch
+
+```bash
+git fetch origin
+git checkout main && git pull origin main
+git checkout -b issue-<number>-<short-slug>
+```
+
+Branch naming: `issue-<number>-<slug>` where slug is 2-3 words from the title in kebab-case.
+
+## Phase 3: Implement
+
+For each step in the implementation plan:
+
+1. **Read** the relevant files first — understand existing code before changing
+2. **Implement** the change — follow existing patterns, naming conventions, imports
+3. **Build** — verify after each step:
+   ```bash
+   go build ./cmd/bomclaw/
+   ```
+   If build fails, fix before moving on.
+4. **Commit** — one atomic commit per logical step:
+   ```bash
+   git add <specific-files>
+   git commit -m "$(cat <<'EOF'
+   <type>: <short description>
+
+   <what changed and why>
+
+   Refs #<number>
+   EOF
+   )"
+   ```
+
+Commit types: `feat`, `fix`, `refactor`, `docs`, `chore`, `perf`, `test`
+
+**Rules during implementation**:
+- Follow existing code patterns exactly (naming, error handling, imports)
+- Read before write — never edit a file you haven't read
+- No TODO comments — implement completely or skip the step
+- No placeholder/mock code — everything must work
+- If a step is unclear, use Grep/Glob/Agent to explore before implementing
+
+## Phase 4: Run Tests
+
+After all steps are implemented:
+
+```bash
+go build ./cmd/bomclaw/
+go vet ./...
+go test ./internal/... -count=1
+```
+
+Fix any failures before proceeding.
+
+## Phase 5: Push & Create PR
+
+```bash
+git push -u origin issue-<number>-<short-slug>
+```
+
+Create PR linked to the issue:
+
+```bash
+gh pr create -R TARGET_REPO \
+  --title "<type>: <short description from issue title>" \
+  --body "$(cat <<'PR_EOF'
+## Summary
+<2-3 bullet points: what was implemented>
+
+## Changes
+| File | Change |
+|------|--------|
+| `path/to/file.go` | <what changed> |
+
+## Implementation Steps
+- [x] Step 1: ...
+- [x] Step 2: ...
+- [x] Step N: ...
+
+## Verification
+- [ ] `go build ./cmd/bomclaw/` passes
+- [ ] `go vet ./...` passes
+- [ ] `go test ./internal/...` passes
+- [ ] <manual verification from acceptance criteria>
+
+Closes #<number>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PR_EOF
+)"
+```
+
+Use `Closes #<number>` so merging the PR auto-closes the issue.
+
+## Phase 6: Report
+
+Show:
+- ✅ PR URL
+- Branch name
+- Commits list (hash + message)
+- Implementation steps completed
+- Any remaining work or known issues
+- Suggest: merge the PR to close issue #<number>
+
+## Rules
+
+- ALWAYS read the issue first — don't re-plan from scratch
+- ALWAYS create a feature branch from latest main
+- ALWAYS reference the issue in commits (`Refs #<number>`)
+- ALWAYS atomic commits — one per logical step
+- ALWAYS verify build after each step
+- ALWAYS use `Closes #<number>` in the PR body
+- Follow existing code patterns (check similar files before writing)
+- Do NOT ask for confirmation — read, implement, push, create PR. Report at the end.
+- Write PR body in the same language as the issue content

--- a/.claude/commands/recheck-issue.md
+++ b/.claude/commands/recheck-issue.md
@@ -1,0 +1,170 @@
+---
+allowed-tools: Bash(gh issue view*), Bash(gh issue list*), Bash(gh issue edit*), Bash(gh issue comment*), Bash(gh api*), Bash(gh repo view*), Bash(git *), Bash(go *), Agent, Read, Glob, Grep, AskUserQuestion
+description: "Read issue, re-research codebase, compare plan vs reality, report gaps, update if approved"
+---
+
+# /recheck-issue — Re-validate Issue Plan Against Current Codebase
+
+You receive a GitHub issue number. You read the issue's implementation plan, re-research the codebase to check if the plan is still accurate, report any gaps or outdated assumptions, and — if the user approves — update the issue with a corrected plan.
+
+## Usage
+
+```
+/recheck-issue <issue-number>
+```
+
+**Examples**:
+- `/recheck-issue 42`
+- `/recheck-issue #42`
+
+## Arguments: $ARGUMENTS
+
+## Phase 1: Read Issue
+
+Parse `$ARGUMENTS` — extract the issue number (strip `#` if present).
+
+Detect repo:
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+Store as `TARGET_REPO`.
+
+Fetch the issue:
+```bash
+gh issue view <number> -R TARGET_REPO --json title,body,labels,comments,state
+```
+
+Extract from the issue body:
+1. **Goal** — what this issue is trying to achieve
+2. **Implementation Plan** — the numbered steps with file paths and changes
+3. **Files Affected** — the list of files to create/modify
+4. **Acceptance Criteria** — how to verify
+
+If the issue has no implementation plan, tell the user and stop — nothing to recheck.
+
+## Phase 2: Re-research Codebase
+
+For EVERY file and function mentioned in the plan, verify against the current codebase:
+
+1. **File existence** — do the referenced files still exist? Have they been renamed/moved?
+   - Use Glob to check paths
+   - Use Grep to search for moved/renamed files if missing
+
+2. **Function/struct existence** — do the referenced symbols still exist?
+   - Use Grep to find function/struct definitions
+   - Check signatures haven't changed
+
+3. **Pattern validity** — are the code patterns referenced in the plan still used?
+   - Read relevant files to verify current patterns
+   - Check imports, naming conventions, error handling style
+
+4. **Architecture changes** — has the project structure shifted since the plan was written?
+   - Check for new packages, refactored modules, changed interfaces
+   - Look at recent commits for relevant changes:
+     ```bash
+     git log --oneline -20
+     ```
+
+5. **Dependency changes** — have relevant dependencies been added/removed/updated?
+   - Check go.mod, package.json, or relevant dependency files
+
+Use Agent(subagent_type="Explore") for broad exploration when needed. Use Grep/Glob/Read for targeted checks.
+
+## Phase 3: Gap Analysis
+
+Compare the plan against your findings. For each step in the plan, classify as:
+
+- **Still valid** — code matches plan's assumptions, step can proceed as-is
+- **Needs update** — file/function exists but has changed (different signature, moved location, etc.)
+- **Obsolete** — referenced code no longer exists or has been replaced
+- **Already done** — the change described has already been implemented
+- **New dependency** — step requires additional changes not in the original plan
+- **Missing step** — something the plan didn't account for that's now needed
+
+## Phase 4: Report to User
+
+Present a clear gap report in this format:
+
+```
+## Recheck Report: Issue #<number> — <title>
+
+### Summary
+<1-2 sentences: overall plan health>
+
+### Step-by-step Review
+
+#### Step 1: <title>
+**Status**: Still valid | Needs update | Obsolete | Already done
+**Details**: <what matched, what didn't, what changed>
+**Files checked**: `path/to/file.go`
+
+#### Step 2: <title>
+...
+
+### Gaps Found
+| # | Type | Description | Impact |
+|---|------|-------------|--------|
+| 1 | <type> | <what's wrong> | <how it affects implementation> |
+
+### Proposed Changes
+<If gaps exist, show the corrected plan diff — what would change>
+```
+
+Then ask the user for approval using AskUserQuestion:
+- **Option 1**: "Update issue" — apply the corrected plan to the issue
+- **Option 2**: "Show full new plan" — display the complete updated plan before deciding
+- **Option 3**: "No changes needed" — keep the issue as-is
+
+## Phase 5: Update Issue (if approved)
+
+If the user chose "Update issue" (or approved after seeing the full plan):
+
+1. Build the updated issue body preserving the original structure but with corrected:
+   - File paths and function names
+   - Implementation steps (reordered, added, removed as needed)
+   - Acceptance criteria (updated if scope changed)
+   - Files Affected table
+
+2. Update the issue:
+   ```bash
+   gh issue edit <number> -R TARGET_REPO --body "$(cat <<'BODY_EOF'
+   <updated issue body>
+   BODY_EOF
+   )"
+   ```
+
+3. Add a comment documenting what changed:
+   ```bash
+   gh issue comment <number> -R TARGET_REPO --body "$(cat <<'COMMENT_EOF'
+   ## Plan Rechecked
+
+   **Date**: <today>
+   **Reason**: Codebase has diverged from original plan
+
+   ### Changes Made
+   - <bullet list of what was updated in the plan>
+
+   ---
+   _Rechecked by Claude Code via `/recheck-issue`_
+   COMMENT_EOF
+   )"
+   ```
+
+## Phase 6: Report
+
+Show:
+- Issue URL
+- Number of gaps found
+- Steps updated / added / removed
+- Whether issue was updated or left as-is
+
+## Rules
+
+- ALWAYS read the issue first — understand the existing plan before researching
+- ALWAYS verify EVERY file path and symbol mentioned in the plan
+- ALWAYS show the gap report BEFORE making any changes
+- ALWAYS ask for user approval — never update the issue without explicit consent
+- Check recent git history for context on what changed and why
+- Write the report and updated plan in the same language as the issue content
+- If no gaps are found, say so clearly — don't invent problems
+- Do NOT change the issue's title or labels — only the body (plan content)

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,134 @@
+---
+allowed-tools: Bash(gh pr view*), Bash(gh pr diff*), Bash(gh pr checks*), Bash(gh api*), Bash(gh repo view*), Bash(gh pr review*), Bash(git *), Agent, Read, Glob, Grep
+description: "Fetch PR, review architecture/best-practices/security, comment on PR"
+---
+
+# /review-pr — Fetch PR → Review → Comment
+
+You receive a PR number. You fetch the PR diff, review it for architecture, best practices, and security issues, then post a structured review comment on the PR.
+
+## Usage
+
+```
+/review-pr <pr-number>
+```
+
+**Examples**:
+- `/review-pr 36`
+- `/review-pr #36`
+
+## Arguments: $ARGUMENTS
+
+## Phase 1: Fetch PR
+
+Parse `$ARGUMENTS` — extract the PR number (strip `#` if present).
+
+Detect repo:
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+Store as `TARGET_REPO`.
+
+Fetch PR metadata and diff:
+```bash
+gh pr view <number> -R TARGET_REPO --json title,body,files,baseRefName,headRefName,additions,deletions,commits
+gh pr diff <number> -R TARGET_REPO
+```
+
+Also fetch the list of changed files:
+```bash
+gh pr view <number> -R TARGET_REPO --json files -q '.files[].path'
+```
+
+## Phase 2: Understand Context
+
+For each changed file in the PR:
+1. **Read the full file** (not just the diff) to understand the surrounding code
+2. **Read related files** — imports, callers, tests — to understand the impact
+3. If the PR references an issue, fetch it: `gh issue view <issue-number> -R TARGET_REPO --json title,body`
+
+Use Agent(subagent_type="Explore") if you need broader codebase understanding.
+
+## Phase 3: Review
+
+Analyze the diff across three dimensions. For each dimension, assign a rating (pass/warn/fail) and list specific findings with file:line references.
+
+### 3a: Architecture Review
+- Does the change fit the existing codebase architecture?
+- Are responsibilities correctly separated (single responsibility)?
+- Are new abstractions justified or premature?
+- Does it introduce coupling between unrelated packages?
+- Are interfaces used appropriately?
+- Is the change in the right layer (handler vs service vs model)?
+
+### 3b: Best Practices Review
+- Error handling: are errors wrapped with context? Silently swallowed?
+- Naming: do new names follow existing conventions?
+- DRY: is there duplicated logic that should be shared?
+- Tests: are new code paths covered? Are edge cases tested?
+- Concurrency: are shared resources protected? Race conditions?
+- Resource management: are resources (goroutines, files, connections) properly cleaned up?
+- API design: are function signatures clear? Do they accept the narrowest interface?
+
+### 3c: Security Review
+- Input validation: is user input validated/sanitized?
+- Injection: SQL injection, command injection, path traversal?
+- Secrets: are credentials, tokens, or keys exposed?
+- Auth: are authorization checks in place where needed?
+- Data exposure: does logging or error messages leak sensitive data?
+- Dependencies: are new dependencies from trusted sources?
+
+## Phase 4: Comment on PR
+
+Post a review comment using `gh pr review`. Choose the review type based on severity:
+
+- **APPROVE** — if no warn/fail findings, or only minor style suggestions
+- **COMMENT** — if there are warnings but nothing blocking
+- **REQUEST_CHANGES** — if there are fail-level issues that must be fixed
+
+Format the review body in this structure:
+
+```bash
+gh pr review <number> -R TARGET_REPO --<type> --body "$(cat <<'REVIEW_EOF'
+## Code Review
+
+### Architecture <rating>
+<findings with file:line references, or "Looks good" if clean>
+
+### Best Practices <rating>
+<findings with file:line references, or "Looks good" if clean>
+
+### Security <rating>
+<findings with file:line references, or "No issues found" if clean>
+
+### Summary
+<1-3 sentence overall assessment>
+
+<optional: specific suggestions as a numbered list>
+
+---
+🤖 Reviewed by [Claude Code](https://claude.com/claude-code)
+REVIEW_EOF
+)"
+```
+
+Rating symbols: `✅` pass, `⚠️` warn, `❌` fail
+
+## Phase 5: Report
+
+Show to the user:
+- PR title and number of changed files
+- Overall verdict (approve/comment/request changes)
+- Key findings summary (if any)
+- Confirm the review was posted
+
+## Rules
+
+- ALWAYS read the full changed files, not just the diff — context matters
+- ALWAYS reference specific file:line when citing issues
+- Be honest — do NOT rubber-stamp. If there are real problems, say so.
+- Be constructive — explain WHY something is a problem and suggest a fix
+- Prioritize: security > correctness > architecture > style
+- Do NOT nitpick formatting or style unless it's inconsistent with the codebase
+- Write review comments in the same language the PR is written in (Vietnamese if PR is Vietnamese)
+- Do NOT ask for confirmation — fetch, review, comment. Report at the end.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# GoTerm Control — Project Notes
+
+## Known Ops Issues
+
+### Telegram bot conflict on restart
+When restarting the gateway service, stale Claude CLI subprocesses (spawned by previous bot sessions) can hold Telegram's `getUpdates` polling connection. This causes `"Conflict: terminated by other getUpdates request"` errors and the bot stops receiving messages.
+
+**Fix checklist before restart:**
+1. Kill any orphaned claude subprocesses: `pgrep -lf "claude.*--resume" | grep -v grep` then `kill <pid>`
+2. Clear Telegram state: `curl "https://api.telegram.org/bot${TOKEN}/deleteWebhook?drop_pending_updates=true"`
+3. Then restart: `./bomclaw gateway restart`
+
+**Root cause:** `client.go` spawns `claude -p --resume <session>` as a child process. If the parent gateway dies (crash, restart) without killing the child, the orphaned claude process keeps its Telegram long-poll alive. The new gateway instance then conflicts with it.
+
+**TODO:** Add child process cleanup on gateway shutdown (kill all spawned claude subprocesses in `Bot.Shutdown()`).


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with known ops issues (Telegram bot conflict on restart) and fix checklist
- Add `.claude/commands/` with 5 custom workflow commands: `create-issue`, `implement-issue`, `review-pr`, `recheck-issue`, `deploy`

## Test plan
- [ ] Verify `/deploy` command works with `bomclaw gateway restart`
- [ ] Verify `/create-issue` and `/implement-issue` workflows create proper GitHub issues/PRs
- [ ] Verify `/review-pr` fetches and reviews PRs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)