### PR TITLE
feat(bot): auto-continue when end_turn lands with pending TodoWrite items

### DIFF
--- a/internal/bot/autocontinue.go
+++ b/internal/bot/autocontinue.go
@@ -1,0 +1,94 @@
+package bot
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Auto-continue lets the agent loop survive Claude stopping with `end_turn`
+// while a TodoWrite list still has pending or in_progress items. Without it,
+// the user has to manually nudge the bot ("sao rồi?") to resume work.
+const (
+	maxAutoContinue     = 3
+	autoContinuePrompt  = "continue"
+	autoContinueTailLen = 300 // chars of tail text inspected for the question guard
+)
+
+// todoItem mirrors the schema of TodoWrite tool input items.
+type todoItem struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`
+	ActiveForm string `json:"activeForm"`
+}
+
+// parseTodoWriteInput extracts todos from a TodoWrite tool call's input JSON.
+// Returns nil when the JSON shape doesn't match (malformed, wrong type, etc.).
+func parseTodoWriteInput(inputJSON string) []todoItem {
+	var input struct {
+		Todos []todoItem `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(inputJSON), &input); err != nil {
+		return nil
+	}
+	return input.Todos
+}
+
+// pendingTodos returns the content strings of items still pending or in_progress.
+func pendingTodos(todos []todoItem) []string {
+	var out []string
+	for _, t := range todos {
+		if t.Status == "pending" || t.Status == "in_progress" {
+			out = append(out, t.Content)
+		}
+	}
+	return out
+}
+
+// askingMarkers are phrases that signal the model is asking the user something
+// rather than reporting completion. We bail out of auto-continue when we see
+// these so we don't stomp on a clarifying question with a "continue" prompt.
+var askingMarkers = []string{
+	// English
+	"shall i ", "should i ", "do you want", "would you like",
+	"let me know", "please confirm", "which would you",
+	// Vietnamese
+	"có muốn", "đúng không", "được không", "có nên",
+	"bạn muốn", "bạn cần", "xác nhận", "chọn cái nào",
+}
+
+// shouldAutoContinue returns true when the loop should send another "continue"
+// to the model. Two preconditions must hold:
+//  1. There is at least one pending/in_progress todo (the work is unfinished).
+//  2. The latest assistant turn does not look like a question to the user.
+//
+// The question guard inspects the tail of the text since clarifying questions
+// almost always land at the end of an assistant turn.
+func shouldAutoContinue(latestText string, pending []string) bool {
+	if len(pending) == 0 {
+		return false
+	}
+	trimmed := strings.TrimSpace(latestText)
+	if trimmed == "" {
+		// No text but pending todos — model probably stopped after tool calls
+		// without summarizing. Continue.
+		return true
+	}
+
+	tail := trimmed
+	if runes := []rune(trimmed); len(runes) > autoContinueTailLen {
+		tail = string(runes[len(runes)-autoContinueTailLen:])
+	}
+
+	// Trailing question mark (ASCII or fullwidth).
+	if strings.HasSuffix(tail, "?") || strings.HasSuffix(tail, "？") {
+		return false
+	}
+
+	tailLower := strings.ToLower(tail)
+	for _, m := range askingMarkers {
+		if strings.Contains(tailLower, m) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bot/autocontinue_test.go
+++ b/internal/bot/autocontinue_test.go
@@ -1,0 +1,155 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTodoWriteInput(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		want     int
+		firstStt string
+	}{
+		{
+			name:     "valid two items",
+			input:    `{"todos":[{"content":"a","status":"pending","activeForm":"doing a"},{"content":"b","status":"completed","activeForm":"doing b"}]}`,
+			want:     2,
+			firstStt: "pending",
+		},
+		{
+			name:  "empty todos array",
+			input: `{"todos":[]}`,
+			want:  0,
+		},
+		{
+			name:  "missing todos field",
+			input: `{}`,
+			want:  0,
+		},
+		{
+			name:  "invalid json",
+			input: `not json`,
+			want:  0,
+		},
+		{
+			name:  "wrong type for todos",
+			input: `{"todos":"oops"}`,
+			want:  0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseTodoWriteInput(tc.input)
+			if len(got) != tc.want {
+				t.Fatalf("got %d todos, want %d", len(got), tc.want)
+			}
+			if tc.want > 0 && got[0].Status != tc.firstStt {
+				t.Errorf("first status = %q, want %q", got[0].Status, tc.firstStt)
+			}
+		})
+	}
+}
+
+func TestPendingTodos(t *testing.T) {
+	todos := []todoItem{
+		{Content: "a", Status: "completed"},
+		{Content: "b", Status: "in_progress"},
+		{Content: "c", Status: "pending"},
+		{Content: "d", Status: "completed"},
+		{Content: "e", Status: "pending"},
+	}
+	got := pendingTodos(todos)
+	want := []string{"b", "c", "e"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d items, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPendingTodos_AllDone(t *testing.T) {
+	todos := []todoItem{
+		{Content: "a", Status: "completed"},
+		{Content: "b", Status: "completed"},
+	}
+	if got := pendingTodos(todos); len(got) != 0 {
+		t.Errorf("expected no pending, got %v", got)
+	}
+}
+
+func TestShouldAutoContinue(t *testing.T) {
+	cases := []struct {
+		name    string
+		text    string
+		pending []string
+		want    bool
+	}{
+		{
+			name:    "no pending todos",
+			text:    "Tôi đã hoàn thành các bước.",
+			pending: nil,
+			want:    false,
+		},
+		{
+			name:    "pending plus statement",
+			text:    "Đã verify file. Tiếp tục xử lý.",
+			pending: []string{"task a"},
+			want:    true,
+		},
+		{
+			name:    "pending plus trailing question mark",
+			text:    "Bạn có muốn tôi tiếp tục không?",
+			pending: []string{"task a"},
+			want:    false,
+		},
+		{
+			name:    "pending plus fullwidth question mark",
+			text:    "Bạn muốn tôi làm gì？",
+			pending: []string{"task a"},
+			want:    false,
+		},
+		{
+			name:    "english shall i marker",
+			text:    "I've identified two options. Shall I proceed with option A or option B?",
+			pending: []string{"task a"},
+			want:    false,
+		},
+		{
+			name:    "let me know variant",
+			text:    "There are two paths forward. Let me know which you prefer.",
+			pending: []string{"task a"},
+			want:    false,
+		},
+		{
+			name:    "vietnamese asking marker without question mark",
+			text:    "Bạn cần tôi viết test cho cả hai trường hợp",
+			pending: []string{"task a"},
+			want:    false,
+		},
+		{
+			name:    "empty text but pending",
+			text:    "",
+			pending: []string{"task a"},
+			want:    true,
+		},
+		{
+			name:    "asking phrase outside tail window does not block",
+			text:    "Earlier I asked: shall I refactor this? You said yes. " + strings.Repeat("Now I'm running tests. ", 30) + "All green.",
+			pending: []string{"task a"},
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldAutoContinue(tc.text, tc.pending)
+			if got != tc.want {
+				t.Errorf("shouldAutoContinue(%q, %v) = %v, want %v", tc.text, tc.pending, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -382,14 +382,24 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 	// Record user message
 	addEvent(transcript.Event{Type: transcript.EventUserMessage, Content: userText})
 
-	// Track assistant text for memory extraction
+	// assistantText accumulates ALL turns (for storage); turnText resets per
+	// iteration so the auto-continue heuristic only inspects the latest turn.
 	var assistantText strings.Builder
+	var turnText strings.Builder
 	var textMu sync.Mutex
+
+	// latestTodos holds the most recent TodoWrite snapshot from the model.
+	// Updated under textMu since OnToolCall and the loop body that reads it
+	// are technically separate happens-before edges (the CLI scanner goroutine
+	// has fully exited by the time we read between SendMessage calls, but we
+	// still take the lock for consistency with the other shared state).
+	var latestTodos []todoItem
 
 	cb := claude.StreamCallbacks{
 		OnText: func(chunk string) {
 			textMu.Lock()
 			assistantText.WriteString(chunk)
+			turnText.WriteString(chunk)
 			textMu.Unlock()
 			streamer.Write(chunk)
 		},
@@ -400,6 +410,14 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 			streamer.NoteTool(label)
 			// Mirror to session so /status can show what's running right now.
 			sess.NoteTool(label)
+			// Snapshot the latest TodoWrite state for the auto-continue check.
+			if name == "TodoWrite" {
+				if todos := parseTodoWriteInput(inputJSON); todos != nil {
+					textMu.Lock()
+					latestTodos = todos
+					textMu.Unlock()
+				}
+			}
 		},
 		OnToolResult: func(name string, toolResult tools.ToolResult) {
 			// Log to transcript only — tool results not shown to user
@@ -422,19 +440,58 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		},
 	}
 
-	if err := h.claude.SendMessage(ctx, sess, modelID, userText, memoryContext, cb); err != nil {
-		if ctx.Err() != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				streamer.Write("\n\n⏰ Task timed out (10 min limit).")
+	currentText := userText
+	currentMemory := memoryContext
+	attempts := 0
+	for {
+		textMu.Lock()
+		turnText.Reset()
+		textMu.Unlock()
+
+		if err := h.claude.SendMessage(ctx, sess, modelID, currentText, currentMemory, cb); err != nil {
+			if ctx.Err() != nil {
+				if ctx.Err() == context.DeadlineExceeded {
+					streamer.Write("\n\n⏰ Task timed out.")
+				}
+				result.Status = execution.RunCanceled
+				streamer.Finalize()
+				return result, nil
 			}
-			result.Status = execution.RunCanceled
-			streamer.Finalize()
-			return result, nil
+			log.Printf("claude error: %v", err)
+			streamer.Write(fmt.Sprintf("\n\n❌ Error: %v", err))
+			result.Status = execution.RunFailed
+			result.Error = err
+			break
 		}
-		log.Printf("claude error: %v", err)
-		streamer.Write(fmt.Sprintf("\n\n❌ Error: %v", err))
-		result.Status = execution.RunFailed
-		result.Error = err
+
+		if attempts >= maxAutoContinue {
+			break
+		}
+
+		textMu.Lock()
+		pending := pendingTodos(latestTodos)
+		lastTurn := turnText.String()
+		textMu.Unlock()
+
+		if !shouldAutoContinue(lastTurn, pending) {
+			break
+		}
+
+		// Visible marker so the user sees a continuation rather than a
+		// silent extra round of tool calls.
+		marker := fmt.Sprintf("\n\n_…auto-continue (%d todo còn lại)…_\n\n", len(pending))
+		streamer.Write(marker)
+		textMu.Lock()
+		assistantText.WriteString(marker)
+		textMu.Unlock()
+		addEvent(transcript.Event{
+			Type:    transcript.EventUserMessage,
+			Content: fmt.Sprintf("[auto-continue %d/%d, %d pending] %s", attempts+1, maxAutoContinue, len(pending), strings.Join(pending, " | ")),
+		})
+
+		currentText = autoContinuePrompt
+		currentMemory = "" // memory injection is first-call only
+		attempts++
 	}
 
 	streamer.Finalize()


### PR DESCRIPTION
## Summary
- Bot now auto-resumes multi-step plans instead of stopping on every `end_turn`. After each turn, if the latest `TodoWrite` still has pending/in-progress items, the loop sends `continue` (capped at 3 attempts).
- Question-guard inspects the last 300 chars of the turn for trailing `?`/`？` or asking-phrase markers (English + Vietnamese) so a genuine clarifying question to the user is **not** stomped.
- A visible `…auto-continue (N todo còn lại)…` marker is streamed before each retry; the auto-prompt is also recorded as a synthetic user event in the transcript.

## Why
Previously the user had to manually nudge the bot ("sao rồi?", "tiếp đi") whenever Claude finished a turn mid-plan. This patch closes that gap for the common case where the model itself has declared remaining work via TodoWrite.

## Implementation notes
- `runClaude` now wraps `claude.SendMessage` in a `for` loop with `attempts < maxAutoContinue`.
- `assistantText` accumulates **all** turns (for storage/memory extraction) but a separate `turnText` resets per iteration so `shouldAutoContinue` only inspects the latest turn.
- `latestTodos` is updated inside `OnToolCall` when `name == "TodoWrite"`, guarded by the existing `textMu` for consistency.
- Memory context is injected only on the first call (`currentMemory = ""` after attempt 0).

## Test plan
- [x] `go test ./internal/bot/ -run "TestParseTodoWriteInput|TestPendingTodos|TestShouldAutoContinue" -v` — all green
- [x] `go build ./internal/bot/... ./cmd/bomclaw/...` — clean
- [ ] Smoke test on the gateway: kick off a multi-step task and confirm bot continues without manual prompt
- [ ] Smoke test the question-guard: send a request that ends in a clarifying question — confirm bot does NOT auto-continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)