### PR TITLE
fix: session recovery + forward unknown slash commands to Claude

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -160,7 +160,10 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 		h.sendText(chatID, "🛑 Request cancelled.")
 
 	default:
-		h.sendText(chatID, fmt.Sprintf("Unknown command: /%s\n\nTry /start for help.", msg.Command()))
+		// Unknown slash commands are forwarded to Claude as-is.
+		// This lets users invoke custom Claude Code skills like /retro,
+		// /vops:plan, etc. defined in .claude/commands/.
+		h.handleMessage(msg)
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -81,8 +81,25 @@ func (m *Manager) Get(chatID int64) *Session {
 		if s, exists := cs.Sessions[cs.ActiveSessionID]; exists {
 			return s
 		}
+		// ChatState exists but ActiveSessionID is stale — recover by picking
+		// the most recently updated session instead of wiping all sessions.
+		if len(cs.Sessions) > 0 {
+			cs.ActiveSessionID = pickMostRecentSession(cs.Sessions)
+			m.scheduleSave()
+			return cs.Sessions[cs.ActiveSessionID]
+		}
+		// No sessions left in this ChatState — create a new one in place.
+		s := New(chatID)
+		cs.Sessions[s.ID] = s
+		cs.ActiveSessionID = s.ID
+		if cs.NextSeq < 1 {
+			cs.NextSeq = 1
+		}
+		m.scheduleSave()
+		return s
 	}
 
+	// Brand new chat — create ChatState with first session.
 	s := New(chatID)
 	m.chats[chatID] = &ChatState{
 		ActiveSessionID: s.ID,
@@ -91,6 +108,19 @@ func (m *Manager) Get(chatID int64) *Session {
 	}
 	m.scheduleSave()
 	return s
+}
+
+// pickMostRecentSession returns the ID of the most recently updated session.
+func pickMostRecentSession(sessions map[string]*Session) string {
+	var bestID string
+	var bestTime time.Time
+	for id, s := range sessions {
+		if s.UpdatedAt.After(bestTime) {
+			bestTime = s.UpdatedAt
+			bestID = id
+		}
+	}
+	return bestID
 }
 
 // GetByID returns a specific session by its ID, or nil if not found.

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -140,6 +140,43 @@ func TestManagerMultiSession(t *testing.T) {
 	}
 }
 
+// Regression test: if ActiveSessionID points to a non-existent session
+// (e.g. stale chat_state from migration), Get() must recover gracefully
+// instead of wiping all existing sessions in the ChatState.
+func TestManagerGetRecoversFromStaleActiveID(t *testing.T) {
+	mgr := NewManager(nil)
+
+	now := time.Now()
+	older := &Session{ID: "chat_100_old", ChatID: 100, ClaudeSessionID: "claude-old", UpdatedAt: now.Add(-time.Hour)}
+	newer := &Session{ID: "chat_100_new", ChatID: 100, ClaudeSessionID: "claude-new", UpdatedAt: now}
+
+	// Manually inject ChatState with a stale ActiveSessionID
+	mgr.chats[100] = &ChatState{
+		ActiveSessionID: "chat_100_missing", // does not exist in Sessions
+		NextSeq:         3,
+		Sessions: map[string]*Session{
+			"chat_100_old": older,
+			"chat_100_new": newer,
+		},
+	}
+
+	got := mgr.Get(100)
+	if got == nil {
+		t.Fatal("expected recovery, got nil session")
+	}
+	if got.ID != "chat_100_new" {
+		t.Errorf("expected most recent session chat_100_new, got %s", got.ID)
+	}
+
+	// Original sessions should still be present
+	if mgr.GetByID("chat_100_old") == nil {
+		t.Error("chat_100_old session lost after recovery")
+	}
+	if mgr.GetByID("chat_100_new") == nil {
+		t.Error("chat_100_new session lost after recovery")
+	}
+}
+
 func TestManagerSessionLimit(t *testing.T) {
 	mgr := NewManager(nil) // in-memory only
 


### PR DESCRIPTION
## Summary

Two related fixes for **context loss** issues users experienced in Telegram:

### 1. Manager.Get() wiped sessions on stale ActiveSessionID (commit `fb2a855`)

When ChatState.ActiveSessionID pointed to a session that no longer existed in cs.Sessions (data corruption, race condition, or migration edge case), Manager.Get() silently wiped all sessions for that chat by overwriting the entire ChatState with a fresh one.

Now Get() recovers gracefully:
1. If sessions exist → pick most recently updated as new active
2. If ChatState empty → create new session in place (preserve NextSeq)
3. Only allocate brand-new ChatState when chat has never been seen

### 2. Unknown slash commands rejected instead of forwarded (commit `b044c06`)

Custom Claude Code skills like \`/retro\`, \`/vops:plan\` defined in \`.claude/commands/\` were rejected with "Unknown command" — never reaching Claude. The bot's command router only knew its own built-ins (/start, /sessions, /new, /reset, /status, /models, /model, /cancel).

Now any unknown /command is forwarded to Claude as plain text via the normal message queue. Telegram includes the slash + arguments in msg.Text, so Claude receives the full invocation and dispatches to the appropriate skill.

## Test plan

- [x] \`go test ./internal/session/\` — new \`TestManagerGetRecoversFromStaleActiveID\` passes
- [x] All existing tests still pass
- [x] \`go build ./...\` clean
- [ ] Deploy and verify in Telegram:
  - [ ] Existing conversations retain context after restart
  - [ ] \`/retro\` (or any custom skill) is forwarded to Claude
  - [ ] Built-in commands still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)