### PR TITLE
fix(status): show live running-task state

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -185,21 +185,56 @@ func (h *Handler) showStatus(chatID int64) {
 		label = sess.ID
 	}
 	sessionCount := len(h.sessions.ListForChat(chatID))
-	h.sendText(chatID, fmt.Sprintf(
-		"📊 *Session Status*\n\n"+
-			"Chat ID: `%d`\n"+
+
+	var sb strings.Builder
+	sb.WriteString("📊 *Session Status*\n\n")
+
+	// Live run line — shows what the agent is doing right now so a long task
+	// doesn't look like a frozen bot. Mirrors openclaw's taskLine pattern.
+	info := sess.RunInfo()
+	collected := 0
+	if h.queue != nil {
+		collected = h.queue.PendingCount(chatID)
+	}
+	queueDepth := h.engine.QueueDepth(chatID)
+
+	switch {
+	case info.Running:
+		elapsed := time.Since(info.StartedAt).Truncate(time.Second)
+		sb.WriteString(fmt.Sprintf("🔄 *Running* · %s · tools: %d", elapsed, info.ToolCount))
+		if info.LastTool != "" {
+			sb.WriteString(fmt.Sprintf("\nLast tool: `%s`", info.LastTool))
+			if !info.LastToolAt.IsZero() {
+				sb.WriteString(fmt.Sprintf(" (%s ago)", time.Since(info.LastToolAt).Truncate(time.Second)))
+			}
+		}
+		if info.CurrentTask != "" {
+			sb.WriteString(fmt.Sprintf("\nTask: _%s_", info.CurrentTask))
+		}
+		if collected > 0 || queueDepth > 0 {
+			sb.WriteString(fmt.Sprintf("\nWaiting: %d collected · %d queued", collected, queueDepth))
+		}
+		sb.WriteString("\n\n")
+	case collected > 0 || queueDepth > 0:
+		sb.WriteString(fmt.Sprintf("⏳ *Pending* · %d collected · %d queued\n\n", collected, queueDepth))
+	default:
+		sb.WriteString("✅ *Idle*\n\n")
+	}
+
+	sb.WriteString(fmt.Sprintf(
+		"Chat ID: `%d`\n"+
 			"Active: %s\n"+
 			"Sessions: %d total\n"+
 			"Turns: %d\n"+
 			"Claude: `%s`\n"+
 			"Model: `%s`\n"+
-			"Tokens: %d in / %d out\n"+
-			"Queue: %d pending",
+			"Tokens: %d in / %d out",
 		chatID, label, sessionCount,
 		sess.GetMessageCount(), sessionID, modelName,
 		sess.InputTokens, sess.OutputTokens,
-		h.engine.QueueDepth(chatID),
 	))
+
+	h.sendText(chatID, sb.String())
 }
 
 func (h *Handler) handleModelsCommand(chatID int64) {
@@ -280,6 +315,10 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	// Cancel any in-flight request for this session
 	sess.Cancel()
 
+	// Track live run state so /status can report what the agent is doing.
+	sess.MarkRunning(truncateLabel(text, 60))
+	defer sess.MarkIdle()
+
 	// Configurable timeout prevents a stuck Claude CLI from blocking the queue
 	// lane forever. The user can still /cancel manually for shorter waits.
 	execTimeout := time.Duration(h.cfg.Claude.ExecutionTimeout) * time.Minute
@@ -356,8 +395,11 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		},
 		OnToolCall: func(name string, inputJSON string) {
 			addEvent(transcript.Event{Type: transcript.EventToolCall, ToolName: name, ToolInput: inputJSON})
+			label := toolLabel(name, inputJSON)
 			// Compact tool progress with short snippet: Bash(cd stock_d) → Read(main.go)
-			streamer.NoteTool(toolLabel(name, inputJSON))
+			streamer.NoteTool(label)
+			// Mirror to session so /status can show what's running right now.
+			sess.NoteTool(label)
 		},
 		OnToolResult: func(name string, toolResult tools.ToolResult) {
 			// Log to transcript only — tool results not shown to user

--- a/internal/msgqueue/collector.go
+++ b/internal/msgqueue/collector.go
@@ -72,6 +72,26 @@ func (c *Collector) Done(chatID int64) (followup string, ok bool) {
 	return followup, true
 }
 
+// PendingCount returns the number of messages collected (queued) while the
+// agent was busy for chatID. Excludes any currently-running request.
+func (c *Collector) PendingCount(chatID int64) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cs, ok := c.state[chatID]
+	if !ok {
+		return 0
+	}
+	return len(cs.collected)
+}
+
+// Busy reports whether the agent is currently executing for chatID.
+func (c *Collector) Busy(chatID int64) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cs, ok := c.state[chatID]
+	return ok && cs.busy
+}
+
 // Cancel clears collected messages for chatID.
 func (c *Collector) Cancel(chatID int64) {
 	c.mu.Lock()

--- a/internal/msgqueue/queue.go
+++ b/internal/msgqueue/queue.go
@@ -47,6 +47,11 @@ func (q *Queue) Cancel(chatID int64) {
 	q.collector.Cancel(chatID)
 }
 
+// PendingCount returns how many messages are waiting in the collector for chatID.
+func (q *Queue) PendingCount(chatID int64) int {
+	return q.collector.PendingCount(chatID)
+}
+
 // Close stops the debouncer.
 func (q *Queue) Close() {
 	q.debouncer.Close()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -22,6 +22,24 @@ type Session struct {
 
 	mu       sync.Mutex `json:"-"`
 	cancelFn func()     `json:"-"`
+
+	// Live run state (not persisted) — populated while a request is executing
+	// so /status can report what the agent is currently doing.
+	runningSince time.Time `json:"-"`
+	currentTask  string    `json:"-"`
+	lastTool     string    `json:"-"`
+	lastToolAt   time.Time `json:"-"`
+	runToolCount int       `json:"-"`
+}
+
+// RunInfo is a snapshot of the live execution state for status reporting.
+type RunInfo struct {
+	Running      bool
+	StartedAt    time.Time
+	CurrentTask  string
+	LastTool     string
+	LastToolAt   time.Time
+	ToolCount    int
 }
 
 // SessionSnapshot is a mutex-free copy of session fields for persistence.
@@ -124,6 +142,62 @@ func (s *Session) Reset() {
 	s.ClaudeSessionID = ""
 	s.MessageCount = 0
 	s.UpdatedAt = time.Now()
+}
+
+// MarkRunning records that a request has started executing for this session.
+// task is a short label describing the current user prompt.
+func (s *Session) MarkRunning(task string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runningSince = time.Now()
+	s.currentTask = task
+	s.lastTool = ""
+	s.lastToolAt = time.Time{}
+	s.runToolCount = 0
+}
+
+// MarkIdle clears the live run state when a request finishes.
+func (s *Session) MarkIdle() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runningSince = time.Time{}
+	s.currentTask = ""
+	s.lastTool = ""
+	s.lastToolAt = time.Time{}
+	s.runToolCount = 0
+}
+
+// IsRunning reports whether a request is currently executing.
+func (s *Session) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.runningSince.IsZero()
+}
+
+// NoteTool records the most recent tool invocation during the live run.
+func (s *Session) NoteTool(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.runningSince.IsZero() {
+		return
+	}
+	s.lastTool = name
+	s.lastToolAt = time.Now()
+	s.runToolCount++
+}
+
+// RunInfo returns a snapshot of the live execution state.
+func (s *Session) RunInfo() RunInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return RunInfo{
+		Running:     !s.runningSince.IsZero(),
+		StartedAt:   s.runningSince,
+		CurrentTask: s.currentTask,
+		LastTool:    s.lastTool,
+		LastToolAt:  s.lastToolAt,
+		ToolCount:   s.runToolCount,
+	}
 }
 
 // SetCancel stores a cancel function for the current in-flight request.


### PR DESCRIPTION
## Summary
- `/status` previously showed only static config (model, cumulative tokens, queue depth). During a long-running turn it reported `Queue: 0 pending` even though the agent was actively working, so users couldn't tell whether the bot was stuck or still processing.
- Track per-session live run state (`runningSince`, `currentTask`, `lastTool`, `runToolCount`) via new `MarkRunning`/`MarkIdle`/`NoteTool`/`RunInfo` on `Session`. Mirrored from `executeMessage` and the `OnToolCall` stream callback.
- Expose collected-message count (`Queue.PendingCount` / `Collector.PendingCount`) so `/status` can distinguish the engine lane queue from messages held by the collector while the agent is busy.
- Rewrite `showStatus` with three branches — Running (elapsed, tool count, last tool + ago, current task, waiting counts) / Pending / Idle. Concept ported from openclaw's `auto-reply/reply/commands-status.ts` `taskLine`.

## Test plan
- [x] `go build ./internal/session/... ./internal/msgqueue/... ./internal/bot/...` passes
- [x] `go test ./internal/session/... ./internal/msgqueue/... ./internal/bot/...` passes
- [x] `go build -o bomclaw ./cmd/bomclaw/` produces a working binary
- [ ] Manual: send a long task to the bot, then type `status` mid-run and confirm it shows `🔄 Running · Xs · tools: N` with the most recent tool
- [ ] Manual: confirm idle chats still show `✅ Idle` with model/session info

🤖 Generated with [Claude Code](https://claude.com/claude-code)