### PR TITLE
feat(memory): openclaw-style persistent memory system

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -86,11 +86,21 @@ models:
 
 session:
   data_dir: ""           # default: ~/.goterm/data
-  # Sessions persist until explicit /reset command — no auto-reset on idle.
+  reset:
+    daily_at: "04:00"    # rotate the session daily at this local time ("off" to disable)
+    idle_minutes: 0      # rotate after this many idle minutes (0 = disabled)
+  # Memory is flushed to disk before any automatic rotation, and recent
+  # history is re-injected, so rotations are invisible to the user.
 
 memory:
   enabled: true
-  max_entries: 5         # max memory entries injected per prompt
+  dir: ""                # memory root; default: claude.workspace
+  max_file_chars: 20000  # per-file cap when injecting memory into the system prompt
+  max_total_chars: 60000 # total cap for the injected memory block
+  flush:
+    soft_threshold_tokens: 100000 # flush memory early once session context exceeds this
+    timeout_seconds: 120          # max duration of a silent flush turn
+    prompt: ""                    # override default flush prompt ({today} = today's note path)
 
 security:
   allowed_user_ids: []  # empty = allow all (not recommended for production)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/memory"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/msgqueue"
 	"github.com/ngocp/goterm-control/internal/session"
@@ -48,6 +49,8 @@ func New(cfg *config.Config) (*Bot, error) {
 		tgbotapi.BotCommand{Command: "status", Description: "Show session info"},
 		tgbotapi.BotCommand{Command: "models", Description: "List available models"},
 		tgbotapi.BotCommand{Command: "model", Description: "Switch model (e.g. /model sonnet)"},
+		tgbotapi.BotCommand{Command: "memory", Description: "Show persistent memory"},
+		tgbotapi.BotCommand{Command: "remember", Description: "Save a note to memory"},
 		tgbotapi.BotCommand{Command: "cancel", Description: "Cancel current request"},
 	)
 	if _, err := api.Request(commands); err != nil {
@@ -95,6 +98,25 @@ func New(cfg *config.Config) (*Bot, error) {
 	// Execution engine
 	engine := execution.NewEngine(execution.Hooks{}, 3)
 
+	// Persistent memory (openclaw pattern) — markdown files in the workspace
+	// that the Claude CLI reads/writes with its own tools.
+	memManager := memory.NewManager(memory.Config{
+		Enabled:             cfg.Memory.Enabled,
+		Dir:                 cfg.Memory.Dir,
+		MaxFileChars:        cfg.Memory.MaxFileChars,
+		MaxTotalChars:       cfg.Memory.MaxTotalChars,
+		FlushPrompt:         cfg.Memory.Flush.Prompt,
+		SoftThresholdTokens: cfg.Memory.Flush.SoftThresholdTokens,
+		FlushTimeout:        time.Duration(cfg.Memory.Flush.TimeoutSeconds) * time.Second,
+	})
+	if memManager.Enabled() {
+		if err := memManager.Bootstrap(); err != nil {
+			log.Printf("bot: warning: memory bootstrap failed: %v", err)
+		} else {
+			log.Printf("bot: memory enabled (dir=%s)", cfg.Memory.Dir)
+		}
+	}
+
 	// Build handler first (queue needs handler.executeMessage as callback)
 	handler := &Handler{
 		bot:              api,
@@ -105,6 +127,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		transcript:       transcriptWriter,
 		messages:         messageStore,
 		resolver:         resolver,
+		memory:           memManager,
 		approvalRequests: make(map[string]chan bool),
 		indicator:        indicator,
 		typing:           typing,

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/memory"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/msgqueue"
 	"github.com/ngocp/goterm-control/internal/session"
@@ -41,6 +42,7 @@ type Handler struct {
 	queue      *msgqueue.Queue // debounce + collect layer
 	indicator  *NameIndicator
 	typing     *TypingIndicator
+	memory     *memory.Manager // markdown persistent memory (nil-safe)
 
 	// approvalRequests maps callbackData → channel to signal approval/cancel
 	approvalMu       sync.Mutex
@@ -57,6 +59,7 @@ func NewHandler(
 	messages MessageStore,
 	resolver *models.Resolver,
 	queue *msgqueue.Queue,
+	mem *memory.Manager,
 ) *Handler {
 	return &Handler{
 		bot:              bot,
@@ -68,6 +71,7 @@ func NewHandler(
 		messages:         messages,
 		resolver:         resolver,
 		queue:            queue,
+		memory:           mem,
 		approvalRequests: make(map[string]chan bool),
 	}
 }
@@ -138,6 +142,8 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 				"• /status — show session info\n"+
 				"• /models — list available models\n"+
 				"• /model `<name>` — switch model\n"+
+				"• /memory — show persistent memory\n"+
+				"• /remember `<fact>` — save a note to memory\n"+
 				"• /cancel — cancel current request\n\n"+
 				"📎 Send me a photo or file (with an optional caption) and I'll read and process it.\n\n"+
 				"Just send me any message and I'll help you control your Mac!",
@@ -162,6 +168,12 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 
 	case "model":
 		h.handleModelCommand(chatID, msg.CommandArguments())
+
+	case "memory":
+		h.showMemory(chatID)
+
+	case "remember":
+		h.handleRemember(chatID, msg.CommandArguments())
 
 	case "cancel":
 		sess := h.sessions.Get(chatID)
@@ -307,6 +319,53 @@ func (h *Handler) handleModelCommand(chatID int64, arg string) {
 	))
 }
 
+// showMemory renders persistent-memory stats and a MEMORY.md preview.
+func (h *Handler) showMemory(chatID int64) {
+	if !h.memory.Enabled() {
+		h.sendText(chatID, "💾 Memory is disabled (set `memory.enabled: true` in config).")
+		return
+	}
+	st, err := h.memory.Stats(time.Now())
+	if err != nil {
+		h.sendText(chatID, fmt.Sprintf("❌ %v", err))
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString("💾 *Persistent Memory*\n\n")
+	sb.WriteString(fmt.Sprintf(
+		"Dir: `%s`\n"+
+			"MEMORY.md: %d bytes\n"+
+			"Daily notes: %d files (today: %d bytes)\n",
+		st.Dir, st.MemoryMDBytes, st.DailyNoteCount, st.TodayBytes,
+	))
+	if st.MemoryMDPreview != "" {
+		sb.WriteString("\n*MEMORY.md preview:*\n")
+		sb.WriteString(st.MemoryMDPreview)
+	}
+	h.sendText(chatID, sb.String())
+}
+
+// handleRemember appends a fact to today's daily note directly — no Claude
+// turn needed, so it is instant and free.
+func (h *Handler) handleRemember(chatID int64, arg string) {
+	if !h.memory.Enabled() {
+		h.sendText(chatID, "💾 Memory is disabled (set `memory.enabled: true` in config).")
+		return
+	}
+	fact := strings.TrimSpace(arg)
+	if fact == "" {
+		h.sendText(chatID, "Usage: `/remember <fact>` — e.g. `/remember deploy freeze until Friday`")
+		return
+	}
+	now := time.Now()
+	if err := h.memory.AppendNote(now, fact); err != nil {
+		h.sendText(chatID, fmt.Sprintf("❌ %v", err))
+		return
+	}
+	h.sendText(chatID, fmt.Sprintf("📝 Noted in `memory/%s.md`", now.Format("2006-01-02")))
+}
+
 func (h *Handler) handleMessage(msg *tgbotapi.Message) {
 	h.queue.Submit(msg.Chat.ID, msg.Text)
 }
@@ -347,15 +406,16 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 		return
 	}
 
-	// Inject recent conversation history when starting a brand-new session
-	// (first message or after explicit /reset) so Claude has some context.
-	historyContext := ""
+	// Inject persistent memory (MEMORY.md + recent daily notes) and recent
+	// conversation history when starting a brand-new session (first message
+	// or after a reset) so Claude has durable facts plus short-term context.
+	newSessionContext := ""
 	if sess.GetSessionID() == "" {
-		historyContext = h.buildHistoryContext(sess.ID, 8)
+		newSessionContext = h.memory.BuildContext(time.Now()) + h.buildHistoryContext(sess.ID, 8)
 	}
 
 	_, err := h.engine.Enqueue(ctx, chatID, func(ctx context.Context) (*execution.RunResult, error) {
-		return h.runClaude(ctx, sess, chatID, modelID, text, historyContext, placeholder)
+		return h.runClaude(ctx, sess, chatID, modelID, text, newSessionContext, placeholder)
 	})
 
 	if err != nil {

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -492,6 +492,18 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	// Cancel any in-flight request for this session
 	sess.Cancel()
 
+	// Daily/idle session rotation (openclaw pattern): flush memory, then
+	// reset so this message starts a fresh CLI session with re-injected
+	// context. Recent-history injection keeps the rotation invisible.
+	if sess.GetSessionID() != "" {
+		idle := time.Duration(h.cfg.Session.Reset.IdleMinutes) * time.Minute
+		if rotate, reason := memory.ShouldRotate(sess.LastActivity(), time.Now(), h.cfg.Session.Reset.DailyAt, idle); rotate {
+			log.Printf("session: rotating (chat=%d reason=%s)", chatID, reason)
+			h.flushMemory(chatID, reason)
+			h.sessions.Reset(chatID)
+		}
+	}
+
 	// Track live run state so /status can report what the agent is doing.
 	sess.MarkRunning(truncateLabel(text, 60))
 	defer sess.MarkIdle()
@@ -529,6 +541,18 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 
 	if err != nil {
 		log.Printf("handler: enqueue error: %v", err)
+		return
+	}
+
+	// Token-threshold memory flush: once the session context grows past the
+	// soft threshold, persist durable notes early. Fires at most once per
+	// session (flag cleared on reset); does not reset the session itself.
+	if h.memory.Enabled() {
+		if th := h.memory.SoftThresholdTokens(); th > 0 &&
+			sess.LastContextTokens() >= th && !sess.IsMemoryFlushed() {
+			sess.MarkMemoryFlushed()
+			h.flushMemory(chatID, "token-threshold")
+		}
 	}
 }
 

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -150,6 +150,10 @@ func (h *Handler) handleCommand(msg *tgbotapi.Message) {
 		)
 
 	case "reset":
+		if h.willFlush(chatID) {
+			h.sendText(chatID, "💾 Saving memory...")
+		}
+		h.flushMemory(chatID, "reset")
 		h.sessions.Reset(chatID)
 		h.resolver.ClearOverride(chatID)
 		h.sendText(chatID, "🔄 Conversation history cleared.")
@@ -291,6 +295,12 @@ func (h *Handler) handleModelCommand(chatID int64, arg string) {
 	}
 
 	if arg == "default" || arg == "reset" {
+		// Flush with the outgoing model — the old session is model-bound.
+		oldModel := h.currentModelID(chatID)
+		if h.willFlush(chatID) {
+			h.sendText(chatID, "💾 Saving memory...")
+		}
+		h.flushMemoryWithModel(chatID, "model-switch", oldModel)
 		h.resolver.ClearOverride(chatID)
 		// Reset session so new model takes effect cleanly
 		h.sessions.Reset(chatID)
@@ -303,11 +313,20 @@ func (h *Handler) handleModelCommand(chatID int64, arg string) {
 		return
 	}
 
+	// Capture the outgoing model before the override changes — the flush must
+	// resume the old session with the model it was created with.
+	oldModel := h.currentModelID(chatID)
+
 	m, err := h.resolver.SetOverride(chatID, arg)
 	if err != nil {
 		h.sendText(chatID, fmt.Sprintf("❌ %v", err))
 		return
 	}
+
+	if h.willFlush(chatID) {
+		h.sendText(chatID, "💾 Saving memory...")
+	}
+	h.flushMemoryWithModel(chatID, "model-switch", oldModel)
 
 	// Reset session so the new model starts fresh (Claude CLI sessions are model-bound)
 	h.sessions.Reset(chatID)
@@ -364,6 +383,96 @@ func (h *Handler) handleRemember(chatID int64, arg string) {
 		return
 	}
 	h.sendText(chatID, fmt.Sprintf("📝 Noted in `memory/%s.md`", now.Format("2006-01-02")))
+}
+
+// --- Memory flush (openclaw pre-compaction pattern) ---
+
+// willFlush reports whether a memory flush would actually run for this chat,
+// so callers can show a "saving..." notice before a blocking flush.
+func (h *Handler) willFlush(chatID int64) bool {
+	if !h.memory.Enabled() {
+		return false
+	}
+	sess := h.sessions.Get(chatID)
+	return sess.GetSessionID() != "" && sess.GetMessageCount() > 0
+}
+
+// currentModelID resolves the active model for a chat ("" if unknown).
+func (h *Handler) currentModelID(chatID int64) string {
+	if m := h.resolver.Resolve(chatID); m != nil {
+		return m.ID
+	}
+	return ""
+}
+
+// flushMemory runs a silent turn on the active session prompting the agent to
+// write durable notes to memory files before the session context is lost.
+// It blocks until the flush finishes; errors are logged and swallowed —
+// losing a flush must never block the user's reset.
+func (h *Handler) flushMemory(chatID int64, reason string) {
+	h.flushMemoryWithModel(chatID, reason, h.currentModelID(chatID))
+}
+
+// flushMemoryWithModel is flushMemory with an explicit model — used by
+// /model, where the flush must resume the old session with its old model.
+func (h *Handler) flushMemoryWithModel(chatID int64, reason, modelID string) {
+	if !h.memory.Enabled() {
+		return
+	}
+	sess := h.sessions.Get(chatID)
+	if sess.GetSessionID() == "" || sess.GetMessageCount() == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), h.memory.FlushTimeout())
+	defer cancel()
+
+	log.Printf("memory: flush start (chat=%d reason=%s)", chatID, reason)
+	start := time.Now()
+	_, err := h.engine.Enqueue(ctx, chatID, func(ctx context.Context) (*execution.RunResult, error) {
+		return h.runFlush(ctx, sess, modelID)
+	})
+	if err != nil {
+		log.Printf("memory: flush failed (chat=%d reason=%s): %v", chatID, reason, err)
+		return
+	}
+	log.Printf("memory: flush done (chat=%d reason=%s took=%s)",
+		chatID, reason, time.Since(start).Truncate(time.Millisecond))
+}
+
+// runFlush executes the silent flush turn. Nothing is streamed to Telegram;
+// the agent's reply (normally the NO_REPLY sentinel) is only logged.
+func (h *Handler) runFlush(ctx context.Context, sess *session.Session, modelID string) (*execution.RunResult, error) {
+	sess.MarkRunning("memory flush")
+	defer sess.MarkIdle()
+
+	var reply strings.Builder
+	cb := claude.StreamCallbacks{
+		OnText: func(chunk string) { reply.WriteString(chunk) },
+		OnToolCall: func(name, inputJSON string) {
+			sess.NoteTool(name)
+			log.Printf("memory: flush tool %s", toolLabel(name, inputJSON))
+		},
+	}
+
+	result := &execution.RunResult{
+		SessionID: sess.ID,
+		StartedAt: time.Now(),
+		Status:    execution.RunSuccess,
+	}
+	err := h.claude.SendMessage(ctx, sess, modelID, h.memory.FlushPrompt(time.Now()), "", cb)
+	result.EndedAt = time.Now()
+	if err != nil {
+		result.Status = execution.RunFailed
+		result.Error = err
+		return result, err
+	}
+	if h.memory.IsNoReply(reply.String()) {
+		log.Printf("memory: flush ok (NO_REPLY)")
+	} else {
+		log.Printf("memory: flush replied with text (len=%d)", len(reply.String()))
+	}
+	return result, nil
 }
 
 func (h *Handler) handleMessage(msg *tgbotapi.Message) {
@@ -678,6 +787,11 @@ func (h *Handler) showSessionList(chatID int64) {
 }
 
 func (h *Handler) handleNewSession(chatID int64) {
+	// Flush the outgoing session's memory before switching to a fresh one.
+	if h.willFlush(chatID) {
+		h.sendText(chatID, "💾 Saving memory...")
+	}
+	h.flushMemory(chatID, "new-session")
 	sess, err := h.sessions.NewSession(chatID)
 	if err != nil {
 		h.sendText(chatID, fmt.Sprintf("❌ %v", err))

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -62,6 +62,15 @@ type streamEvent struct {
 	SessionID string      `json:"session_id,omitempty"`
 	Result    string      `json:"result,omitempty"`
 	IsError   bool        `json:"is_error,omitempty"`
+	Usage     *cliUsage   `json:"usage,omitempty"`
+}
+
+// cliUsage is the usage object on the final "result" event.
+type cliUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 }
 
 type cliMessage struct {
@@ -224,6 +233,13 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 
 		case "result":
 			sess.IncrementMessages()
+			if ev.Usage != nil {
+				sess.AddTokens(ev.Usage.InputTokens, ev.Usage.OutputTokens)
+				// Context size proxy for the threshold memory flush: what the
+				// last call actually carried, including cached prompt tokens.
+				sess.SetLastContextTokens(ev.Usage.InputTokens +
+					ev.Usage.CacheReadInputTokens + ev.Usage.CacheCreationInputTokens)
+			}
 			if ev.IsError {
 				return fmt.Errorf("claude error: %s", ev.Result)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Security SecurityConfig `yaml:"security"`
 	Tools    ToolsConfig    `yaml:"tools"`
 	Session  SessionConfig  `yaml:"session"`
+	Memory   MemoryConfig   `yaml:"memory"`
 }
 
 // ClaudeConfig is kept for backward compatibility — the claude CLI subprocess config.
@@ -65,7 +66,32 @@ type ToolsConfig struct {
 }
 
 type SessionConfig struct {
-	DataDir string `yaml:"data_dir"`
+	DataDir string      `yaml:"data_dir"`
+	Reset   ResetConfig `yaml:"reset"`
+}
+
+// ResetConfig controls automatic session rotation (openclaw pattern).
+// Memory is flushed to disk before any automatic reset.
+type ResetConfig struct {
+	DailyAt     string `yaml:"daily_at"`     // "HH:MM" local time; "off" disables (default "04:00")
+	IdleMinutes int    `yaml:"idle_minutes"` // rotate after this much inactivity; 0 disables
+}
+
+// MemoryConfig controls the markdown-based persistent memory system.
+type MemoryConfig struct {
+	Enabled       bool        `yaml:"enabled"`
+	Dir           string      `yaml:"dir"`             // memory root; default: claude.workspace
+	MaxFileChars  int         `yaml:"max_file_chars"`  // per injected file cap (default 20000)
+	MaxTotalChars int         `yaml:"max_total_chars"` // whole memory block cap (default 60000)
+	Flush         FlushConfig `yaml:"flush"`
+}
+
+// FlushConfig controls the silent memory-flush turn that runs before a
+// session is reset or when its context grows past the soft threshold.
+type FlushConfig struct {
+	SoftThresholdTokens int    `yaml:"soft_threshold_tokens"` // default 100000
+	TimeoutSeconds      int    `yaml:"timeout_seconds"`       // default 120
+	Prompt              string `yaml:"prompt"`                // override default flush prompt; {today} expands to today's note path
 }
 
 func Load(path string) (*Config, error) {
@@ -116,6 +142,27 @@ func Load(path string) (*Config, error) {
 	if cfg.Session.DataDir == "" {
 		home, _ := os.UserHomeDir()
 		cfg.Session.DataDir = home + "/.goterm/data"
+	}
+	if cfg.Session.Reset.DailyAt == "" {
+		cfg.Session.Reset.DailyAt = "04:00"
+	}
+	if cfg.Memory.Dir == "" {
+		cfg.Memory.Dir = cfg.Claude.Workspace
+	} else if strings.HasPrefix(cfg.Memory.Dir, "~/") {
+		home, _ := os.UserHomeDir()
+		cfg.Memory.Dir = home + cfg.Memory.Dir[1:]
+	}
+	if cfg.Memory.MaxFileChars == 0 {
+		cfg.Memory.MaxFileChars = 20000
+	}
+	if cfg.Memory.MaxTotalChars == 0 {
+		cfg.Memory.MaxTotalChars = 60000
+	}
+	if cfg.Memory.Flush.SoftThresholdTokens == 0 {
+		cfg.Memory.Flush.SoftThresholdTokens = 100000
+	}
+	if cfg.Memory.Flush.TimeoutSeconds == 0 {
+		cfg.Memory.Flush.TimeoutSeconds = 120
 	}
 	if cfg.Telegram.Indicator.Enabled {
 		if len(cfg.Telegram.Indicator.Frames) == 0 {

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,0 +1,199 @@
+// Package memory implements an openclaw-style persistent memory system for
+// the bot: plain markdown files inside the agent workspace (MEMORY.md for
+// curated long-term memory, memory/YYYY-MM-DD.md for append-only daily notes).
+//
+// The Claude CLI subprocess has full tool access in the workspace, so the
+// agent itself reads, writes, and greps these files. This package only owns
+// the file layout, the context block injected into new sessions, the flush
+// prompt, and the rotation schedule — orchestration lives in the bot handler.
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Config controls the persistent memory system.
+type Config struct {
+	Enabled             bool
+	Dir                 string        // memory root; normally the claude workspace
+	MaxFileChars        int           // per embedded file cap
+	MaxTotalChars       int           // cap for the whole injected block
+	FlushPrompt         string        // custom flush prompt ("" = default)
+	SoftThresholdTokens int           // context tokens that trigger an early flush
+	FlushTimeout        time.Duration // max duration of a flush turn
+}
+
+// Manager owns the markdown memory files inside the agent workspace.
+type Manager struct {
+	cfg Config
+	loc *time.Location
+}
+
+func NewManager(cfg Config) *Manager {
+	return &Manager{cfg: cfg, loc: time.Local}
+}
+
+// Enabled reports whether memory is active. Safe on a nil manager.
+func (m *Manager) Enabled() bool { return m != nil && m.cfg.Enabled && m.cfg.Dir != "" }
+
+func (m *Manager) SoftThresholdTokens() int { return m.cfg.SoftThresholdTokens }
+
+func (m *Manager) FlushTimeout() time.Duration { return m.cfg.FlushTimeout }
+
+// MemoryFilePath returns the absolute path of MEMORY.md.
+func (m *Manager) MemoryFilePath() string { return filepath.Join(m.cfg.Dir, "MEMORY.md") }
+
+// NotesDir returns the absolute path of the daily-notes directory.
+func (m *Manager) NotesDir() string { return filepath.Join(m.cfg.Dir, "memory") }
+
+// TodayNotePath returns the absolute path of today's daily note.
+func (m *Manager) TodayNotePath(now time.Time) string {
+	return filepath.Join(m.NotesDir(), m.dayStamp(now)+".md")
+}
+
+func (m *Manager) dayStamp(t time.Time) string { return t.In(m.loc).Format("2006-01-02") }
+
+// relNote is the workspace-relative daily-note path used inside prompts,
+// e.g. "memory/2026-07-02.md" — the CLI runs with the workspace as cwd.
+func (m *Manager) relNote(t time.Time) string { return "memory/" + m.dayStamp(t) + ".md" }
+
+// Bootstrap creates the memory directory and seeds MEMORY.md if missing.
+// It never overwrites existing files.
+func (m *Manager) Bootstrap() error {
+	if !m.Enabled() {
+		return nil
+	}
+	if err := os.MkdirAll(m.NotesDir(), 0755); err != nil {
+		return fmt.Errorf("create memory dir: %w", err)
+	}
+	path := m.MemoryFilePath()
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(memorySeed), 0644); err != nil {
+		return fmt.Errorf("seed MEMORY.md: %w", err)
+	}
+	return nil
+}
+
+// BuildContext returns the memory block appended to the system prompt of a
+// brand-new session: usage policy + MEMORY.md + today's + yesterday's notes.
+// Returns "" when memory is disabled.
+func (m *Manager) BuildContext(now time.Time) string {
+	if !m.Enabled() {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf(policyHeader, m.relNote(now)))
+
+	sb.WriteString("\n### MEMORY.md\n")
+	sb.WriteString(m.readCapped(m.MemoryFilePath(), "MEMORY.md", "(empty)"))
+
+	sb.WriteString(fmt.Sprintf("\n\n### Today (%s)\n", m.relNote(now)))
+	sb.WriteString(m.readCapped(m.TodayNotePath(now), m.relNote(now), "(no notes yet)"))
+
+	yesterday := now.AddDate(0, 0, -1)
+	sb.WriteString(fmt.Sprintf("\n\n### Yesterday (%s)\n", m.relNote(yesterday)))
+	sb.WriteString(m.readCapped(m.TodayNotePath(yesterday), m.relNote(yesterday), "(no notes)"))
+	sb.WriteString("\n")
+
+	out := sb.String()
+	if max := m.cfg.MaxTotalChars; max > 0 {
+		if r := []rune(out); len(r) > max {
+			out = string(r[:max]) + "\n[memory truncated — read MEMORY.md and memory/ for full contents]\n"
+		}
+	}
+	return out
+}
+
+// readCapped reads a file trimmed and capped at MaxFileChars, appending a
+// truncation marker that points the agent at the on-disk file.
+func (m *Manager) readCapped(path, relPath, empty string) string {
+	data, err := os.ReadFile(path)
+	content := strings.TrimSpace(string(data))
+	if err != nil || content == "" {
+		return empty
+	}
+	if max := m.cfg.MaxFileChars; max > 0 {
+		if r := []rune(content); len(r) > max {
+			return string(r[:max]) + fmt.Sprintf("\n[truncated — read %s for the rest]", relPath)
+		}
+	}
+	return content
+}
+
+// AppendNote appends a timestamped bullet to today's daily note, creating the
+// file (with a date header) and directory as needed. Used by /remember.
+func (m *Manager) AppendNote(now time.Time, text string) error {
+	if !m.Enabled() {
+		return fmt.Errorf("memory is disabled")
+	}
+	if err := os.MkdirAll(m.NotesDir(), 0755); err != nil {
+		return fmt.Errorf("create memory dir: %w", err)
+	}
+	path := m.TodayNotePath(now)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	entry := ""
+	if st.Size() == 0 {
+		entry = "# " + m.dayStamp(now) + "\n\n"
+	}
+	entry += fmt.Sprintf("- %s %s\n", now.In(m.loc).Format("15:04"), strings.TrimSpace(text))
+	_, err = f.WriteString(entry)
+	return err
+}
+
+// Stats summarises the memory store for the /memory command.
+type Stats struct {
+	Dir             string
+	MemoryMDBytes   int64
+	MemoryMDPreview string
+	DailyNoteCount  int
+	TodayBytes      int64
+}
+
+const previewChars = 600
+
+// Stats returns a summary of the memory files on disk.
+func (m *Manager) Stats(now time.Time) (Stats, error) {
+	st := Stats{Dir: m.cfg.Dir}
+	if !m.Enabled() {
+		return st, fmt.Errorf("memory is disabled")
+	}
+
+	if data, err := os.ReadFile(m.MemoryFilePath()); err == nil {
+		st.MemoryMDBytes = int64(len(data))
+		preview := strings.TrimSpace(string(data))
+		if r := []rune(preview); len(r) > previewChars {
+			preview = string(r[:previewChars]) + "..."
+		}
+		st.MemoryMDPreview = preview
+	}
+
+	if entries, err := os.ReadDir(m.NotesDir()); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+				st.DailyNoteCount++
+			}
+		}
+	}
+
+	if fi, err := os.Stat(m.TodayNotePath(now)); err == nil {
+		st.TodayBytes = fi.Size()
+	}
+	return st, nil
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,0 +1,238 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testManager(t *testing.T, cfg Config) *Manager {
+	t.Helper()
+	if cfg.Dir == "" {
+		cfg.Dir = t.TempDir()
+	}
+	cfg.Enabled = true
+	return NewManager(cfg)
+}
+
+func TestBootstrapIdempotent(t *testing.T) {
+	m := testManager(t, Config{})
+	if err := m.Bootstrap(); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if _, err := os.Stat(m.MemoryFilePath()); err != nil {
+		t.Fatalf("MEMORY.md not created: %v", err)
+	}
+	if _, err := os.Stat(m.NotesDir()); err != nil {
+		t.Fatalf("memory/ not created: %v", err)
+	}
+
+	// Second bootstrap must not overwrite user edits.
+	custom := []byte("# MEMORY.md\n- user fact\n")
+	if err := os.WriteFile(m.MemoryFilePath(), custom, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Bootstrap(); err != nil {
+		t.Fatalf("second bootstrap: %v", err)
+	}
+	data, _ := os.ReadFile(m.MemoryFilePath())
+	if string(data) != string(custom) {
+		t.Errorf("bootstrap overwrote MEMORY.md: %q", data)
+	}
+}
+
+func TestBuildContextIncludesFiles(t *testing.T) {
+	m := testManager(t, Config{MaxFileChars: 20000, MaxTotalChars: 60000})
+	if err := m.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 2, 10, 0, 0, 0, time.Local)
+
+	os.WriteFile(m.MemoryFilePath(), []byte("- user is ngoc"), 0644)
+	os.WriteFile(m.TodayNotePath(now), []byte("- today note"), 0644)
+	os.WriteFile(m.TodayNotePath(now.AddDate(0, 0, -1)), []byte("- yesterday note"), 0644)
+
+	got := m.BuildContext(now)
+	for _, want := range []string{
+		"## Persistent Memory",
+		"memory/2026-07-02.md",
+		"- user is ngoc",
+		"- today note",
+		"### Yesterday (memory/2026-07-01.md)",
+		"- yesterday note",
+		"grep -ri",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("BuildContext missing %q", want)
+		}
+	}
+}
+
+func TestBuildContextEmptyFiles(t *testing.T) {
+	m := testManager(t, Config{})
+	now := time.Date(2026, 7, 2, 10, 0, 0, 0, time.Local)
+	got := m.BuildContext(now)
+	for _, want := range []string{"(empty)", "(no notes yet)", "(no notes)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("BuildContext missing placeholder %q", want)
+		}
+	}
+}
+
+func TestBuildContextDisabled(t *testing.T) {
+	m := NewManager(Config{Enabled: false, Dir: t.TempDir()})
+	if got := m.BuildContext(time.Now()); got != "" {
+		t.Errorf("disabled manager returned context: %q", got)
+	}
+	var nilManager *Manager
+	if nilManager.Enabled() {
+		t.Error("nil manager reported enabled")
+	}
+}
+
+func TestBuildContextPerFileCap(t *testing.T) {
+	m := testManager(t, Config{MaxFileChars: 100, MaxTotalChars: 60000})
+	now := time.Now()
+	os.WriteFile(m.MemoryFilePath(), []byte(strings.Repeat("x", 500)), 0644)
+
+	got := m.BuildContext(now)
+	if !strings.Contains(got, "[truncated — read MEMORY.md for the rest]") {
+		t.Error("missing per-file truncation marker")
+	}
+	if strings.Contains(got, strings.Repeat("x", 200)) {
+		t.Error("file content not capped")
+	}
+}
+
+func TestBuildContextTotalCap(t *testing.T) {
+	m := testManager(t, Config{MaxFileChars: 20000, MaxTotalChars: 500})
+	now := time.Now()
+	os.WriteFile(m.MemoryFilePath(), []byte(strings.Repeat("y", 2000)), 0644)
+
+	got := m.BuildContext(now)
+	if !strings.Contains(got, "[memory truncated") {
+		t.Error("missing total truncation marker")
+	}
+	if len([]rune(got)) > 600 {
+		t.Errorf("block not capped: %d chars", len([]rune(got)))
+	}
+}
+
+func TestAppendNote(t *testing.T) {
+	m := testManager(t, Config{})
+	now := time.Date(2026, 7, 2, 15, 4, 0, 0, time.Local)
+
+	if err := m.AppendNote(now, "first fact"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := m.AppendNote(now, "second fact"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	data, err := os.ReadFile(m.TodayNotePath(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.HasPrefix(got, "# 2026-07-02\n") {
+		t.Errorf("missing date header: %q", got)
+	}
+	if !strings.Contains(got, "- 15:04 first fact\n") || !strings.Contains(got, "- 15:04 second fact\n") {
+		t.Errorf("missing bullets: %q", got)
+	}
+	if strings.Count(got, "# 2026-07-02") != 1 {
+		t.Errorf("header duplicated: %q", got)
+	}
+}
+
+func TestFlushPrompt(t *testing.T) {
+	m := testManager(t, Config{})
+	now := time.Date(2026, 7, 2, 10, 0, 0, 0, time.Local)
+
+	got := m.FlushPrompt(now)
+	if !strings.Contains(got, "memory/2026-07-02.md") {
+		t.Errorf("flush prompt missing today path: %q", got)
+	}
+	if !strings.Contains(got, NoReplySentinel) {
+		t.Error("flush prompt missing sentinel")
+	}
+
+	custom := testManager(t, Config{FlushPrompt: "save to {today} please"})
+	if got := custom.FlushPrompt(now); got != "save to memory/2026-07-02.md please" {
+		t.Errorf("custom prompt: %q", got)
+	}
+}
+
+func TestIsNoReply(t *testing.T) {
+	m := testManager(t, Config{})
+	if !m.IsNoReply("  NO_REPLY \n") {
+		t.Error("trimmed sentinel not detected")
+	}
+	if m.IsNoReply("NO_REPLY but also saved 3 notes") {
+		t.Error("false positive on longer reply")
+	}
+}
+
+func TestStats(t *testing.T) {
+	m := testManager(t, Config{})
+	if err := m.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	if err := m.AppendNote(now, "a fact"); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(m.NotesDir(), "2026-01-01.md"), []byte("- old"), 0644)
+
+	st, err := m.Stats(now)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if st.MemoryMDBytes == 0 {
+		t.Error("MEMORY.md size not reported")
+	}
+	if st.DailyNoteCount != 2 {
+		t.Errorf("DailyNoteCount = %d, want 2", st.DailyNoteCount)
+	}
+	if st.TodayBytes == 0 {
+		t.Error("today size not reported")
+	}
+}
+
+func TestShouldRotate(t *testing.T) {
+	loc := time.Local
+	base := time.Date(2026, 7, 2, 10, 0, 0, 0, loc) // 10:00 today
+
+	cases := []struct {
+		name         string
+		lastActivity time.Time
+		now          time.Time
+		dailyAt      string
+		idle         time.Duration
+		want         bool
+		wantReason   string
+	}{
+		{"active this morning after boundary", time.Date(2026, 7, 2, 8, 0, 0, 0, loc), base, "04:00", 0, false, ""},
+		{"last active yesterday evening", time.Date(2026, 7, 1, 22, 0, 0, 0, loc), base, "04:00", 0, true, "daily"},
+		{"last active before 4am today", time.Date(2026, 7, 2, 3, 0, 0, 0, loc), base, "04:00", 0, true, "daily"},
+		{"now before boundary, active yesterday after prev boundary", time.Date(2026, 7, 1, 23, 0, 0, 0, loc), time.Date(2026, 7, 2, 2, 0, 0, 0, loc), "04:00", 0, false, ""},
+		{"daily disabled via off", time.Date(2026, 6, 20, 10, 0, 0, 0, loc), base, "off", 0, false, ""},
+		{"daily disabled via empty", time.Date(2026, 6, 20, 10, 0, 0, 0, loc), base, "", 0, false, ""},
+		{"idle exceeded", base.Add(-2 * time.Hour), base, "off", time.Hour, true, "idle"},
+		{"idle not exceeded", base.Add(-30 * time.Minute), base, "off", time.Hour, false, ""},
+		{"idle wins over daily", time.Date(2026, 7, 1, 6, 0, 0, 0, loc), base, "04:00", time.Hour, true, "idle"},
+		{"zero last activity", time.Time{}, base, "04:00", time.Hour, false, ""},
+		{"invalid dailyAt ignored", time.Date(2026, 6, 20, 10, 0, 0, 0, loc), base, "4am", 0, false, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := ShouldRotate(tc.lastActivity, tc.now, tc.dailyAt, tc.idle)
+			if got != tc.want || reason != tc.wantReason {
+				t.Errorf("ShouldRotate() = (%v, %q), want (%v, %q)", got, reason, tc.want, tc.wantReason)
+			}
+		})
+	}
+}

--- a/internal/memory/prompts.go
+++ b/internal/memory/prompts.go
@@ -1,0 +1,62 @@
+package memory
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// NoReplySentinel is what the agent replies with after a successful flush
+// turn when it has nothing to say to the user (openclaw NO_REPLY pattern).
+const NoReplySentinel = "NO_REPLY"
+
+// policyHeader is the memory usage policy injected at the top of the memory
+// block. The %s placeholder is today's workspace-relative note path.
+const policyHeader = `
+
+## Persistent Memory
+
+You have persistent memory stored as markdown in your workspace:
+- MEMORY.md — curated long-term memory (stable facts, preferences, active projects, key decisions). Keep it lean (< ~200 lines).
+- memory/YYYY-MM-DD.md — append-only daily notes. Today's file: %s
+
+Rules:
+1. MANDATORY: before answering questions about prior work, decisions, dates, people, preferences, or TODOs not visible in this conversation, search memory first: grep -ri "<keyword>" memory/ MEMORY.md
+2. When an important fact emerges (a decision, preference, project state change, follow-up), silently append a short bullet to today's note. Do not announce it or ask permission.
+3. Periodically synthesize durable facts from daily notes into MEMORY.md; remove stale entries.
+4. Never store secrets (tokens, passwords, keys) in memory files.
+`
+
+// defaultFlushPrompt is sent as a user turn on the resumed session right
+// before it is reset. The %s placeholders are today's relative note path.
+const defaultFlushPrompt = `[Memory flush — session is about to be reset; its context will be lost]
+Review this conversation and append anything worth remembering to %s:
+decisions made, current task state and next steps, new facts about the user or projects, open TODOs.
+Use short markdown bullets under a "## HH:MM" heading. Update MEMORY.md only if a durable long-term fact emerged.
+If nothing is worth saving, write nothing. Do not address the user. When done, reply with exactly: ` + NoReplySentinel + "\n"
+
+// memorySeed is the initial MEMORY.md created by Bootstrap.
+const memorySeed = `# MEMORY.md — Long-Term Memory
+
+<!--
+Curated long-term memory for the assistant. Keep it lean (< ~200 lines):
+synthesize, don't transcribe. Detailed day-to-day observations belong in
+memory/YYYY-MM-DD.md; promote only durable facts here and prune stale ones.
+Sections you may want: User, Preferences, Active Projects, Decisions.
+-->
+`
+
+// FlushPrompt returns the prompt for a silent memory-flush turn. A custom
+// prompt from config may embed {today} which expands to the relative path of
+// today's daily note.
+func (m *Manager) FlushPrompt(now time.Time) string {
+	if p := strings.TrimSpace(m.cfg.FlushPrompt); p != "" {
+		return strings.ReplaceAll(p, "{today}", m.relNote(now))
+	}
+	return fmt.Sprintf(defaultFlushPrompt, m.relNote(now))
+}
+
+// IsNoReply reports whether a flush reply is the bare NO_REPLY sentinel.
+func (m *Manager) IsNoReply(reply string) bool {
+	return strings.TrimSpace(reply) == NoReplySentinel
+}

--- a/internal/memory/schedule.go
+++ b/internal/memory/schedule.go
@@ -1,0 +1,51 @@
+package memory
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ShouldRotate reports whether a session last active at lastActivity should
+// be rotated (memory flush + reset) at now, and why ("daily" or "idle").
+//
+// Daily: the session was last active before the most recent dailyAt boundary
+// (e.g. "04:00" local). Idle: more than idle has passed since last activity
+// (0 disables). Rotation is checked lazily on the next inbound message — the
+// caller only invokes this for sessions with a live CLI session ID.
+func ShouldRotate(lastActivity, now time.Time, dailyAt string, idle time.Duration) (bool, string) {
+	if lastActivity.IsZero() {
+		return false, ""
+	}
+	if idle > 0 && now.Sub(lastActivity) > idle {
+		return true, "idle"
+	}
+	if h, m, ok := parseDailyAt(dailyAt); ok {
+		boundary := time.Date(now.Year(), now.Month(), now.Day(), h, m, 0, 0, now.Location())
+		if boundary.After(now) {
+			boundary = boundary.AddDate(0, 0, -1)
+		}
+		if lastActivity.Before(boundary) {
+			return true, "daily"
+		}
+	}
+	return false, ""
+}
+
+// parseDailyAt parses "HH:MM". Empty or "off" disables the daily boundary.
+func parseDailyAt(s string) (hour, min int, ok bool) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" || s == "off" {
+		return 0, 0, false
+	}
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	h, err1 := strconv.Atoi(parts[0])
+	m, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, 0, false
+	}
+	return h, m, true
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -19,9 +19,15 @@ type Session struct {
 	CompactSummary  string    `json:"compact_summary,omitempty"`
 	Label           string    `json:"label,omitempty"`
 	Seq             int       `json:"seq"`
+	MemoryFlushed   bool      `json:"memory_flushed,omitempty"` // threshold flush already ran this session
 
 	mu       sync.Mutex `json:"-"`
 	cancelFn func()     `json:"-"`
+
+	// lastContextTokens is the context size of the most recent CLI call
+	// (input + cache tokens). In-memory only — after a restart the threshold
+	// flush simply re-arms on the next turn.
+	lastContextTokens int `json:"-"`
 
 	// Live run state (not persisted) — populated while a request is executing
 	// so /status can report what the agent is currently doing.
@@ -55,6 +61,7 @@ type SessionSnapshot struct {
 	CompactSummary  string
 	Label           string
 	Seq             int
+	MemoryFlushed   bool
 }
 
 func New(chatID int64) *Session {
@@ -141,7 +148,45 @@ func (s *Session) Reset() {
 	defer s.mu.Unlock()
 	s.ClaudeSessionID = ""
 	s.MessageCount = 0
+	s.MemoryFlushed = false
+	s.lastContextTokens = 0
 	s.UpdatedAt = time.Now()
+}
+
+// LastActivity returns when the session last saw a turn or state change.
+func (s *Session) LastActivity() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.UpdatedAt
+}
+
+// SetLastContextTokens records the context size of the most recent CLI call.
+func (s *Session) SetLastContextTokens(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastContextTokens = n
+}
+
+// LastContextTokens returns the context size of the most recent CLI call.
+func (s *Session) LastContextTokens() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastContextTokens
+}
+
+// MarkMemoryFlushed records that the threshold-triggered memory flush ran,
+// so it fires at most once per session. Cleared by Reset.
+func (s *Session) MarkMemoryFlushed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.MemoryFlushed = true
+}
+
+// IsMemoryFlushed reports whether the threshold flush already ran.
+func (s *Session) IsMemoryFlushed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.MemoryFlushed
 }
 
 // MarkRunning records that a request has started executing for this session.
@@ -234,11 +279,12 @@ func (s *Session) Snapshot() SessionSnapshot {
 		CompactSummary:  s.CompactSummary,
 		Label:           s.Label,
 		Seq:             s.Seq,
+		MemoryFlushed:   s.MemoryFlushed,
 	}
 }
 
 // NewFromDB creates a Session from database fields (used by SQLite store).
-func NewFromDB(id string, chatID int64, created, updated time.Time, claudeSessionID string, msgCount, inTok, outTok int, compactSummary, label string, seq int) *Session {
+func NewFromDB(id string, chatID int64, created, updated time.Time, claudeSessionID string, msgCount, inTok, outTok int, compactSummary, label string, seq int, memoryFlushed bool) *Session {
 	return &Session{
 		ID:              id,
 		ChatID:          chatID,
@@ -251,6 +297,7 @@ func NewFromDB(id string, chatID int64, created, updated time.Time, claudeSessio
 		CompactSummary:  compactSummary,
 		Label:           label,
 		Seq:             seq,
+		MemoryFlushed:   memoryFlushed,
 	}
 }
 

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -76,8 +77,8 @@ func TestSessionStoreRoundtrip(t *testing.T) {
 	db := testDB(t)
 	store := NewSessionStore(db)
 
-	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_abc", 5, 1000, 500, "summary text", "First chat", 0)
-	s2 := session.NewFromDB("chat_200", 200, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_abc", 5, 1000, 500, "summary text", "First chat", 0, false)
+	s2 := session.NewFromDB("chat_200", 200, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0, false)
 
 	if err := store.Save(chatStates(s1, s2)); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -115,7 +116,7 @@ func TestSessionStoreUpsert(t *testing.T) {
 	db := testDB(t)
 	store := NewSessionStore(db)
 
-	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "v1", 1, 100, 50, "", "", 0)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "v1", 1, 100, 50, "", "", 0, false)
 	store.Save(chatStates(s))
 
 	// Update
@@ -138,8 +139,8 @@ func TestSessionStoreMultipleSessionsPerChat(t *testing.T) {
 	db := testDB(t)
 	store := NewSessionStore(db)
 
-	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_1", 5, 100, 50, "", "Session 1", 0)
-	s2 := session.NewFromDB("chat_100_1", 100, time.Now(), time.Now(), "claude_2", 3, 200, 80, "", "Session 2", 1)
+	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "claude_1", 5, 100, 50, "", "Session 1", 0, false)
+	s2 := session.NewFromDB("chat_100_1", 100, time.Now(), time.Now(), "claude_2", 3, 200, 80, "", "Session 2", 1, false)
 
 	chats := map[int64]*session.ChatState{
 		100: {
@@ -180,7 +181,7 @@ func TestMessageStoreRoundtrip(t *testing.T) {
 	sessStore := NewSessionStore(db)
 	msgStore := NewMessageStore(db)
 
-	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0, false)
 	sessStore.Save(chatStates(s))
 
 	msgs := []agent.Message{
@@ -216,7 +217,7 @@ func TestMessageStoreLimit(t *testing.T) {
 	sessStore := NewSessionStore(db)
 	msgStore := NewMessageStore(db)
 
-	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0, false)
 	sessStore.Save(chatStates(s))
 
 	for i := 0; i < 10; i++ {
@@ -237,7 +238,7 @@ func TestMessageStoreDeleteBySession(t *testing.T) {
 	sessStore := NewSessionStore(db)
 	msgStore := NewMessageStore(db)
 
-	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0)
+	s := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "", 0, 0, 0, "", "", 0, false)
 	sessStore.Save(chatStates(s))
 
 	msgStore.Append("chat_100", agent.Message{Role: "user", Content: "hello"})
@@ -308,5 +309,95 @@ func TestOpenIdempotent(t *testing.T) {
 	ver, _ := db2.currentVersion()
 	if ver != schemaVersion {
 		t.Errorf("version after reopen = %d, want %d", ver, schemaVersion)
+	}
+}
+
+func TestMigrateV2ToV3(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	// Build a v2 database by hand (no memory_flushed column, version 2).
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	stmts := []string{
+		`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		`INSERT INTO meta(key, value) VALUES('schema_version', '2')`,
+		`CREATE TABLE sessions (
+			id                TEXT PRIMARY KEY,
+			chat_id           INTEGER NOT NULL,
+			created_at        TEXT NOT NULL,
+			updated_at        TEXT NOT NULL,
+			claude_session_id TEXT DEFAULT '',
+			message_count     INTEGER DEFAULT 0,
+			input_tokens      INTEGER DEFAULT 0,
+			output_tokens     INTEGER DEFAULT 0,
+			compact_summary   TEXT DEFAULT '',
+			label             TEXT DEFAULT '',
+			seq               INTEGER DEFAULT 0
+		)`,
+		`CREATE TABLE chat_state (
+			chat_id           INTEGER PRIMARY KEY,
+			active_session_id TEXT NOT NULL,
+			next_seq          INTEGER DEFAULT 1
+		)`,
+		`CREATE TABLE messages (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id   TEXT NOT NULL,
+			role         TEXT NOT NULL,
+			content      TEXT NOT NULL,
+			tool_calls   TEXT DEFAULT '',
+			tool_results TEXT DEFAULT '',
+			tokens       INTEGER DEFAULT 0,
+			created_at   TEXT NOT NULL
+		)`,
+		`INSERT INTO sessions (id, chat_id, created_at, updated_at, claude_session_id, message_count)
+			VALUES ('chat_100', 100, '2026-07-01T10:00:00Z', '2026-07-01T10:00:00Z', 'claude_v2', 4)`,
+		`INSERT INTO chat_state (chat_id, active_session_id, next_seq) VALUES (100, 'chat_100', 1)`,
+	}
+	for _, s := range stmts {
+		if _, err := raw.Exec(s); err != nil {
+			t.Fatalf("seed v2 db: %v\n%s", err, s)
+		}
+	}
+	raw.Close()
+
+	// Open runs the migration.
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (migrate): %v", err)
+	}
+	defer db.Close()
+
+	ver, _ := db.currentVersion()
+	if ver != 3 {
+		t.Errorf("version = %d, want 3", ver)
+	}
+
+	// Existing row must load with memory_flushed defaulting to false.
+	loaded, err := NewSessionStore(db).Load()
+	if err != nil {
+		t.Fatalf("Load after migrate: %v", err)
+	}
+	s := loaded[100].Sessions["chat_100"]
+	if s == nil {
+		t.Fatal("session chat_100 not found after migration")
+	}
+	if s.GetSessionID() != "claude_v2" || s.GetMessageCount() != 4 {
+		t.Errorf("migrated session data lost: id=%q count=%d", s.GetSessionID(), s.GetMessageCount())
+	}
+	if s.IsMemoryFlushed() {
+		t.Error("memory_flushed should default to false after migration")
+	}
+
+	// Round-trip the new flag through Save/Load.
+	s.MarkMemoryFlushed()
+	if err := NewSessionStore(db).Save(loaded); err != nil {
+		t.Fatalf("Save after migrate: %v", err)
+	}
+	reloaded, _ := NewSessionStore(db).Load()
+	if !reloaded[100].Sessions["chat_100"].IsMemoryFlushed() {
+		t.Error("memory_flushed flag did not persist")
 	}
 }

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -2,7 +2,7 @@ package storage
 
 import "fmt"
 
-const schemaVersion = 2
+const schemaVersion = 3
 
 // DDL statements executed in order for fresh installs.
 var ddl = []string{
@@ -22,7 +22,8 @@ var ddl = []string{
 		output_tokens     INTEGER DEFAULT 0,
 		compact_summary   TEXT DEFAULT '',
 		label             TEXT DEFAULT '',
-		seq               INTEGER DEFAULT 0
+		seq               INTEGER DEFAULT 0,
+		memory_flushed    INTEGER DEFAULT 0
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_sessions_chat ON sessions(chat_id)`,
 
@@ -64,9 +65,25 @@ func (db *DB) migrate() error {
 		if err := db.migrateV1ToV2(); err != nil {
 			return fmt.Errorf("migrate v1→v2: %w", err)
 		}
-		return db.setVersion(2)
+		if err := db.setVersion(2); err != nil {
+			return err
+		}
+		ver = 2
+	}
+	if ver < 3 {
+		if err := db.migrateV2ToV3(); err != nil {
+			return fmt.Errorf("migrate v2→v3: %w", err)
+		}
+		return db.setVersion(3)
 	}
 	return nil
+}
+
+// migrateV2ToV3 adds the memory_flushed column used by the token-threshold
+// memory flush (fires at most once per session).
+func (db *DB) migrateV2ToV3() error {
+	_, err := db.conn.Exec(`ALTER TABLE sessions ADD COLUMN memory_flushed INTEGER DEFAULT 0`)
+	return err
 }
 
 // migrateV1ToV2 removes the UNIQUE constraint on chat_id, adds label/seq

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -23,7 +23,7 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 	rows, err := s.db.conn.Query(`SELECT
 		id, chat_id, created_at, updated_at, claude_session_id,
 		message_count, input_tokens, output_tokens, compact_summary,
-		label, seq
+		label, seq, memory_flushed
 		FROM sessions`)
 	if err != nil {
 		return nil, fmt.Errorf("query sessions: %w", err)
@@ -37,16 +37,17 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 			chatID                       int64
 			createdStr, updatedStr       string
 			msgCount, inTok, outTok, seq int
+			memFlushed                   int
 		)
 		if err := rows.Scan(&id, &chatID, &createdStr, &updatedStr, &claudeID,
-			&msgCount, &inTok, &outTok, &summary, &label, &seq); err != nil {
+			&msgCount, &inTok, &outTok, &summary, &label, &seq, &memFlushed); err != nil {
 			continue
 		}
 
 		created, _ := time.Parse(time.RFC3339, createdStr)
 		updated, _ := time.Parse(time.RFC3339, updatedStr)
 
-		sess := session.NewFromDB(id, chatID, created, updated, claudeID, msgCount, inTok, outTok, summary, label, seq)
+		sess := session.NewFromDB(id, chatID, created, updated, claudeID, msgCount, inTok, outTok, summary, label, seq, memFlushed != 0)
 
 		cs, ok := chats[chatID]
 		if !ok {
@@ -110,8 +111,9 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 
 	sessStmt, err := tx.Prepare(`INSERT INTO sessions
 		(id, chat_id, created_at, updated_at, claude_session_id,
-		 message_count, input_tokens, output_tokens, compact_summary, label, seq)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 message_count, input_tokens, output_tokens, compact_summary, label, seq,
+		 memory_flushed)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			updated_at = excluded.updated_at,
 			claude_session_id = excluded.claude_session_id,
@@ -119,7 +121,8 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 			input_tokens = excluded.input_tokens,
 			output_tokens = excluded.output_tokens,
 			compact_summary = excluded.compact_summary,
-			label = excluded.label`)
+			label = excluded.label,
+			memory_flushed = excluded.memory_flushed`)
 	if err != nil {
 		return fmt.Errorf("prepare sessions: %w", err)
 	}
@@ -139,12 +142,16 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 	for chatID, cs := range chats {
 		for _, sess := range cs.Sessions {
 			snap := sess.Snapshot()
+			memFlushed := 0
+			if snap.MemoryFlushed {
+				memFlushed = 1
+			}
 			_, err := sessStmt.Exec(
 				snap.ID, snap.ChatID,
 				snap.CreatedAt.Format(time.RFC3339), snap.UpdatedAt.Format(time.RFC3339),
 				snap.ClaudeSessionID, snap.MessageCount,
 				snap.InputTokens, snap.OutputTokens, snap.CompactSummary,
-				snap.Label, snap.Seq,
+				snap.Label, snap.Seq, memFlushed,
 			)
 			if err != nil {
 				return fmt.Errorf("upsert session %s: %w", snap.ID, err)


### PR DESCRIPTION
## Summary

Adds an OpenClaw-style persistent memory system so the bot remembers the user, preferences, and in-progress work across sessions.

- **Passive memory layer** — new `internal/memory` package managing markdown memory in the claude workspace: `MEMORY.md` (curated long-term, seeded on bootstrap) + `memory/YYYY-MM-DD.md` (append-only daily notes). New sessions get an injected context block (usage policy + MEMORY.md + today/yesterday notes, capped 20k/file, 60k total) via the existing `--append-system-prompt` pipe. Recall is grep-based: the CLI subprocess greps `memory/` itself. New commands: `/memory` (stats + preview), `/remember <fact>` (instant append, no Claude turn).
- **Memory flush** — before `/reset`, `/new`, and `/model` clear the CLI session, a silent resumed turn prompts the agent to write durable notes to today's daily note (NO_REPLY sentinel, never streamed to Telegram). Runs through the per-chat execution lane; failures log and never block the reset. `/model` captures the outgoing model first since CLI sessions are model-bound.
- **Session lifecycle** — sessions rotate lazily at the daily boundary (`session.reset.daily_at`, default 04:00 local) or after `idle_minutes` of inactivity, always flushing first and re-injecting recent history so rotation is invisible. A soft-threshold flush fires once per session at 100k context tokens (persisted `memory_flushed` flag, schema v3 migration). Also fixes `/status` always showing 0 tokens — CLI usage was never parsed.

## Config

Claims the previously-dead `memory:` key in config.yaml:

```yaml
session:
  reset: { daily_at: "04:00", idle_minutes: 0 }
memory:
  enabled: true
  dir: ""  # default: claude.workspace
  max_file_chars: 20000
  max_total_chars: 60000
  flush: { soft_threshold_tokens: 100000, timeout_seconds: 120, prompt: "" }
```

## Test plan

- [x] Unit tests: memory (caps/truncation, ShouldRotate table tests, bootstrap idempotency, flush prompt), storage (v2→v3 migration + flag round-trip), session, bot — all pass
- [x] `go build ./cmd/bomclaw` + config.yaml smoke load (defaults resolve, dir expands)
- [ ] E2E after deploy: fact recall across `/reset`, flush section in daily note, rotation log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)