### PR TITLE
docs(changelog): feature v0.2.0 on a real page + add nav link

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -30,6 +30,7 @@
         <a href="{{ '/dashboard' | relative_url }}" {% if page.url == '/dashboard' %}class="active"{% endif %}>Dashboard</a>
         <a href="{{ '/configuration' | relative_url }}" {% if page.url == '/configuration' %}class="active"{% endif %}>Config</a>
         <a href="{{ '/api-reference' | relative_url }}" {% if page.url == '/api-reference' %}class="active"{% endif %}>API</a>
+        <a href="{{ '/changelog' | relative_url }}" {% if page.url == '/changelog' %}class="active"{% endif %}>Changelog</a>
         <a href="https://github.com/phanngoc/goterm-control" class="nav-github" target="_blank" rel="noopener">
           <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         </a>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,27 @@
 ---
-layout: default
 title: Changelog
-nav_order: 10
+layout: default
 ---
 
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
 # Changelog
+
+<p class="lead">Release notes for BomClaw. The current release is <strong>v0.2.0</strong> — tagged 2026-04-25. <a href="https://github.com/phanngoc/goterm-control/releases/tag/v0.2.0" target="_blank" rel="noopener">View on GitHub →</a></p>
+
+## Latest release
+
+**v0.2.0** rolls up every change since v0.1.0: multi-session Telegram UI, SQLite hybrid storage, live `/status` reporting, rolling tool-progress window, typing + streamer heartbeat, session recovery fix, and the memory-package removal.
+
+- **Multi-session** — `/sessions` inline keyboard, `/new`, tap to switch
+- **Live `/status`** — elapsed time, last tool call, collected/queued message counts
+- **SQLite storage** — sessions + messages persisted in `~/.goterm/data/goterm.db`
+- **Rolling tool progress** — first 8 tools + sampled checkpoints every 10
+- **Configurable execution timeout** — `claude.execution_timeout` (default 20 min)
+- **Typing + heartbeat** — Telegram `typing…` keepalive + elapsed-time placeholder while Claude thinks
+
+Full notes below.
 
 ## [0.2.0] - 2026-04-25
 
@@ -98,3 +115,6 @@ Migrated from file-based storage (JSON + JSONL) to SQLite hybrid model for impro
 - **Dual-write**: JSONL transcripts still written alongside SQLite for audit compliance
 - **Backward compatible**: existing `*session.Store` and `*memory.Store` still satisfy the new interfaces
 - **Binary size**: +15MB (pure-Go SQLite driver, no CGO dependency)
+
+</div>
+</section>


### PR DESCRIPTION
## Summary
- Wrap `docs/changelog.md` in the standard `<section class="doc-page">` / `<div class="doc-content" markdown="1">` block used by Configuration/Features so the page matches the site's visual style.
- Add a "Latest release" lead block highlighting v0.2.0 with bullet highlights and a link to the GitHub release.
- Expose the Changelog page from the top nav in `_layouts/default.html` (was only reachable by typing the URL).

Site: https://phanngoc.github.io/goterm-control/changelog

## Test plan
- [ ] After merge, confirm GitHub Pages rebuild succeeds.
- [ ] Nav shows the new "Changelog" link on https://phanngoc.github.io/goterm-control/ and it's marked `active` on the changelog page.
- [ ] Lead block renders with the v0.2.0 summary and the GitHub release link opens in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)