### PR TITLE
feat: LLM-powered memory extraction thay thế rule-based regex

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -28,6 +28,7 @@ import (
 	agentctx "github.com/ngocp/goterm-control/internal/context"
 	"github.com/ngocp/goterm-control/internal/daemon"
 	"github.com/ngocp/goterm-control/internal/gateway"
+	"github.com/ngocp/goterm-control/internal/memory"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/storage"
@@ -193,14 +194,23 @@ func runGateway(args []string) {
 	// Memory store (SQLite with FTS5)
 	memoryStore := storage.NewMemoryStore(db)
 
+	// Create Completer for LLM-based memory extraction (uses Haiku model).
+	// Only created when extraction mode requires LLM and API key is available.
+	var memCompleter memory.Completer
+	if cfg.Memory.Enabled && cfg.Memory.ExtractionMode != "rule" && cfg.Claude.APIKey != "" {
+		memCompleter = anthropicClient.New(cfg.Claude.APIKey)
+	}
+
 	deps := gateway.Deps{
-		Sessions: sessions,
-		Resolver: resolver,
-		Provider: provider,
-		System:   cfg.Claude.SystemPrompt,
-		DataDir:  cfg.Session.DataDir,
-		Memory:   memoryStore,
-		Uptime:   func() time.Duration { return time.Since(startTime) },
+		Sessions:       sessions,
+		Resolver:       resolver,
+		Provider:       provider,
+		System:         cfg.Claude.SystemPrompt,
+		DataDir:        cfg.Session.DataDir,
+		Memory:         memoryStore,
+		Completer:      memCompleter,
+		ExtractionMode: cfg.Memory.ExtractionMode,
+		Uptime:         func() time.Duration { return time.Since(startTime) },
 	}
 
 	srv := gateway.NewServer(addr, gateway.NewMethodHandler(deps), gateway.NewStreamSendHandler(deps), "dashboard/dist")

--- a/internal/anthropic/client.go
+++ b/internal/anthropic/client.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Client implements agent.ModelProvider using the Anthropic Messages API directly.
+// It also provides Complete() for non-streaming single-turn calls (used by memory extraction).
 type Client struct {
 	sdk sdk.Client
 }
@@ -22,6 +23,40 @@ func New(apiKey string) *Client {
 	return &Client{
 		sdk: sdk.NewClient(option.WithAPIKey(apiKey)),
 	}
+}
+
+// Complete makes a non-streaming single-turn API call and returns the text response.
+// Used for lightweight tasks like memory extraction where streaming is unnecessary.
+func (c *Client) Complete(ctx context.Context, model, system, userMessage string, maxTokens int) (string, error) {
+	if maxTokens <= 0 {
+		maxTokens = 1024
+	}
+
+	var systemBlocks []sdk.TextBlockParam
+	if system != "" {
+		systemBlocks = []sdk.TextBlockParam{{Text: system}}
+	}
+
+	resp, err := c.sdk.Messages.New(ctx, sdk.MessageNewParams{
+		Model:     sdk.Model(model),
+		MaxTokens: int64(maxTokens),
+		System:    systemBlocks,
+		Messages: []sdk.MessageParam{
+			sdk.NewUserMessage(sdk.NewTextBlock(userMessage)),
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("anthropic complete: %w", err)
+	}
+
+	// Extract text from response content blocks
+	var text string
+	for _, block := range resp.Content {
+		if tb, ok := block.AsAny().(sdk.TextBlock); ok {
+			text += tb.Text
+		}
+	}
+	return text, nil
 }
 
 // Stream implements agent.ModelProvider.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	anthropicAPI "github.com/ngocp/goterm-control/internal/anthropic"
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/execution"
@@ -101,6 +102,13 @@ func New(cfg *config.Config) (*Bot, error) {
 	// Execution engine
 	engine := execution.NewEngine(execution.Hooks{}, 3)
 
+	// Create Anthropic API client for LLM-based memory extraction (uses Haiku).
+	// This is separate from the main claude CLI client used for conversation.
+	var completer memory.Completer
+	if cfg.Memory.Enabled && cfg.Memory.ExtractionMode != "rule" && cfg.Claude.APIKey != "" {
+		completer = anthropicAPI.New(cfg.Claude.APIKey)
+	}
+
 	// Build handler first (queue needs handler.executeMessage as callback)
 	handler := &Handler{
 		bot:              api,
@@ -115,6 +123,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		approvalRequests: make(map[string]chan bool),
 		indicator:        indicator,
 		typing:           typing,
+		completer:        completer,
 	}
 
 	// Message queue: debounce 800ms + collect while busy

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -43,6 +43,7 @@ type Handler struct {
 	queue      *msgqueue.Queue // debounce + collect layer
 	indicator  *NameIndicator
 	typing     *TypingIndicator
+	completer  memory.Completer // for LLM-based memory extraction
 
 	// approvalRequests maps callbackData → channel to signal approval/cancel
 	approvalMu       sync.Mutex
@@ -414,7 +415,7 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 
 	// Extract and store memory
 	if h.memory != nil && respText != "" {
-		entry := memory.ExtractFacts(sess.ID, chatID, userText, respText)
+		entry := memory.Extract(ctx, h.completer, h.cfg.Memory.ExtractionMode, sess.ID, chatID, userText, respText)
 		if len(entry.Keywords) > 0 || len(entry.Facts) > 0 {
 			if err := h.memory.Append(entry); err != nil {
 				log.Printf("handler: memory append error: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,8 +71,9 @@ type SessionConfig struct {
 }
 
 type MemoryConfig struct {
-	Enabled    bool `yaml:"enabled"`
-	MaxEntries int  `yaml:"max_entries"`
+	Enabled        bool   `yaml:"enabled"`
+	MaxEntries     int    `yaml:"max_entries"`
+	ExtractionMode string `yaml:"extraction_mode"` // "llm", "rule", or "hybrid" (default: "rule")
 }
 
 func Load(path string) (*Config, error) {
@@ -129,6 +130,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Memory.MaxEntries == 0 {
 		cfg.Memory.MaxEntries = 5
+	}
+	if cfg.Memory.ExtractionMode == "" {
+		cfg.Memory.ExtractionMode = "rule"
 	}
 	if cfg.Telegram.Indicator.Enabled {
 		if len(cfg.Telegram.Indicator.Frames) == 0 {

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -18,15 +18,17 @@ import (
 
 // Deps holds the dependencies needed by RPC method handlers.
 type Deps struct {
-	Sessions      *session.Manager
-	Resolver      *models.Resolver
-	Provider      agent.ModelProvider
-	ToolExecutor  agent.ToolExecutor
-	Tools         []agent.ToolDef
-	System        string // system prompt
-	DataDir       string // data directory for transcripts
-	Memory        memory.MemoryBackend
-	Uptime        func() time.Duration
+	Sessions       *session.Manager
+	Resolver       *models.Resolver
+	Provider       agent.ModelProvider
+	ToolExecutor   agent.ToolExecutor
+	Tools          []agent.ToolDef
+	System         string // system prompt
+	DataDir        string // data directory for transcripts
+	Memory         memory.MemoryBackend
+	Completer      memory.Completer // for LLM-based memory extraction
+	ExtractionMode string           // "llm", "rule", or "hybrid"
+	Uptime         func() time.Duration
 }
 
 // NewMethodHandler creates a MethodHandler that routes to the appropriate handler.
@@ -313,7 +315,7 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 
 		// Extract and save memory for future sessions
 		if deps.Memory != nil && responseText != "" {
-			entry := memory.ExtractFacts(sessionID, 0, p.Message, responseText)
+			entry := memory.Extract(ctx, deps.Completer, deps.ExtractionMode, sessionID, 0, p.Message, responseText)
 			if len(entry.Keywords) > 0 || len(entry.Facts) > 0 {
 				deps.Memory.Append(entry)
 			}

--- a/internal/memory/extract.go
+++ b/internal/memory/extract.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"time"
@@ -10,6 +11,63 @@ var (
 	pathRe = regexp.MustCompile(`(?:^|[\s"'` + "`" + `])([/~][\w./-]+)`)
 	urlRe  = regexp.MustCompile(`https?://\S+`)
 )
+
+// Extract dispatches to the appropriate extraction method based on mode.
+// Modes: "llm" (LLM with rule-based fallback), "rule" (rule-based only), "hybrid" (merge both).
+// If client is nil, falls back to rule-based regardless of mode.
+func Extract(ctx context.Context, client Completer, mode string, sessionID string, chatID int64, userMsg, assistantResp string) Entry {
+	switch mode {
+	case "llm":
+		if client == nil {
+			return ExtractFacts(sessionID, chatID, userMsg, assistantResp)
+		}
+		entry, err := ExtractFactsLLM(ctx, client, sessionID, chatID, userMsg, assistantResp)
+		if err != nil {
+			logLLMFallback(err)
+			return ExtractFacts(sessionID, chatID, userMsg, assistantResp)
+		}
+		return entry
+
+	case "hybrid":
+		ruleBased := ExtractFacts(sessionID, chatID, userMsg, assistantResp)
+		if client == nil {
+			return ruleBased
+		}
+		llmBased, err := ExtractFactsLLM(ctx, client, sessionID, chatID, userMsg, assistantResp)
+		if err != nil {
+			logLLMFallback(err)
+			return ruleBased
+		}
+		return mergeEntries(llmBased, ruleBased)
+
+	default: // "rule"
+		return ExtractFacts(sessionID, chatID, userMsg, assistantResp)
+	}
+}
+
+// mergeEntries combines LLM and rule-based entries, preferring LLM for keywords/summary/intent
+// and merging facts from both sources.
+func mergeEntries(llm, rule Entry) Entry {
+	merged := llm // Start with LLM result (better keywords, summary, intent)
+
+	// Merge facts: add rule-based facts not already captured by LLM
+	seen := make(map[string]bool, len(llm.Facts))
+	for _, f := range llm.Facts {
+		seen[f] = true
+	}
+	for _, f := range rule.Facts {
+		if !seen[f] {
+			merged.Facts = append(merged.Facts, f)
+		}
+	}
+
+	// Cap merged facts
+	if len(merged.Facts) > 20 {
+		merged.Facts = merged.Facts[:20]
+	}
+
+	return merged
+}
 
 // ExtractFacts performs rule-based extraction of key facts from a conversation turn.
 // No LLM call — fast and deterministic.

--- a/internal/memory/llm_extract.go
+++ b/internal/memory/llm_extract.go
@@ -1,0 +1,190 @@
+package memory
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+// Completer makes a non-streaming LLM call. Implemented by anthropic.Client.
+type Completer interface {
+	Complete(ctx context.Context, model, system, userMessage string, maxTokens int) (string, error)
+}
+
+// extractionModel is the model used for memory extraction (fast + cheap).
+const extractionModel = "claude-haiku-4-5-20251001"
+
+const extractionPrompt = `You are a memory extraction system. Given a user message and assistant response from a conversation, extract structured memory data.
+
+Return ONLY valid JSON with this exact schema:
+{
+  "keywords": ["semantic", "keywords", "capturing", "intent"],
+  "facts": ["path: /file/paths", "url: https://urls", "error: error messages", "decision: technical decisions"],
+  "summary": "One sentence capturing the main point of this exchange",
+  "intent": "What the user is trying to accomplish (one short sentence)"
+}
+
+Rules:
+- keywords: 5-15 semantic keywords that capture the MEANING, not just raw words. Include technologies, concepts, and actions.
+- facts: Extract file paths (prefix "path:"), URLs (prefix "url:"), error messages (prefix "error:"), code references (prefix "ref:"), and technical decisions (prefix "decision:"). Max 15 items.
+- summary: Capture the main point of the conversation turn, not just the first sentence. Max 200 chars.
+- intent: What the user is trying to do in one short sentence. Max 100 chars.`
+
+// extractionResult is the JSON structure returned by the LLM.
+type extractionResult struct {
+	Keywords []string `json:"keywords"`
+	Facts    []string `json:"facts"`
+	Summary  string   `json:"summary"`
+	Intent   string   `json:"intent"`
+}
+
+// ExtractFactsLLM uses an LLM to extract structured memory from a conversation turn.
+// Falls back to rule-based extraction on any error.
+func ExtractFactsLLM(ctx context.Context, client Completer, sessionID string, chatID int64, userMessage, assistantResponse string) (Entry, error) {
+	combined := fmt.Sprintf("USER MESSAGE:\n%s\n\nASSISTANT RESPONSE:\n%s", userMessage, truncate(assistantResponse, 2000))
+
+	// Check cache first
+	cacheKey := contentHash(combined)
+	if cached, ok := extractionCache.get(cacheKey); ok {
+		cached.SessionID = sessionID
+		cached.ChatID = chatID
+		cached.CreatedAt = time.Now()
+		return cached, nil
+	}
+
+	resp, err := client.Complete(ctx, extractionModel, extractionPrompt, combined, 500)
+	if err != nil {
+		return Entry{}, fmt.Errorf("llm extraction: %w", err)
+	}
+
+	var result extractionResult
+	if err := json.Unmarshal([]byte(resp), &result); err != nil {
+		// Try to extract JSON from response (LLM might add markdown fences)
+		if cleaned := extractJSON(resp); cleaned != "" {
+			if err2 := json.Unmarshal([]byte(cleaned), &result); err2 != nil {
+				return Entry{}, fmt.Errorf("parse extraction response: %w", err)
+			}
+		} else {
+			return Entry{}, fmt.Errorf("parse extraction response: %w", err)
+		}
+	}
+
+	entry := Entry{
+		CreatedAt: time.Now(),
+		SessionID: sessionID,
+		ChatID:    chatID,
+		Keywords:  result.Keywords,
+		Facts:     result.Facts,
+		Summary:   result.Summary,
+		Intent:    result.Intent,
+	}
+
+	// Cache the result
+	extractionCache.set(cacheKey, entry)
+
+	return entry, nil
+}
+
+// truncate limits text to maxLen characters.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// extractJSON tries to find a JSON object in text (handles markdown code fences).
+func extractJSON(text string) string {
+	// Find first { and last }
+	start := -1
+	end := -1
+	for i, ch := range text {
+		if ch == '{' && start == -1 {
+			start = i
+		}
+		if ch == '}' {
+			end = i
+		}
+	}
+	if start >= 0 && end > start {
+		return text[start : end+1]
+	}
+	return ""
+}
+
+func contentHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:16])
+}
+
+// --- In-memory cache with TTL ---
+
+var extractionCache = newExtrCache()
+
+type extrCache struct {
+	mu      sync.RWMutex
+	entries map[string]extrCacheEntry
+}
+
+type extrCacheEntry struct {
+	entry   Entry
+	expires time.Time
+}
+
+const cacheTTL = 1 * time.Hour
+const cacheMaxSize = 100
+
+func newExtrCache() *extrCache {
+	return &extrCache{entries: make(map[string]extrCacheEntry)}
+}
+
+func (c *extrCache) get(key string) (Entry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key]
+	if !ok || time.Now().After(e.expires) {
+		return Entry{}, false
+	}
+	return e.entry, true
+}
+
+func (c *extrCache) set(key string, entry Entry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict expired entries if cache is full
+	if len(c.entries) >= cacheMaxSize {
+		now := time.Now()
+		for k, v := range c.entries {
+			if now.After(v.expires) {
+				delete(c.entries, k)
+			}
+		}
+		// If still full, clear oldest half
+		if len(c.entries) >= cacheMaxSize {
+			count := 0
+			for k := range c.entries {
+				delete(c.entries, k)
+				count++
+				if count >= cacheMaxSize/2 {
+					break
+				}
+			}
+		}
+	}
+
+	c.entries[key] = extrCacheEntry{
+		entry:   entry,
+		expires: time.Now().Add(cacheTTL),
+	}
+}
+
+// logLLMFallback logs when LLM extraction fails and falls back to rule-based.
+func logLLMFallback(err error) {
+	log.Printf("memory: LLM extraction failed, falling back to rule-based: %v", err)
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,6 +1,9 @@
 package memory
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -85,6 +88,176 @@ func TestBuildMemoryContext(t *testing.T) {
 
 	if !contains(ctx, "Relevant Memory") {
 		t.Error("expected memory context header")
+	}
+}
+
+// mockCompleter simulates an LLM extraction response.
+type mockCompleter struct {
+	response string
+	err      error
+}
+
+func (m *mockCompleter) Complete(ctx context.Context, model, system, userMessage string, maxTokens int) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.response, nil
+}
+
+func TestExtractModeSwitching(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("rule mode ignores completer", func(t *testing.T) {
+		entry := Extract(ctx, nil, "rule", "sess1", 100, "hello", "world")
+		if entry.SessionID != "sess1" {
+			t.Errorf("expected sess1, got %s", entry.SessionID)
+		}
+	})
+
+	t.Run("llm mode with nil completer falls back to rule", func(t *testing.T) {
+		entry := Extract(ctx, nil, "llm", "sess1", 100, "check /tmp/test.go", "I checked the file.")
+		if entry.SessionID != "sess1" {
+			t.Errorf("expected sess1, got %s", entry.SessionID)
+		}
+		if entry.Summary == "" {
+			t.Error("expected summary from rule-based fallback")
+		}
+	})
+
+	t.Run("llm mode with working completer", func(t *testing.T) {
+		resp, _ := json.Marshal(extractionResult{
+			Keywords: []string{"deployment", "kubernetes", "production"},
+			Facts:    []string{"path: /etc/k8s/config.yaml", "decision: use rolling update"},
+			Summary:  "User wants to deploy to production using Kubernetes",
+			Intent:   "Deploy application to production k8s cluster",
+		})
+		client := &mockCompleter{response: string(resp)}
+		entry := Extract(ctx, client, "llm", "sess1", 100, "deploy to k8s", "I'll help you deploy.")
+		if entry.Intent != "Deploy application to production k8s cluster" {
+			t.Errorf("expected LLM intent, got %q", entry.Intent)
+		}
+		if len(entry.Keywords) != 3 {
+			t.Errorf("expected 3 keywords, got %d", len(entry.Keywords))
+		}
+	})
+
+	t.Run("llm mode with error falls back to rule", func(t *testing.T) {
+		client := &mockCompleter{err: fmt.Errorf("api error")}
+		entry := Extract(ctx, client, "llm", "sess1", 100, "check /tmp/file.go", "Done checking.")
+		if entry.Intent != "" {
+			t.Errorf("rule-based should not set intent, got %q", entry.Intent)
+		}
+		if entry.Summary == "" {
+			t.Error("expected summary from rule-based fallback")
+		}
+	})
+
+	t.Run("hybrid mode merges results", func(t *testing.T) {
+		resp, _ := json.Marshal(extractionResult{
+			Keywords: []string{"docker", "container", "deploy"},
+			Facts:    []string{"decision: use multi-stage build"},
+			Summary:  "Setting up Docker for deployment",
+			Intent:   "Containerize application with Docker",
+		})
+		client := &mockCompleter{response: string(resp)}
+		entry := Extract(ctx, client, "hybrid", "sess1", 100,
+			"help with docker build, check /usr/local/Dockerfile",
+			"I'll help with the Docker build process. Check https://docs.docker.com for more.")
+
+		// Should have LLM intent
+		if entry.Intent != "Containerize application with Docker" {
+			t.Errorf("expected LLM intent, got %q", entry.Intent)
+		}
+		// Should have LLM keywords
+		if len(entry.Keywords) < 3 {
+			t.Errorf("expected at least 3 keywords, got %d", len(entry.Keywords))
+		}
+		// Should have merged facts (LLM decision + rule-based URL/path)
+		hasDecision := false
+		hasURL := false
+		for _, f := range entry.Facts {
+			if f == "decision: use multi-stage build" {
+				hasDecision = true
+			}
+			if contains(f, "docs.docker.com") {
+				hasURL = true
+			}
+		}
+		if !hasDecision {
+			t.Error("expected LLM-extracted decision fact")
+		}
+		if !hasURL {
+			t.Error("expected rule-extracted URL fact")
+		}
+	})
+}
+
+func TestExtractFactsLLMCache(t *testing.T) {
+	callCount := 0
+	resp, _ := json.Marshal(extractionResult{
+		Keywords: []string{"test"},
+		Facts:    []string{"path: /test"},
+		Summary:  "Test summary",
+		Intent:   "Testing",
+	})
+	client := &mockCompleter{response: string(resp)}
+
+	// Wrap to count calls
+	wrapper := &countCompleter{inner: client, count: &callCount}
+
+	ctx := context.Background()
+	// First call
+	entry1, err := ExtractFactsLLM(ctx, wrapper, "s1", 1, "same message", "same response")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 call, got %d", callCount)
+	}
+
+	// Second call with same content should hit cache
+	entry2, err := ExtractFactsLLM(ctx, wrapper, "s2", 2, "same message", "same response")
+	if err != nil {
+		t.Fatalf("cached call: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected cache hit (1 call), got %d calls", callCount)
+	}
+	// Cached entry should have updated session/chat IDs
+	if entry2.SessionID != "s2" {
+		t.Errorf("expected s2, got %s", entry2.SessionID)
+	}
+	_ = entry1
+}
+
+type countCompleter struct {
+	inner *mockCompleter
+	count *int
+}
+
+func (c *countCompleter) Complete(ctx context.Context, model, system, userMessage string, maxTokens int) (string, error) {
+	*c.count++
+	return c.inner.Complete(ctx, model, system, userMessage, maxTokens)
+}
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain json", `{"key": "value"}`, `{"key": "value"}`},
+		{"markdown fenced", "```json\n{\"key\": \"value\"}\n```", `{"key": "value"}`},
+		{"text before", "Here is the result:\n{\"a\": 1}", `{"a": 1}`},
+		{"no json", "no json here", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractJSON(tt.input)
+			if got != tt.want {
+				t.Errorf("extractJSON(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -26,6 +26,7 @@ type Entry struct {
 	Facts     []string  `json:"facts"`
 	Keywords  []string  `json:"keywords"`
 	Summary   string    `json:"summary"`
+	Intent    string    `json:"intent,omitempty"`
 }
 
 // Store manages memory entries in a JSONL file.

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -37,11 +37,11 @@ func (m *SQLiteMemoryStore) Append(entry memory.Entry) error {
 		return fmt.Errorf("marshal keywords: %w", err)
 	}
 
-	_, err = m.db.conn.Exec(`INSERT INTO memory (id, created_at, session_id, chat_id, facts, keywords, summary)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	_, err = m.db.conn.Exec(`INSERT INTO memory (id, created_at, session_id, chat_id, facts, keywords, summary, intent)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		entry.ID, entry.CreatedAt.Format(time.RFC3339),
 		entry.SessionID, entry.ChatID,
-		string(factsJSON), string(keywordsJSON), entry.Summary,
+		string(factsJSON), string(keywordsJSON), entry.Summary, entry.Intent,
 	)
 	return err
 }
@@ -67,7 +67,7 @@ func (m *SQLiteMemoryStore) Search(query string, limit int) ([]memory.Entry, err
 	ftsQuery := strings.Join(tokens, " OR ")
 
 	rows, err := m.db.conn.Query(`
-		SELECT m.id, m.created_at, m.session_id, m.chat_id, m.facts, m.keywords, m.summary
+		SELECT m.id, m.created_at, m.session_id, m.chat_id, m.facts, m.keywords, m.summary, m.intent
 		FROM memory m
 		JOIN memory_fts f ON f.rowid = m.rowid
 		WHERE memory_fts MATCH ?
@@ -86,11 +86,11 @@ func (m *SQLiteMemoryStore) Search(query string, limit int) ([]memory.Entry, err
 func (m *SQLiteMemoryStore) searchFallback(query string, limit int) ([]memory.Entry, error) {
 	pattern := "%" + query + "%"
 	rows, err := m.db.conn.Query(`
-		SELECT id, created_at, session_id, chat_id, facts, keywords, summary
+		SELECT id, created_at, session_id, chat_id, facts, keywords, summary, intent
 		FROM memory
-		WHERE keywords LIKE ? OR facts LIKE ? OR summary LIKE ?
+		WHERE keywords LIKE ? OR facts LIKE ? OR summary LIKE ? OR intent LIKE ?
 		ORDER BY created_at DESC
-		LIMIT ?`, pattern, pattern, pattern, limit)
+		LIMIT ?`, pattern, pattern, pattern, pattern, limit)
 	if err != nil {
 		return nil, fmt.Errorf("search fallback: %w", err)
 	}
@@ -100,7 +100,7 @@ func (m *SQLiteMemoryStore) searchFallback(query string, limit int) ([]memory.En
 
 // ReadAll returns all memory entries ordered by creation time.
 func (m *SQLiteMemoryStore) ReadAll() ([]memory.Entry, error) {
-	rows, err := m.db.conn.Query(`SELECT id, created_at, session_id, chat_id, facts, keywords, summary
+	rows, err := m.db.conn.Query(`SELECT id, created_at, session_id, chat_id, facts, keywords, summary, intent
 		FROM memory ORDER BY created_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("read all memory: %w", err)
@@ -119,10 +119,10 @@ func scanMemoryRows(rows rowScanner) ([]memory.Entry, error) {
 	var entries []memory.Entry
 	for rows.Next() {
 		var (
-			id, createdStr, sessionID, factsStr, keywordsStr, summary string
-			chatID                                                    int64
+			id, createdStr, sessionID, factsStr, keywordsStr, summary, intent string
+			chatID                                                            int64
 		)
-		if err := rows.Scan(&id, &createdStr, &sessionID, &chatID, &factsStr, &keywordsStr, &summary); err != nil {
+		if err := rows.Scan(&id, &createdStr, &sessionID, &chatID, &factsStr, &keywordsStr, &summary, &intent); err != nil {
 			continue
 		}
 
@@ -141,6 +141,7 @@ func scanMemoryRows(rows rowScanner) ([]memory.Entry, error) {
 			Facts:     facts,
 			Keywords:  keywords,
 			Summary:   summary,
+			Intent:    intent,
 		})
 	}
 	return entries, rows.Err()

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -2,7 +2,7 @@ package storage
 
 import "fmt"
 
-const schemaVersion = 1
+const schemaVersion = 2
 
 // DDL statements executed in order.
 var ddl = []string{
@@ -42,23 +42,24 @@ var ddl = []string{
 		chat_id    INTEGER DEFAULT 0,
 		facts      TEXT NOT NULL,
 		keywords   TEXT NOT NULL,
-		summary    TEXT DEFAULT ''
+		summary    TEXT DEFAULT '',
+		intent     TEXT DEFAULT ''
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_memory_chat ON memory(chat_id, created_at DESC)`,
 
 	`CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
-		keywords, facts, summary, content=memory, content_rowid=rowid
+		keywords, facts, summary, intent, content=memory, content_rowid=rowid
 	)`,
 
 	// FTS sync triggers
 	`CREATE TRIGGER IF NOT EXISTS memory_ai AFTER INSERT ON memory BEGIN
-		INSERT INTO memory_fts(rowid, keywords, facts, summary)
-		VALUES (new.rowid, new.keywords, new.facts, new.summary);
+		INSERT INTO memory_fts(rowid, keywords, facts, summary, intent)
+		VALUES (new.rowid, new.keywords, new.facts, new.summary, new.intent);
 	END`,
 
 	`CREATE TRIGGER IF NOT EXISTS memory_ad AFTER DELETE ON memory BEGIN
-		INSERT INTO memory_fts(memory_fts, rowid, keywords, facts, summary)
-		VALUES ('delete', old.rowid, old.keywords, old.facts, old.summary);
+		INSERT INTO memory_fts(memory_fts, rowid, keywords, facts, summary, intent)
+		VALUES ('delete', old.rowid, old.keywords, old.facts, old.summary, old.intent);
 	END`,
 }
 
@@ -77,11 +78,50 @@ func (db *DB) migrate() error {
 		return db.migrateFromLegacy()
 	}
 
+	if ver < 2 {
+		if err := db.migrateV2AddIntent(); err != nil {
+			return fmt.Errorf("migrate v2: %w", err)
+		}
+	}
+
 	if ver < schemaVersion {
 		if err := db.createTables(); err != nil {
 			return err
 		}
 		return db.setVersion(schemaVersion)
+	}
+	return nil
+}
+
+// migrateV2AddIntent adds the intent column to memory table and rebuilds FTS.
+func (db *DB) migrateV2AddIntent() error {
+	// Add column (SQLite ignores if column already exists via error)
+	_, _ = db.conn.Exec(`ALTER TABLE memory ADD COLUMN intent TEXT DEFAULT ''`)
+
+	// Rebuild FTS table and triggers to include intent
+	stmts := []string{
+		`DROP TRIGGER IF EXISTS memory_ai`,
+		`DROP TRIGGER IF EXISTS memory_ad`,
+		`DROP TABLE IF EXISTS memory_fts`,
+		`CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+			keywords, facts, summary, intent, content=memory, content_rowid=rowid
+		)`,
+		`CREATE TRIGGER IF NOT EXISTS memory_ai AFTER INSERT ON memory BEGIN
+			INSERT INTO memory_fts(rowid, keywords, facts, summary, intent)
+			VALUES (new.rowid, new.keywords, new.facts, new.summary, new.intent);
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS memory_ad AFTER DELETE ON memory BEGIN
+			INSERT INTO memory_fts(memory_fts, rowid, keywords, facts, summary, intent)
+			VALUES ('delete', old.rowid, old.keywords, old.facts, old.summary, old.intent);
+		END`,
+		// Rebuild FTS content from existing data
+		`INSERT INTO memory_fts(rowid, keywords, facts, summary, intent)
+			SELECT rowid, keywords, facts, summary, intent FROM memory`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.conn.Exec(stmt); err != nil {
+			return fmt.Errorf("migrate v2 DDL: %w\nstatement: %s", err, stmt)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Thêm `Complete()` non-streaming method vào Anthropic client cho lightweight LLM calls
- Implement LLM-based memory extraction dùng Haiku model với structured JSON prompt
- Hỗ trợ 3 extraction modes: `llm`, `rule`, `hybrid` qua config `memory.extraction_mode`
- Thêm field `intent` vào memory Entry, lưu vào SQLite + FTS5 search

## Changes
| File | Change |
|------|--------|
| `internal/anthropic/client.go` | Add `Complete()` non-streaming method |
| `internal/memory/store.go` | Add `Intent` field to `Entry` struct |
| `internal/storage/schema.go` | Schema v2 migration: add `intent` column + rebuild FTS5 |
| `internal/storage/memory.go` | Update INSERT/SELECT/scan for `intent` column |
| `internal/memory/llm_extract.go` | **New** — LLM extraction, prompt template, in-memory cache |
| `internal/memory/extract.go` | Add `Extract()` mode switcher with fallback |
| `internal/config/config.go` | Add `ExtractionMode` to `MemoryConfig` |
| `internal/bot/handler.go` | Update call site to use `Extract()` |
| `internal/bot/bot.go` | Create Anthropic client for extraction |
| `internal/gateway/methods.go` | Add `Completer`/`ExtractionMode` to `Deps`, update call site |
| `cmd/bomclaw/main.go` | Wire Completer into gateway deps |
| `internal/memory/memory_test.go` | Tests for mode switching, cache, JSON parsing |

## Implementation Steps
- [x] Step 1: Add non-streaming Complete() to Anthropic client
- [x] Step 2: Add `intent` field to Entry struct
- [x] Step 3: Update SQLite storage + schema migration v1→v2
- [x] Step 4: Design extraction prompt template
- [x] Step 5: Implement LLM-based extraction function
- [x] Step 6: Add config `memory.extraction_mode`
- [x] Step 7: Implement extraction mode switching + fallback
- [x] Step 8: Update call sites (handler.go + methods.go)
- [x] Step 9: Cache extraction results (in-memory, 100 entries, 1h TTL)
- [x] Step 10: Tests + verification

## Verification
- [x] `go build ./cmd/bomclaw/` passes
- [x] `go vet` passes (affected packages)
- [x] `go test ./internal/memory/ ./internal/storage/ ./internal/bot/` — all pass
- [ ] Manual: set `extraction_mode: llm` in config, verify semantic extraction
- [ ] Manual: verify fallback khi LLM unavailable
- [ ] Manual: verify `intent` field in SQLite query

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)