### PR TITLE
feat: multi-session support with inline keyboard switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,13 @@ Once the gateway is running with a Telegram token:
 | Command | Description |
 |---|---|
 | `/start` | Show welcome and help |
+| `/sessions` | List and switch between sessions |
+| `/new` | Start a new conversation session |
 | `/models` | List available models with pricing |
 | `/model <name>` | Switch model (e.g. `/model opus`, `/model haiku`) |
 | `/model default` | Reset to default model |
 | `/status` | Show session info, token usage, queue depth |
-| `/reset` | Clear conversation history |
+| `/reset` | Clear current session history |
 | `/cancel` | Cancel in-flight request |
 
 ## Architecture
@@ -435,7 +437,7 @@ models:
 
 session:
   data_dir: ""                   # default: ~/.goterm/data
-  idle_timeout: 30               # minutes before auto-reset
+  # Sessions persist until explicit /reset command.
 
 security:
   allowed_user_ids: []           # Telegram user whitelist (empty = allow all)

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -185,7 +185,7 @@ func runGateway(args []string) {
 	defer db.Close()
 
 	// Session manager (SQLite-backed)
-	sessions := session.NewManager(storage.NewSessionStore(db), 0)
+	sessions := session.NewManager(storage.NewSessionStore(db))
 
 	// Gateway RPC server
 	addr := fmt.Sprintf("%s:%d", *bind, *port)

--- a/config.yaml
+++ b/config.yaml
@@ -86,7 +86,7 @@ models:
 
 session:
   data_dir: ""           # default: ~/.goterm/data
-  idle_timeout: 30       # minutes before session auto-reset
+  # Sessions persist until explicit /reset command — no auto-reset on idle.
 
 memory:
   enabled: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,10 +131,13 @@ internal/
 
 ### Session Lifecycle
 
-- Sessions are created per Telegram chat ID or per WebSocket client
-- Each session has its own conversation history and token count
-- Sessions persist to disk as JSON metadata + JSONL transcripts
-- Idle sessions auto-reset after the configured timeout (default: 30 min)
+- Each Telegram chat can have multiple sessions (up to 20)
+- One session is "active" at a time; messages are routed to the active session
+- Each session has its own Claude CLI conversation, message history, and token count
+- Sessions persist to disk (SQLite + JSONL transcripts) until explicitly reset via `/reset`
+- `/sessions` lists all sessions with inline keyboard buttons to switch
+- `/new` creates a new session and makes it active
+- Sessions are auto-labeled from the first user message
 
 ### Context Budget
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ models:
 
 session:
   data_dir: ""                   # Default: ~/.goterm/data
-  idle_timeout: 30               # Minutes before auto-reset
+  # Sessions persist until explicit /reset command.
 
 security:
   allowed_user_ids: []           # Telegram user whitelist (empty = all)
@@ -79,7 +79,6 @@ models:
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `data_dir` | string | `~/.goterm/data` | Directory for sessions and transcripts. |
-| `idle_timeout` | int | `30` | Minutes before a session auto-resets. |
 
 ### `security`
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -42,7 +42,9 @@ func New(cfg *config.Config) (*Bot, error) {
 	// Register commands with Telegram menu
 	commands := tgbotapi.NewSetMyCommands(
 		tgbotapi.BotCommand{Command: "start", Description: "Show welcome message and help"},
-		tgbotapi.BotCommand{Command: "reset", Description: "Clear conversation history"},
+		tgbotapi.BotCommand{Command: "sessions", Description: "List and switch sessions"},
+		tgbotapi.BotCommand{Command: "new", Description: "Start a new conversation"},
+		tgbotapi.BotCommand{Command: "reset", Description: "Clear current session"},
 		tgbotapi.BotCommand{Command: "status", Description: "Show session info"},
 		tgbotapi.BotCommand{Command: "models", Description: "List available models"},
 		tgbotapi.BotCommand{Command: "model", Description: "Switch model (e.g. /model sonnet)"},
@@ -71,9 +73,8 @@ func New(cfg *config.Config) (*Bot, error) {
 		return nil, fmt.Errorf("storage: %w", err)
 	}
 
-	// Session persistence (SQLite-backed)
-	idleTimeout := time.Duration(cfg.Session.IdleTimeout) * time.Minute
-	sessions := session.NewManager(storage.NewSessionStore(db), idleTimeout)
+	// Session persistence (SQLite-backed) — sessions persist until /reset.
+	sessions := session.NewManager(storage.NewSessionStore(db))
 
 	// Transcript writer (JSONL audit trail — kept alongside SQLite)
 	transcriptWriter := transcript.NewWriter(filepath.Join(cfg.Session.DataDir, "transcripts"))

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -124,7 +124,9 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 			"👋 *GoTerm Control*\n\n"+
 				"I'm your Mac AI assistant powered by Claude.\n\n"+
 				"Commands:\n"+
-				"• /reset — clear conversation history\n"+
+				"• /sessions — list & switch sessions\n"+
+				"• /new — start a new session\n"+
+				"• /reset — clear current session\n"+
 				"• /status — show session info\n"+
 				"• /models — list available models\n"+
 				"• /model `<name>` — switch model\n"+
@@ -136,6 +138,12 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 		h.sessions.Reset(chatID)
 		h.resolver.ClearOverride(chatID)
 		h.sendText(chatID, "🔄 Conversation history cleared.")
+
+	case "sessions", "session":
+		h.showSessionList(chatID)
+
+	case "new":
+		h.handleNewSession(chatID)
 
 	case "status":
 		h.showStatus(chatID)
@@ -169,15 +177,23 @@ func (h *Handler) showStatus(chatID int64) {
 	if m != nil {
 		modelName = m.ID
 	}
+	label := sess.GetLabel()
+	if label == "" {
+		label = sess.ID
+	}
+	sessionCount := len(h.sessions.ListForChat(chatID))
 	h.sendText(chatID, fmt.Sprintf(
 		"📊 *Session Status*\n\n"+
 			"Chat ID: `%d`\n"+
+			"Active: %s\n"+
+			"Sessions: %d total\n"+
 			"Turns: %d\n"+
-			"Session: `%s`\n"+
+			"Claude: `%s`\n"+
 			"Model: `%s`\n"+
 			"Tokens: %d in / %d out\n"+
 			"Queue: %d pending",
-		chatID, sess.GetMessageCount(), sessionID, modelName,
+		chatID, label, sessionCount,
+		sess.GetMessageCount(), sessionID, modelName,
 		sess.InputTokens, sess.OutputTokens,
 		h.engine.QueueDepth(chatID),
 	))
@@ -280,9 +296,8 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 		return
 	}
 
-	// Inject recent conversation history when starting a fresh session
-	// (e.g. after idle timeout reset) so Claude has context for follow-ups
-	// like "Run lại thử" after a previous "push crypto-radar" message.
+	// Inject recent conversation history when starting a brand-new session
+	// (first message or after explicit /reset) so Claude has some context.
 	historyContext := ""
 	if sess.GetSessionID() == "" {
 		historyContext = h.buildHistoryContext(sess.ID, 8)
@@ -404,6 +419,11 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		}
 	}
 
+	// Auto-label session from first user message
+	if sess.GetLabel() == "" && userText != "" {
+		sess.SetLabel(truncateLabel(userText, 40))
+	}
+
 	// Mark session dirty for persistence
 	h.sessions.MarkDirty()
 
@@ -418,6 +438,14 @@ func (h *Handler) handleCallback(cb *tgbotapi.CallbackQuery) {
 	answer := tgbotapi.NewCallback(cb.ID, "")
 	_, _ = h.bot.Request(answer)
 
+	// Session selection callback
+	if strings.HasPrefix(data, "sess:") {
+		sessionID := strings.TrimPrefix(data, "sess:")
+		h.handleSessionSwitch(chatID, sessionID, cb.Message.MessageID)
+		return
+	}
+
+	// Approval callback
 	h.approvalMu.Lock()
 	ch, ok := h.approvalRequests[data]
 	if ok {
@@ -441,6 +469,80 @@ func (h *Handler) handleCallback(cb *tgbotapi.CallbackQuery) {
 	}
 	edit := tgbotapi.NewEditMessageText(chatID, cb.Message.MessageID, label)
 	_, _ = h.bot.Send(edit)
+}
+
+// --- Session management ---
+
+func (h *Handler) showSessionList(chatID int64) {
+	sessions := h.sessions.ListForChat(chatID)
+	if len(sessions) == 0 {
+		h.sendText(chatID, "No sessions yet. Send a message to start.")
+		return
+	}
+
+	activeID := h.sessions.ActiveSessionID(chatID)
+
+	var rows [][]tgbotapi.InlineKeyboardButton
+	for _, s := range sessions {
+		label := s.GetLabel()
+		if label == "" {
+			label = fmt.Sprintf("Session %d", s.Seq)
+		}
+
+		btnText := fmt.Sprintf("%s (%d msgs)", label, s.GetMessageCount())
+		if s.ID == activeID {
+			btnText = "✅ " + btnText
+		}
+
+		rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(btnText, "sess:"+s.ID),
+		))
+	}
+
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(rows...)
+	msg := tgbotapi.NewMessage(chatID, "📋 *Sessions* — tap to switch:")
+	msg.ParseMode = "Markdown"
+	msg.ReplyMarkup = keyboard
+	h.bot.Send(msg)
+}
+
+func (h *Handler) handleNewSession(chatID int64) {
+	sess, err := h.sessions.NewSession(chatID)
+	if err != nil {
+		h.sendText(chatID, fmt.Sprintf("❌ %v", err))
+		return
+	}
+	h.sendText(chatID, fmt.Sprintf("✨ New session created (Session %d). Send a message to start.", sess.Seq))
+}
+
+func (h *Handler) handleSessionSwitch(chatID int64, sessionID string, msgID int) {
+	if err := h.sessions.SwitchActive(chatID, sessionID); err != nil {
+		h.sendText(chatID, fmt.Sprintf("❌ %v", err))
+		return
+	}
+	sess := h.sessions.Get(chatID)
+	label := sess.GetLabel()
+	if label == "" {
+		label = fmt.Sprintf("Session %d", sess.Seq)
+	}
+
+	text := fmt.Sprintf("Switched to: *%s* (%d messages)", label, sess.GetMessageCount())
+	edit := tgbotapi.NewEditMessageText(chatID, msgID, text)
+	edit.ParseMode = "Markdown"
+	h.bot.Send(edit)
+}
+
+// truncateLabel returns first line of text, truncated to maxRunes.
+func truncateLabel(text string, maxRunes int) string {
+	if idx := strings.IndexByte(text, '\n'); idx >= 0 {
+		text = text[:idx]
+	}
+	text = strings.TrimSpace(text)
+	r := []rune(text)
+	if len(r) > maxRunes {
+		return string(r[:maxRunes]) + "..."
+	}
+	return text
 }
 
 // toolLabel creates a short label like Bash(cd stock_d) or Read(bot/handler.go)
@@ -591,9 +693,8 @@ func (h *Handler) sendText(chatID int64, text string) int {
 }
 
 // buildHistoryContext loads recent messages from the store and formats them
-// as a conversation summary for context injection into new sessions.
-// This ensures follow-up messages like "Run lại thử" retain context from
-// previous turns even after an idle-timeout session reset.
+// as a conversation summary for context injection into brand-new sessions
+// (first message or after explicit /reset).
 func (h *Handler) buildHistoryContext(sessionID string, limit int) string {
 	if h.messages == nil {
 		return ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,8 +65,7 @@ type ToolsConfig struct {
 }
 
 type SessionConfig struct {
-	DataDir     string `yaml:"data_dir"`
-	IdleTimeout int    `yaml:"idle_timeout"` // minutes
+	DataDir string `yaml:"data_dir"`
 }
 
 func Load(path string) (*Config, error) {
@@ -117,9 +116,6 @@ func Load(path string) (*Config, error) {
 	if cfg.Session.DataDir == "" {
 		home, _ := os.UserHomeDir()
 		cfg.Session.DataDir = home + "/.goterm/data"
-	}
-	if cfg.Session.IdleTimeout == 0 {
-		cfg.Session.IdleTimeout = 30
 	}
 	if cfg.Telegram.Indicator.Enabled {
 		if len(cfg.Telegram.Indicator.Frames) == 0 {

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -80,6 +80,8 @@ type SessionInfo struct {
 	OutputTokens    int    `json:"output_tokens"`
 	CreatedAt       string `json:"created_at"`
 	UpdatedAt       string `json:"updated_at"`
+	Label           string `json:"label,omitempty"`
+	Seq             int    `json:"seq"`
 }
 
 func sessionToInfo(s *session.Session) SessionInfo {
@@ -92,6 +94,8 @@ func sessionToInfo(s *session.Session) SessionInfo {
 		OutputTokens:    s.OutputTokens,
 		CreatedAt:       s.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:       s.UpdatedAt.Format(time.RFC3339),
+		Label:           s.GetLabel(),
+		Seq:             s.Seq,
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1,24 +1,34 @@
 package session
 
 import (
+	"fmt"
 	"log"
+	"sort"
 	"sync"
 	"time"
 )
 
-// SessionPersister is the interface for session persistence backends.
-// Both the JSON file Store and SQLite store implement this.
-type SessionPersister interface {
-	Load() (map[int64]*Session, error)
-	Save(sessions map[int64]*Session) error
+// MaxSessionsPerChat is the maximum number of sessions allowed per chat.
+const MaxSessionsPerChat = 20
+
+// ChatState tracks all sessions and the active session for a single chat.
+type ChatState struct {
+	ActiveSessionID string
+	NextSeq         int
+	Sessions        map[string]*Session // keyed by session ID
 }
 
-// Manager stores sessions keyed by chat ID with disk persistence and idle reset.
+// SessionPersister is the interface for session persistence backends.
+type SessionPersister interface {
+	Load() (map[int64]*ChatState, error)
+	Save(chats map[int64]*ChatState) error
+}
+
+// Manager stores sessions keyed by chat ID with disk persistence.
 type Manager struct {
-	mu          sync.RWMutex
-	sessions    map[int64]*Session
-	store       SessionPersister
-	idleTimeout time.Duration
+	mu    sync.RWMutex
+	chats map[int64]*ChatState
+	store SessionPersister
 
 	// Debounced save: after any mutation, schedule a save after saveCooldown.
 	saveMu    sync.Mutex
@@ -26,13 +36,12 @@ type Manager struct {
 	dirty     bool
 }
 
-// NewManager creates a manager with persistence and idle timeout.
+// NewManager creates a manager with persistence.
 // If store is nil, sessions are in-memory only.
-func NewManager(store SessionPersister, idleTimeout time.Duration) *Manager {
+func NewManager(store SessionPersister) *Manager {
 	m := &Manager{
-		sessions:    make(map[int64]*Session),
-		store:       store,
-		idleTimeout: idleTimeout,
+		chats: make(map[int64]*ChatState),
+		store: store,
 	}
 
 	if store != nil {
@@ -40,43 +49,142 @@ func NewManager(store SessionPersister, idleTimeout time.Duration) *Manager {
 		if err != nil {
 			log.Printf("session: failed to load from disk: %v", err)
 		} else {
-			m.sessions = loaded
-			log.Printf("session: loaded %d sessions from disk", len(loaded))
+			m.chats = loaded
+			total := 0
+			for _, cs := range loaded {
+				total += len(cs.Sessions)
+			}
+			log.Printf("session: loaded %d chats (%d sessions) from disk", len(loaded), total)
 		}
 	}
 
 	return m
 }
 
-// Get returns existing session or creates a new one.
-// Automatically resets sessions that have been idle longer than idleTimeout.
+// Get returns the active session for a chat, creating a new ChatState if needed.
+// This is the hot path — all existing callers continue to work unchanged.
 func (m *Manager) Get(chatID int64) *Session {
 	m.mu.RLock()
-	s, ok := m.sessions[chatID]
+	cs, ok := m.chats[chatID]
 	m.mu.RUnlock()
 
 	if ok {
-		if m.idleTimeout > 0 && time.Since(s.UpdatedAt) > m.idleTimeout {
-			log.Printf("session: idle reset chat_%d (idle %s)", chatID, time.Since(s.UpdatedAt).Round(time.Second))
-			s.Reset()
-			m.scheduleSave()
+		if s, exists := cs.Sessions[cs.ActiveSessionID]; exists {
+			return s
 		}
-		return s
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Double-check after acquiring write lock
-	if s, ok = m.sessions[chatID]; ok {
-		return s
+	if cs, ok = m.chats[chatID]; ok {
+		if s, exists := cs.Sessions[cs.ActiveSessionID]; exists {
+			return s
+		}
 	}
-	s = New(chatID)
-	m.sessions[chatID] = s
+
+	s := New(chatID)
+	m.chats[chatID] = &ChatState{
+		ActiveSessionID: s.ID,
+		NextSeq:         1,
+		Sessions:        map[string]*Session{s.ID: s},
+	}
 	m.scheduleSave()
 	return s
 }
 
-// ReloadFromDisk re-reads sessions.json, merging any new sessions from other processes.
+// GetByID returns a specific session by its ID, or nil if not found.
+func (m *Manager) GetByID(sessionID string) *Session {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, cs := range m.chats {
+		if s, ok := cs.Sessions[sessionID]; ok {
+			return s
+		}
+	}
+	return nil
+}
+
+// ListForChat returns all sessions for a chat, sorted by UpdatedAt descending.
+func (m *Manager) ListForChat(chatID int64) []*Session {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cs, ok := m.chats[chatID]
+	if !ok {
+		return nil
+	}
+
+	out := make([]*Session, 0, len(cs.Sessions))
+	for _, s := range cs.Sessions {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out
+}
+
+// NewSession creates a new session for a chat and makes it active.
+// Returns error if the session limit is exceeded.
+func (m *Manager) NewSession(chatID int64) (*Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cs, ok := m.chats[chatID]
+	if !ok {
+		// No chat state yet — create one with the first session.
+		s := New(chatID)
+		m.chats[chatID] = &ChatState{
+			ActiveSessionID: s.ID,
+			NextSeq:         1,
+			Sessions:        map[string]*Session{s.ID: s},
+		}
+		m.scheduleSave()
+		return s, nil
+	}
+
+	if len(cs.Sessions) >= MaxSessionsPerChat {
+		return nil, fmt.Errorf("session limit reached (%d)", MaxSessionsPerChat)
+	}
+
+	seq := cs.NextSeq
+	s := NewWithSeq(chatID, seq)
+	cs.Sessions[s.ID] = s
+	cs.ActiveSessionID = s.ID
+	cs.NextSeq = seq + 1
+	m.scheduleSave()
+	return s, nil
+}
+
+// SwitchActive changes the active session for a chat.
+func (m *Manager) SwitchActive(chatID int64, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cs, ok := m.chats[chatID]
+	if !ok {
+		return fmt.Errorf("no sessions for chat %d", chatID)
+	}
+	if _, exists := cs.Sessions[sessionID]; !exists {
+		return fmt.Errorf("session %s not found in chat %d", sessionID, chatID)
+	}
+	cs.ActiveSessionID = sessionID
+	m.scheduleSave()
+	return nil
+}
+
+// ActiveSessionID returns the active session ID for a chat, or "".
+func (m *Manager) ActiveSessionID(chatID int64) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if cs, ok := m.chats[chatID]; ok {
+		return cs.ActiveSessionID
+	}
+	return ""
+}
+
+// ReloadFromDisk re-reads stored data, merging any new sessions from other processes.
 func (m *Manager) ReloadFromDisk() {
 	if m.store == nil {
 		return
@@ -87,38 +195,35 @@ func (m *Manager) ReloadFromDisk() {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for chatID, s := range loaded {
-		if _, ok := m.sessions[chatID]; !ok {
-			m.sessions[chatID] = s
-		} else if s.UpdatedAt.After(m.sessions[chatID].UpdatedAt) {
-			// Update if disk version is newer (another process wrote it)
-			existing := m.sessions[chatID]
-			existing.ClaudeSessionID = s.ClaudeSessionID
-			existing.MessageCount = s.MessageCount
-			existing.InputTokens = s.InputTokens
-			existing.OutputTokens = s.OutputTokens
-			existing.UpdatedAt = s.UpdatedAt
+	for chatID, lcs := range loaded {
+		if _, ok := m.chats[chatID]; !ok {
+			m.chats[chatID] = lcs
 		}
 	}
 }
 
-// List returns all active sessions.
+// List returns all sessions across all chats.
 func (m *Manager) List() []*Session {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	out := make([]*Session, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		out = append(out, s)
+	var out []*Session
+	for _, cs := range m.chats {
+		for _, s := range cs.Sessions {
+			out = append(out, s)
+		}
 	}
 	return out
 }
 
-// Reset clears history for a chat.
+// Reset clears history for the active session in a chat.
 func (m *Manager) Reset(chatID int64) {
 	m.mu.RLock()
-	s, ok := m.sessions[chatID]
+	cs, ok := m.chats[chatID]
 	m.mu.RUnlock()
-	if ok {
+	if !ok {
+		return
+	}
+	if s, exists := cs.Sessions[cs.ActiveSessionID]; exists {
 		s.Reset()
 		m.scheduleSave()
 	}
@@ -143,13 +248,17 @@ func (m *Manager) SaveNow() {
 	m.saveMu.Unlock()
 
 	m.mu.RLock()
-	sessions := m.sessions
+	chats := m.chats
 	m.mu.RUnlock()
 
-	if err := m.store.Save(sessions); err != nil {
+	if err := m.store.Save(chats); err != nil {
 		log.Printf("session: save error: %v", err)
 	} else {
-		log.Printf("session: saved %d sessions to disk", len(sessions))
+		total := 0
+		for _, cs := range chats {
+			total += len(cs.Sessions)
+		}
+		log.Printf("session: saved %d chats (%d sessions) to disk", len(chats), total)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -17,6 +17,8 @@ type Session struct {
 	InputTokens     int       `json:"input_tokens"`
 	OutputTokens    int       `json:"output_tokens"`
 	CompactSummary  string    `json:"compact_summary,omitempty"`
+	Label           string    `json:"label,omitempty"`
+	Seq             int       `json:"seq"`
 
 	mu       sync.Mutex `json:"-"`
 	cancelFn func()     `json:"-"`
@@ -33,6 +35,8 @@ type SessionSnapshot struct {
 	InputTokens     int
 	OutputTokens    int
 	CompactSummary  string
+	Label           string
+	Seq             int
 }
 
 func New(chatID int64) *Session {
@@ -40,6 +44,19 @@ func New(chatID int64) *Session {
 	return &Session{
 		ID:        fmt.Sprintf("chat_%d", chatID),
 		ChatID:    chatID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// NewWithSeq creates a session with a sequence number.
+// ID format: chat_<chatID>_<seq> (e.g. chat_123_1).
+func NewWithSeq(chatID int64, seq int) *Session {
+	now := time.Now()
+	return &Session{
+		ID:        fmt.Sprintf("chat_%d_%d", chatID, seq),
+		ChatID:    chatID,
+		Seq:       seq,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -81,6 +98,21 @@ func (s *Session) AddTokens(input, output int) {
 	defer s.mu.Unlock()
 	s.InputTokens += input
 	s.OutputTokens += output
+	s.UpdatedAt = time.Now()
+}
+
+// GetLabel returns the human-readable session label.
+func (s *Session) GetLabel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Label
+}
+
+// SetLabel sets the human-readable session label.
+func (s *Session) SetLabel(label string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Label = label
 	s.UpdatedAt = time.Now()
 }
 
@@ -126,11 +158,13 @@ func (s *Session) Snapshot() SessionSnapshot {
 		InputTokens:     s.InputTokens,
 		OutputTokens:    s.OutputTokens,
 		CompactSummary:  s.CompactSummary,
+		Label:           s.Label,
+		Seq:             s.Seq,
 	}
 }
 
 // NewFromDB creates a Session from database fields (used by SQLite store).
-func NewFromDB(id string, chatID int64, created, updated time.Time, claudeSessionID string, msgCount, inTok, outTok int, compactSummary string) *Session {
+func NewFromDB(id string, chatID int64, created, updated time.Time, claudeSessionID string, msgCount, inTok, outTok int, compactSummary, label string, seq int) *Session {
 	return &Session{
 		ID:              id,
 		ChatID:          chatID,
@@ -141,6 +175,8 @@ func NewFromDB(id string, chatID int64, created, updated time.Time, claudeSessio
 		InputTokens:     inTok,
 		OutputTokens:    outTok,
 		CompactSummary:  compactSummary,
+		Label:           label,
+		Seq:             seq,
 	}
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -18,43 +18,71 @@ func NewStore(path string) *Store {
 	return &Store{path: path}
 }
 
-// sessionData is the serializable form (keyed by chatID as string).
-type sessionData map[string]*Session
+// chatStateData is the serializable form for multi-session storage.
+type chatStateData struct {
+	ActiveSessionID string              `json:"active_session_id"`
+	NextSeq         int                 `json:"next_seq"`
+	Sessions        map[string]*Session `json:"sessions"`
+}
 
 // Load reads sessions from disk. Returns empty map if file does not exist.
-func (s *Store) Load() (map[int64]*Session, error) {
+// Backward compatible: detects old flat-session format and wraps in ChatState.
+func (s *Store) Load() (map[int64]*ChatState, error) {
 	data, err := os.ReadFile(s.path)
 	if os.IsNotExist(err) {
-		return make(map[int64]*Session), nil
+		return make(map[int64]*ChatState), nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("read sessions: %w", err)
 	}
 
-	var raw sessionData
-	if err := json.Unmarshal(data, &raw); err != nil {
+	// Try new format first: map[string]chatStateData
+	var newRaw map[string]*chatStateData
+	if err := json.Unmarshal(data, &newRaw); err == nil {
+		// Check if this is actually the new format (has "sessions" key in values)
+		if isNewFormat(newRaw) {
+			return convertNewFormat(newRaw), nil
+		}
+	}
+
+	// Fall back to old format: map[string]*Session (flat)
+	var oldRaw map[string]*Session
+	if err := json.Unmarshal(data, &oldRaw); err != nil {
 		return nil, fmt.Errorf("parse sessions: %w", err)
 	}
 
-	sessions := make(map[int64]*Session, len(raw))
-	for _, sess := range raw {
-		sessions[sess.ChatID] = sess
+	chats := make(map[int64]*ChatState, len(oldRaw))
+	for _, sess := range oldRaw {
+		chats[sess.ChatID] = &ChatState{
+			ActiveSessionID: sess.ID,
+			NextSeq:         1,
+			Sessions:        map[string]*Session{sess.ID: sess},
+		}
 	}
-	return sessions, nil
+	return chats, nil
 }
 
 // Save writes sessions to disk atomically (write tmp then rename).
-func (s *Store) Save(sessions map[int64]*Session) error {
+func (s *Store) Save(chats map[int64]*ChatState) error {
 	dir := filepath.Dir(s.path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 
-	raw := make(sessionData, len(sessions))
-	for _, sess := range sessions {
-		sess.mu.Lock()
-		raw[sess.ID] = sess
-		sess.mu.Unlock()
+	raw := make(map[string]*chatStateData, len(chats))
+	for chatID, cs := range chats {
+		key := fmt.Sprintf("%d", chatID)
+		sessions := make(map[string]*Session, len(cs.Sessions))
+		for id, sess := range cs.Sessions {
+			sess.mu.Lock()
+			sessions[id] = sess
+			sess.mu.Unlock()
+		}
+		raw[key] = &chatStateData{
+			ActiveSessionID: cs.ActiveSessionID,
+			NextSeq:         cs.NextSeq,
+			Sessions:        sessions,
+		}
 	}
 
 	data, err := json.MarshalIndent(raw, "", "  ")
@@ -72,4 +100,37 @@ func (s *Store) Save(sessions map[int64]*Session) error {
 		return fmt.Errorf("rename: %w", err)
 	}
 	return nil
+}
+
+// isNewFormat checks if the parsed data has the ChatState structure.
+func isNewFormat(raw map[string]*chatStateData) bool {
+	for _, v := range raw {
+		if v != nil && v.Sessions != nil {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// convertNewFormat converts parsed new-format data to the ChatState map.
+func convertNewFormat(raw map[string]*chatStateData) map[int64]*ChatState {
+	chats := make(map[int64]*ChatState, len(raw))
+	for _, csd := range raw {
+		if csd == nil || len(csd.Sessions) == 0 {
+			continue
+		}
+		// Get chatID from the first session
+		var chatID int64
+		for _, sess := range csd.Sessions {
+			chatID = sess.ChatID
+			break
+		}
+		chats[chatID] = &ChatState{
+			ActiveSessionID: csd.ActiveSessionID,
+			NextSeq:         csd.NextSeq,
+			Sessions:        csd.Sessions,
+		}
+	}
+	return chats
 }

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -12,33 +11,39 @@ func TestStoreRoundtrip(t *testing.T) {
 	path := filepath.Join(dir, "sessions.json")
 	store := NewStore(path)
 
-	// Create sessions
-	sessions := map[int64]*Session{
-		100: {ID: "chat_100", ChatID: 100, CreatedAt: time.Now(), UpdatedAt: time.Now(), ClaudeSessionID: "abc123", MessageCount: 5, InputTokens: 1000, OutputTokens: 500},
-		200: {ID: "chat_200", ChatID: 200, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	// Create sessions as ChatState map
+	chats := map[int64]*ChatState{
+		100: {
+			ActiveSessionID: "chat_100",
+			NextSeq:         1,
+			Sessions: map[string]*Session{
+				"chat_100": {ID: "chat_100", ChatID: 100, CreatedAt: time.Now(), UpdatedAt: time.Now(), ClaudeSessionID: "abc123", MessageCount: 5, InputTokens: 1000, OutputTokens: 500},
+			},
+		},
+		200: {
+			ActiveSessionID: "chat_200",
+			NextSeq:         1,
+			Sessions: map[string]*Session{
+				"chat_200": {ID: "chat_200", ChatID: 200, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			},
+		},
 	}
 
-	// Save
-	if err := store.Save(sessions); err != nil {
+	if err := store.Save(chats); err != nil {
 		t.Fatalf("save: %v", err)
 	}
 
-	// Verify file exists
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("file not created: %v", err)
-	}
-
-	// Load
 	loaded, err := store.Load()
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
 
 	if len(loaded) != 2 {
-		t.Fatalf("expected 2 sessions, got %d", len(loaded))
+		t.Fatalf("expected 2 chats, got %d", len(loaded))
 	}
 
-	s := loaded[100]
+	cs := loaded[100]
+	s := cs.Sessions["chat_100"]
 	if s.ClaudeSessionID != "abc123" {
 		t.Errorf("expected session ID abc123, got %s", s.ClaudeSessionID)
 	}
@@ -52,21 +57,20 @@ func TestStoreRoundtrip(t *testing.T) {
 
 func TestStoreLoadMissing(t *testing.T) {
 	store := NewStore("/nonexistent/sessions.json")
-	sessions, err := store.Load()
+	chats, err := store.Load()
 	if err != nil {
 		t.Fatalf("expected nil error for missing file, got: %v", err)
 	}
-	if len(sessions) != 0 {
-		t.Fatalf("expected empty map, got %d", len(sessions))
+	if len(chats) != 0 {
+		t.Fatalf("expected empty map, got %d", len(chats))
 	}
 }
 
-func TestManagerIdleReset(t *testing.T) {
+func TestManagerSessionPersistsUntilReset(t *testing.T) {
 	dir := t.TempDir()
 	store := NewStore(filepath.Join(dir, "sessions.json"))
 
-	// 1ms idle timeout for testing
-	mgr := NewManager(store, 1*time.Millisecond)
+	mgr := NewManager(store)
 
 	sess := mgr.Get(100)
 	sess.SetSessionID("original-session")
@@ -74,7 +78,81 @@ func TestManagerIdleReset(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	sess2 := mgr.Get(100)
-	if sess2.GetSessionID() != "" {
-		t.Errorf("expected empty session after idle reset, got %s", sess2.GetSessionID())
+	if sess2.GetSessionID() != "original-session" {
+		t.Errorf("expected session to persist, got %q", sess2.GetSessionID())
+	}
+
+	mgr.Reset(100)
+	sess3 := mgr.Get(100)
+	if sess3.GetSessionID() != "" {
+		t.Errorf("expected empty session after explicit reset, got %s", sess3.GetSessionID())
+	}
+}
+
+func TestManagerMultiSession(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "sessions.json"))
+	mgr := NewManager(store)
+
+	// First session auto-created on Get
+	s1 := mgr.Get(100)
+	s1.SetSessionID("claude-1")
+	s1.SetLabel("First chat")
+
+	// Create second session
+	s2, err := mgr.NewSession(100)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	s2.SetSessionID("claude-2")
+	s2.SetLabel("Second chat")
+
+	// Active session should be s2 now
+	active := mgr.Get(100)
+	if active.GetSessionID() != "claude-2" {
+		t.Errorf("active = %q, want claude-2", active.GetSessionID())
+	}
+
+	// List should return both
+	list := mgr.ListForChat(100)
+	if len(list) != 2 {
+		t.Fatalf("ListForChat = %d, want 2", len(list))
+	}
+
+	// Switch back to s1
+	if err := mgr.SwitchActive(100, s1.ID); err != nil {
+		t.Fatalf("SwitchActive: %v", err)
+	}
+	active = mgr.Get(100)
+	if active.GetSessionID() != "claude-1" {
+		t.Errorf("after switch, active = %q, want claude-1", active.GetSessionID())
+	}
+
+	// Reset only resets active session
+	mgr.Reset(100)
+	if mgr.Get(100).GetSessionID() != "" {
+		t.Error("expected active session reset")
+	}
+	// s2 should still be intact
+	s2check := mgr.GetByID(s2.ID)
+	if s2check.GetSessionID() != "claude-2" {
+		t.Errorf("s2 should be intact, got %q", s2check.GetSessionID())
+	}
+}
+
+func TestManagerSessionLimit(t *testing.T) {
+	mgr := NewManager(nil) // in-memory only
+
+	mgr.Get(100) // creates first session
+	for i := 1; i < MaxSessionsPerChat; i++ {
+		if _, err := mgr.NewSession(100); err != nil {
+			t.Fatalf("NewSession %d: %v", i, err)
+		}
+	}
+
+	// Should fail at the limit
+	_, err := mgr.NewSession(100)
+	if err == nil {
+		t.Error("expected error at session limit")
 	}
 }

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -33,7 +33,7 @@ func TestSchemaCreation(t *testing.T) {
 	db := testDB(t)
 
 	// Verify tables exist
-	tables := []string{"meta", "sessions", "messages"}
+	tables := []string{"meta", "sessions", "messages", "chat_state"}
 	for _, table := range tables {
 		var name string
 		err := db.conn.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name)
@@ -54,33 +54,48 @@ func TestSchemaCreation(t *testing.T) {
 
 // --- Session Store Tests ---
 
+// helper to wrap a single session into ChatState map for Save().
+func chatStates(sessions ...*session.Session) map[int64]*session.ChatState {
+	chats := make(map[int64]*session.ChatState)
+	for _, s := range sessions {
+		cs, ok := chats[s.ChatID]
+		if !ok {
+			cs = &session.ChatState{
+				ActiveSessionID: s.ID,
+				NextSeq:         1,
+				Sessions:        make(map[string]*session.Session),
+			}
+			chats[s.ChatID] = cs
+		}
+		cs.Sessions[s.ID] = s
+	}
+	return chats
+}
+
 func TestSessionStoreRoundtrip(t *testing.T) {
 	db := testDB(t)
 	store := NewSessionStore(db)
 
-	// Save sessions
-	sessions := map[int64]*session.Session{
-		100: session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_abc", 5, 1000, 500, "summary text"),
-		200: session.NewFromDB("chat_200", 200, time.Now(), time.Now(), "", 0, 0, 0, ""),
-	}
+	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_abc", 5, 1000, 500, "summary text", "First chat", 0)
+	s2 := session.NewFromDB("chat_200", 200, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
 
-	if err := store.Save(sessions); err != nil {
+	if err := store.Save(chatStates(s1, s2)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
-	// Load sessions
 	loaded, err := store.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 
 	if len(loaded) != 2 {
-		t.Fatalf("loaded %d sessions, want 2", len(loaded))
+		t.Fatalf("loaded %d chats, want 2", len(loaded))
 	}
 
-	s := loaded[100]
-	if s.ID != "chat_100" {
-		t.Errorf("ID = %q, want chat_100", s.ID)
+	cs := loaded[100]
+	s := cs.Sessions["chat_100"]
+	if s == nil {
+		t.Fatal("session chat_100 not found")
 	}
 	if s.GetSessionID() != "claude_abc" {
 		t.Errorf("ClaudeSessionID = %q, want claude_abc", s.GetSessionID())
@@ -91,29 +106,70 @@ func TestSessionStoreRoundtrip(t *testing.T) {
 	if s.GetCompactSummary() != "summary text" {
 		t.Errorf("CompactSummary = %q, want 'summary text'", s.GetCompactSummary())
 	}
+	if s.GetLabel() != "First chat" {
+		t.Errorf("Label = %q, want 'First chat'", s.GetLabel())
+	}
 }
 
 func TestSessionStoreUpsert(t *testing.T) {
 	db := testDB(t)
 	store := NewSessionStore(db)
 
-	sessions := map[int64]*session.Session{
-		100: session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "v1", 1, 100, 50, ""),
-	}
-	store.Save(sessions)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "v1", 1, 100, 50, "", "", 0)
+	store.Save(chatStates(s))
 
 	// Update
-	sessions[100].SetSessionID("v2")
-	sessions[100].IncrementMessages()
-	store.Save(sessions)
+	s.SetSessionID("v2")
+	s.IncrementMessages()
+	store.Save(chatStates(s))
 
 	loaded, _ := store.Load()
-	s := loaded[100]
-	if s.GetSessionID() != "v2" {
-		t.Errorf("updated ClaudeSessionID = %q, want v2", s.GetSessionID())
+	cs := loaded[100]
+	ls := cs.Sessions["chat_100"]
+	if ls.GetSessionID() != "v2" {
+		t.Errorf("updated ClaudeSessionID = %q, want v2", ls.GetSessionID())
 	}
-	if s.GetMessageCount() != 2 {
-		t.Errorf("updated MessageCount = %d, want 2", s.GetMessageCount())
+	if ls.GetMessageCount() != 2 {
+		t.Errorf("updated MessageCount = %d, want 2", ls.GetMessageCount())
+	}
+}
+
+func TestSessionStoreMultipleSessionsPerChat(t *testing.T) {
+	db := testDB(t)
+	store := NewSessionStore(db)
+
+	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_1", 5, 100, 50, "", "Session 1", 0)
+	s2 := session.NewFromDB("chat_100_1", 100, time.Now(), time.Now(), "claude_2", 3, 200, 80, "", "Session 2", 1)
+
+	chats := map[int64]*session.ChatState{
+		100: {
+			ActiveSessionID: "chat_100_1",
+			NextSeq:         2,
+			Sessions:        map[string]*session.Session{"chat_100": s1, "chat_100_1": s2},
+		},
+	}
+
+	if err := store.Save(chats); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	cs := loaded[100]
+	if cs == nil {
+		t.Fatal("chat 100 not found")
+	}
+	if len(cs.Sessions) != 2 {
+		t.Fatalf("sessions = %d, want 2", len(cs.Sessions))
+	}
+	if cs.ActiveSessionID != "chat_100_1" {
+		t.Errorf("ActiveSessionID = %q, want chat_100_1", cs.ActiveSessionID)
+	}
+	if cs.NextSeq != 2 {
+		t.Errorf("NextSeq = %d, want 2", cs.NextSeq)
 	}
 }
 
@@ -124,13 +180,9 @@ func TestMessageStoreRoundtrip(t *testing.T) {
 	sessStore := NewSessionStore(db)
 	msgStore := NewMessageStore(db)
 
-	// Need a session first (foreign key)
-	sessions := map[int64]*session.Session{
-		100: session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, ""),
-	}
-	sessStore.Save(sessions)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	sessStore.Save(chatStates(s))
 
-	// Append messages
 	msgs := []agent.Message{
 		{Role: "user", Content: "Hello, how are you?"},
 		{Role: "assistant", Content: "I'm doing well, thanks!"},
@@ -143,7 +195,6 @@ func TestMessageStoreRoundtrip(t *testing.T) {
 		t.Fatalf("AppendBatch: %v", err)
 	}
 
-	// Load all
 	loaded, err := msgStore.LoadHistory("chat_100", 0)
 	if err != nil {
 		t.Fatalf("LoadHistory: %v", err)
@@ -165,17 +216,13 @@ func TestMessageStoreLimit(t *testing.T) {
 	sessStore := NewSessionStore(db)
 	msgStore := NewMessageStore(db)
 
-	sessions := map[int64]*session.Session{
-		100: session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, ""),
-	}
-	sessStore.Save(sessions)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	sessStore.Save(chatStates(s))
 
-	// Insert 10 messages
 	for i := 0; i < 10; i++ {
 		msgStore.Append("chat_100", agent.Message{Role: "user", Content: "msg"})
 	}
 
-	// Load last 3
 	loaded, err := msgStore.LoadHistory("chat_100", 3)
 	if err != nil {
 		t.Fatalf("LoadHistory limit: %v", err)
@@ -190,10 +237,8 @@ func TestMessageStoreDeleteBySession(t *testing.T) {
 	sessStore := NewSessionStore(db)
 	msgStore := NewMessageStore(db)
 
-	sessions := map[int64]*session.Session{
-		100: session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, ""),
-	}
-	sessStore.Save(sessions)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	sessStore.Save(chatStates(s))
 
 	msgStore.Append("chat_100", agent.Message{Role: "user", Content: "hello"})
 	msgStore.DeleteBySession("chat_100")
@@ -230,15 +275,17 @@ func TestMigrateFromJSON(t *testing.T) {
 
 	// Verify sessions imported
 	sessStore := NewSessionStore(db)
-	sessions, err := sessStore.Load()
+	chats, err := sessStore.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(sessions) != 1 {
-		t.Fatalf("imported %d sessions, want 1", len(sessions))
+	if len(chats) != 1 {
+		t.Fatalf("imported %d chats, want 1", len(chats))
 	}
-	if sessions[100].GetSessionID() != "sess_abc" {
-		t.Errorf("ClaudeSessionID = %q, want sess_abc", sessions[100].GetSessionID())
+	cs := chats[100]
+	s := cs.Sessions[cs.ActiveSessionID]
+	if s.GetSessionID() != "sess_abc" {
+		t.Errorf("ClaudeSessionID = %q, want sess_abc", s.GetSessionID())
 	}
 }
 
@@ -246,7 +293,6 @@ func TestOpenIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")
 
-	// Open twice — second open should not fail or re-create
 	db1, err := Open(path)
 	if err != nil {
 		t.Fatalf("first Open: %v", err)

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -59,17 +59,25 @@ func (db *DB) importSessions(path string) (int, error) {
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.Prepare(`INSERT OR IGNORE INTO sessions
-		(id, chat_id, created_at, updated_at, claude_session_id, message_count, input_tokens, output_tokens)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+	sessStmt, err := tx.Prepare(`INSERT OR IGNORE INTO sessions
+		(id, chat_id, created_at, updated_at, claude_session_id, message_count, input_tokens, output_tokens, label, seq)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', 0)`)
 	if err != nil {
 		return 0, err
 	}
-	defer stmt.Close()
+	defer sessStmt.Close()
+
+	csStmt, err := tx.Prepare(`INSERT OR IGNORE INTO chat_state
+		(chat_id, active_session_id, next_seq)
+		VALUES (?, ?, 1)`)
+	if err != nil {
+		return 0, err
+	}
+	defer csStmt.Close()
 
 	count := 0
 	for _, s := range raw {
-		_, err := stmt.Exec(
+		_, err := sessStmt.Exec(
 			s.ID, s.ChatID,
 			s.CreatedAt.Format(time.RFC3339), s.UpdatedAt.Format(time.RFC3339),
 			s.ClaudeSessionID, s.MessageCount, s.InputTokens, s.OutputTokens,
@@ -78,6 +86,7 @@ func (db *DB) importSessions(path string) (int, error) {
 			log.Printf("storage: skip session %s: %v", s.ID, err)
 			continue
 		}
+		csStmt.Exec(s.ChatID, s.ID)
 		count++
 	}
 

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -2,9 +2,9 @@ package storage
 
 import "fmt"
 
-const schemaVersion = 1
+const schemaVersion = 2
 
-// DDL statements executed in order.
+// DDL statements executed in order for fresh installs.
 var ddl = []string{
 	`CREATE TABLE IF NOT EXISTS meta (
 		key   TEXT PRIMARY KEY,
@@ -13,14 +13,23 @@ var ddl = []string{
 
 	`CREATE TABLE IF NOT EXISTS sessions (
 		id                TEXT PRIMARY KEY,
-		chat_id           INTEGER UNIQUE NOT NULL,
+		chat_id           INTEGER NOT NULL,
 		created_at        TEXT NOT NULL,
 		updated_at        TEXT NOT NULL,
 		claude_session_id TEXT DEFAULT '',
 		message_count     INTEGER DEFAULT 0,
 		input_tokens      INTEGER DEFAULT 0,
 		output_tokens     INTEGER DEFAULT 0,
-		compact_summary   TEXT DEFAULT ''
+		compact_summary   TEXT DEFAULT '',
+		label             TEXT DEFAULT '',
+		seq               INTEGER DEFAULT 0
+	)`,
+	`CREATE INDEX IF NOT EXISTS idx_sessions_chat ON sessions(chat_id)`,
+
+	`CREATE TABLE IF NOT EXISTS chat_state (
+		chat_id           INTEGER PRIMARY KEY,
+		active_session_id TEXT NOT NULL,
+		next_seq          INTEGER DEFAULT 1
 	)`,
 
 	`CREATE TABLE IF NOT EXISTS messages (
@@ -34,7 +43,6 @@ var ddl = []string{
 		created_at   TEXT NOT NULL
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, id)`,
-
 }
 
 // migrate creates tables and imports legacy data if needed.
@@ -52,13 +60,66 @@ func (db *DB) migrate() error {
 		return db.migrateFromLegacy()
 	}
 
-	if ver < schemaVersion {
-		if err := db.createTables(); err != nil {
-			return err
+	if ver < 2 {
+		if err := db.migrateV1ToV2(); err != nil {
+			return fmt.Errorf("migrate v1→v2: %w", err)
 		}
-		return db.setVersion(schemaVersion)
+		return db.setVersion(2)
 	}
 	return nil
+}
+
+// migrateV1ToV2 removes the UNIQUE constraint on chat_id, adds label/seq
+// columns, and creates the chat_state table.
+func (db *DB) migrateV1ToV2() error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmts := []string{
+		// Recreate sessions table without UNIQUE on chat_id, with new columns.
+		`CREATE TABLE IF NOT EXISTS sessions_new (
+			id                TEXT PRIMARY KEY,
+			chat_id           INTEGER NOT NULL,
+			created_at        TEXT NOT NULL,
+			updated_at        TEXT NOT NULL,
+			claude_session_id TEXT DEFAULT '',
+			message_count     INTEGER DEFAULT 0,
+			input_tokens      INTEGER DEFAULT 0,
+			output_tokens     INTEGER DEFAULT 0,
+			compact_summary   TEXT DEFAULT '',
+			label             TEXT DEFAULT '',
+			seq               INTEGER DEFAULT 0
+		)`,
+		`INSERT INTO sessions_new
+			SELECT id, chat_id, created_at, updated_at, claude_session_id,
+			       message_count, input_tokens, output_tokens, compact_summary,
+			       '', 0
+			FROM sessions`,
+		`DROP TABLE sessions`,
+		`ALTER TABLE sessions_new RENAME TO sessions`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_chat ON sessions(chat_id)`,
+
+		// Create chat_state table.
+		`CREATE TABLE IF NOT EXISTS chat_state (
+			chat_id           INTEGER PRIMARY KEY,
+			active_session_id TEXT NOT NULL,
+			next_seq          INTEGER DEFAULT 1
+		)`,
+
+		// Populate chat_state from existing sessions.
+		`INSERT OR IGNORE INTO chat_state (chat_id, active_session_id, next_seq)
+			SELECT chat_id, id, 1 FROM sessions`,
+	}
+
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("exec: %w\nstatement: %s", err, stmt)
+		}
+	}
+	return tx.Commit()
 }
 
 func (db *DB) createTables() error {

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -17,73 +17,156 @@ func NewSessionStore(db *DB) *SQLiteSessionStore {
 	return &SQLiteSessionStore{db: db}
 }
 
-// Load reads all sessions from the database, keyed by chat ID.
-func (s *SQLiteSessionStore) Load() (map[int64]*session.Session, error) {
+// Load reads all sessions and chat_state from the database.
+func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
+	// Load all sessions grouped by chat_id.
 	rows, err := s.db.conn.Query(`SELECT
 		id, chat_id, created_at, updated_at, claude_session_id,
-		message_count, input_tokens, output_tokens, compact_summary
+		message_count, input_tokens, output_tokens, compact_summary,
+		label, seq
 		FROM sessions`)
 	if err != nil {
 		return nil, fmt.Errorf("query sessions: %w", err)
 	}
 	defer rows.Close()
 
-	sessions := make(map[int64]*session.Session)
+	chats := make(map[int64]*session.ChatState)
 	for rows.Next() {
 		var (
-			id, claudeID, summary string
-			chatID                int64
-			createdStr, updatedStr string
-			msgCount, inTok, outTok int
+			id, claudeID, summary, label string
+			chatID                       int64
+			createdStr, updatedStr       string
+			msgCount, inTok, outTok, seq int
 		)
 		if err := rows.Scan(&id, &chatID, &createdStr, &updatedStr, &claudeID,
-			&msgCount, &inTok, &outTok, &summary); err != nil {
+			&msgCount, &inTok, &outTok, &summary, &label, &seq); err != nil {
 			continue
 		}
 
 		created, _ := time.Parse(time.RFC3339, createdStr)
 		updated, _ := time.Parse(time.RFC3339, updatedStr)
 
-		sess := session.NewFromDB(id, chatID, created, updated, claudeID, msgCount, inTok, outTok, summary)
-		sessions[chatID] = sess
+		sess := session.NewFromDB(id, chatID, created, updated, claudeID, msgCount, inTok, outTok, summary, label, seq)
+
+		cs, ok := chats[chatID]
+		if !ok {
+			cs = &session.ChatState{
+				NextSeq:  1,
+				Sessions: make(map[string]*session.Session),
+			}
+			chats[chatID] = cs
+		}
+		cs.Sessions[id] = sess
 	}
-	return sessions, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Load chat_state to get active session IDs and next_seq.
+	csRows, err := s.db.conn.Query(`SELECT chat_id, active_session_id, next_seq FROM chat_state`)
+	if err != nil {
+		// Table might not exist yet (first load before migration). Use defaults.
+		for chatID, cs := range chats {
+			if cs.ActiveSessionID == "" {
+				// Pick the most recently updated session as active.
+				cs.ActiveSessionID = pickMostRecent(cs.Sessions)
+			}
+			_ = chatID
+		}
+		return chats, nil
+	}
+	defer csRows.Close()
+
+	for csRows.Next() {
+		var chatID int64
+		var activeID string
+		var nextSeq int
+		if err := csRows.Scan(&chatID, &activeID, &nextSeq); err != nil {
+			continue
+		}
+		if cs, ok := chats[chatID]; ok {
+			cs.ActiveSessionID = activeID
+			cs.NextSeq = nextSeq
+		}
+	}
+
+	// For any chat without chat_state row, pick the most recent session.
+	for _, cs := range chats {
+		if cs.ActiveSessionID == "" {
+			cs.ActiveSessionID = pickMostRecent(cs.Sessions)
+		}
+	}
+
+	return chats, nil
 }
 
-// Save persists all sessions to the database in a single transaction.
-func (s *SQLiteSessionStore) Save(sessions map[int64]*session.Session) error {
+// Save persists all sessions and chat_state to the database.
+func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 	tx, err := s.db.conn.Begin()
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.Prepare(`INSERT INTO sessions
-		(id, chat_id, created_at, updated_at, claude_session_id, message_count, input_tokens, output_tokens, compact_summary)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	sessStmt, err := tx.Prepare(`INSERT INTO sessions
+		(id, chat_id, created_at, updated_at, claude_session_id,
+		 message_count, input_tokens, output_tokens, compact_summary, label, seq)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			updated_at = excluded.updated_at,
 			claude_session_id = excluded.claude_session_id,
 			message_count = excluded.message_count,
 			input_tokens = excluded.input_tokens,
 			output_tokens = excluded.output_tokens,
-			compact_summary = excluded.compact_summary`)
+			compact_summary = excluded.compact_summary,
+			label = excluded.label`)
 	if err != nil {
-		return fmt.Errorf("prepare: %w", err)
+		return fmt.Errorf("prepare sessions: %w", err)
 	}
-	defer stmt.Close()
+	defer sessStmt.Close()
 
-	for _, sess := range sessions {
-		snap := sess.Snapshot()
-		_, err := stmt.Exec(
-			snap.ID, snap.ChatID,
-			snap.CreatedAt.Format(time.RFC3339), snap.UpdatedAt.Format(time.RFC3339),
-			snap.ClaudeSessionID, snap.MessageCount,
-			snap.InputTokens, snap.OutputTokens, snap.CompactSummary,
-		)
-		if err != nil {
-			return fmt.Errorf("upsert session %s: %w", snap.ID, err)
+	csStmt, err := tx.Prepare(`INSERT INTO chat_state
+		(chat_id, active_session_id, next_seq)
+		VALUES (?, ?, ?)
+		ON CONFLICT(chat_id) DO UPDATE SET
+			active_session_id = excluded.active_session_id,
+			next_seq = excluded.next_seq`)
+	if err != nil {
+		return fmt.Errorf("prepare chat_state: %w", err)
+	}
+	defer csStmt.Close()
+
+	for chatID, cs := range chats {
+		for _, sess := range cs.Sessions {
+			snap := sess.Snapshot()
+			_, err := sessStmt.Exec(
+				snap.ID, snap.ChatID,
+				snap.CreatedAt.Format(time.RFC3339), snap.UpdatedAt.Format(time.RFC3339),
+				snap.ClaudeSessionID, snap.MessageCount,
+				snap.InputTokens, snap.OutputTokens, snap.CompactSummary,
+				snap.Label, snap.Seq,
+			)
+			if err != nil {
+				return fmt.Errorf("upsert session %s: %w", snap.ID, err)
+			}
+		}
+
+		if _, err := csStmt.Exec(chatID, cs.ActiveSessionID, cs.NextSeq); err != nil {
+			return fmt.Errorf("upsert chat_state for chat %d: %w", chatID, err)
 		}
 	}
 	return tx.Commit()
+}
+
+// pickMostRecent returns the ID of the most recently updated session.
+func pickMostRecent(sessions map[string]*session.Session) string {
+	var bestID string
+	var bestTime time.Time
+	for id, s := range sessions {
+		if s.UpdatedAt.After(bestTime) {
+			bestTime = s.UpdatedAt
+			bestID = id
+		}
+	}
+	return bestID
 }


### PR DESCRIPTION
## Summary

- Each Telegram chat can now have **multiple conversation sessions** (up to 20) instead of just one
- `/sessions` shows an inline keyboard to switch between sessions — active session marked with ✅
- `/new` creates a new session and switches to it immediately
- Sessions are **auto-labeled** from the first user message (40 char truncation)
- Removes idle auto-reset (sessions persist until explicit `/reset`)
- DB migration v1→v2: drops UNIQUE constraint on `chat_id`, adds `label`/`seq` columns and `chat_state` table

## New commands

| Command | Description |
|---------|-------------|
| `/sessions` | List sessions with inline keyboard to switch |
| `/new` | Create a new conversation session |

## Test plan

- [ ] `go build ./...` compiles (excluding pre-existing `internal/bds/` issue)
- [ ] `go test ./internal/session/ ./internal/storage/` — 15 tests pass
- [ ] Deploy and test in Telegram:
  - Send message → session auto-created, auto-labeled
  - `/sessions` → shows 1 session with inline button (marked ✅)
  - `/new` → creates new session, confirmation message
  - `/sessions` → shows 2 sessions, tap old one → switches back
  - `/reset` → only resets active session
- [ ] Existing single-session chats continue working (backward compatible via DB migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)