### PR TITLE
docs(changelog): release v0.2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,48 @@ nav_order: 10
 
 # Changelog
 
-## [Unreleased] - 2026-04-10
+## [0.2.0] - 2026-04-25
+
+Second release since v0.1.0, rolling up multi-session support, the SQLite storage migration, live status reporting, and a batch of streaming/indicator fixes.
+
+### Added
+
+- **Multi-session support** — each chat can hold multiple parallel Claude sessions. `/sessions` lists them with an inline keyboard; `/new` starts a new one; tapping a row switches the active session.
+- **Live `/status`** — reports whether the agent is currently running (elapsed, tool count, last tool, current task) and how many messages are waiting in the collector/engine queues. Ported from openclaw's `taskLine` pattern.
+- **Rolling-window tool progress** — long runs now show the first 8 tools plus sampled checkpoints every 10, e.g. `Bash → Read → … → (+10 more) → Grep → Edit → …`, instead of truncating to the first few.
+- **Configurable execution timeout** — `claude.execution_timeout` (default 20 min) caps stuck Claude CLI turns so the queue lane can recover automatically.
+- **Typing indicator** — per-chat keepalive loop sends Telegram `typing…` while the agent works; TTL auto-matches `execution_timeout`, with heartbeat dedup to avoid wasted API calls.
+- **Streamer heartbeat** — placeholder updates with elapsed time during Claude's thinking phase so the message doesn't look frozen before the first token arrives.
+- **History context injection** — when a session is idle-reset (first message or after `/reset`), recent conversation history is loaded from SQLite and prepended to the system prompt.
+- **Custom slash command forwarding** — unknown `/commands` are now passed through to Claude instead of being rejected, so user-defined skills under `.claude/commands/` work from Telegram.
+
+### Changed
+
+- **SQLite hybrid storage** — migrated from file-based storage (JSON + JSONL) to SQLite via `modernc.org/sqlite` (pure Go, no CGO). Sessions, messages, and the meta/version table all live in `~/.goterm/data/goterm.db`; transcripts are still written as JSONL for audit. Existing `sessions.json` is auto-imported on first run and kept in place for rollback.
+- **Session recovery** — stale `ActiveSessionID` now falls back to the most recently updated session in the `ChatState` instead of wiping all sessions for the chat.
+- **Bash tool labels** — show the subpath (e.g. `cd ../goterm-control`) instead of head-truncating long absolute paths.
+- **Telegram chat-action TTL** — removed the separate `chat_action_ttl` config; it now tracks `execution_timeout` automatically.
+
+### Fixed
+
+- `/status` no longer reports `Queue: 0 pending` while a turn is actively running — it now shows `🔄 Running · Xs · tools: N` with the latest tool call.
+- Typing indicator stops correctly when the agent finishes, even if the turn was cancelled mid-tool-call.
+- Streamer no longer sends duplicate heartbeat edits when the elapsed bucket hasn't advanced.
+- GitHub Pages renders markdown inside `<details>` tags (added the required blank line).
+
+### Removed
+
+- **Memory package** — the cross-session memory store (`internal/memory/` + FTS5 table) was dropped. It duplicated Claude's own session history and complicated the context budget; the `messages` table + history injection cover the remaining use case.
+
+### Docs
+
+- Platform-specific install guides for Mac and Ubuntu/Linux aimed at non-technical users.
+- Getting-started no longer walks through raw API-key setup (OAuth / subscription path is the default).
+- Added a Philosophy section to the GitHub Pages homepage.
+
+---
+
+## [Unreleased - superseded] - 2026-04-10
 
 ### SQLite Hybrid Storage Migration
 


### PR DESCRIPTION
## Summary
- Promote the 2026-04-10 Unreleased block and add a v0.2.0 section covering everything shipped since v0.1.0.
- Highlights: multi-session Telegram UI, SQLite hybrid storage, live /status reporting, rolling tool-progress window, typing + streamer heartbeat, session recovery fix, memory-package removal.
- Kept the prior Unreleased block marked `superseded` for traceability rather than deleting it.

Paired with tag `v0.2.0` + GitHub release (created after merge).

## Test plan
- [x] Preview `docs/changelog.md` locally — Jekyll front-matter unchanged, new section renders.
- [ ] After merge: confirm GitHub Pages rebuild succeeds and the changelog page shows the new v0.2.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)