### PR TITLE
fix(memory): use absolute paths so flush writes land in the workspace store

### DIFF
--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -57,10 +57,6 @@ func (m *Manager) TodayNotePath(now time.Time) string {
 
 func (m *Manager) dayStamp(t time.Time) string { return t.In(m.loc).Format("2006-01-02") }
 
-// relNote is the workspace-relative daily-note path used inside prompts,
-// e.g. "memory/2026-07-02.md" — the CLI runs with the workspace as cwd.
-func (m *Manager) relNote(t time.Time) string { return "memory/" + m.dayStamp(t) + ".md" }
-
 // Bootstrap creates the memory directory and seeds MEMORY.md if missing.
 // It never overwrites existing files.
 func (m *Manager) Bootstrap() error {
@@ -89,23 +85,25 @@ func (m *Manager) BuildContext(now time.Time) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(policyHeader, m.relNote(now)))
+	sb.WriteString(fmt.Sprintf(policyHeader, m.MemoryFilePath(), m.NotesDir(), m.TodayNotePath(now)))
 
-	sb.WriteString("\n### MEMORY.md\n")
-	sb.WriteString(m.readCapped(m.MemoryFilePath(), "MEMORY.md", "(empty)"))
+	sb.WriteString(fmt.Sprintf("\n### %s\n", m.MemoryFilePath()))
+	sb.WriteString(m.readCapped(m.MemoryFilePath(), "(empty)"))
 
-	sb.WriteString(fmt.Sprintf("\n\n### Today (%s)\n", m.relNote(now)))
-	sb.WriteString(m.readCapped(m.TodayNotePath(now), m.relNote(now), "(no notes yet)"))
+	sb.WriteString(fmt.Sprintf("\n\n### Today (%s)\n", m.TodayNotePath(now)))
+	sb.WriteString(m.readCapped(m.TodayNotePath(now), "(no notes yet)"))
 
 	yesterday := now.AddDate(0, 0, -1)
-	sb.WriteString(fmt.Sprintf("\n\n### Yesterday (%s)\n", m.relNote(yesterday)))
-	sb.WriteString(m.readCapped(m.TodayNotePath(yesterday), m.relNote(yesterday), "(no notes)"))
+	sb.WriteString(fmt.Sprintf("\n\n### Yesterday (%s)\n", m.TodayNotePath(yesterday)))
+	sb.WriteString(m.readCapped(m.TodayNotePath(yesterday), "(no notes)"))
 	sb.WriteString("\n")
 
 	out := sb.String()
 	if max := m.cfg.MaxTotalChars; max > 0 {
 		if r := []rune(out); len(r) > max {
-			out = string(r[:max]) + "\n[memory truncated — read MEMORY.md and memory/ for full contents]\n"
+			out = string(r[:max]) + fmt.Sprintf(
+				"\n[memory truncated — read %s and %s for full contents]\n",
+				m.MemoryFilePath(), m.NotesDir())
 		}
 	}
 	return out
@@ -113,7 +111,7 @@ func (m *Manager) BuildContext(now time.Time) string {
 
 // readCapped reads a file trimmed and capped at MaxFileChars, appending a
 // truncation marker that points the agent at the on-disk file.
-func (m *Manager) readCapped(path, relPath, empty string) string {
+func (m *Manager) readCapped(path, empty string) string {
 	data, err := os.ReadFile(path)
 	content := strings.TrimSpace(string(data))
 	if err != nil || content == "" {
@@ -121,7 +119,7 @@ func (m *Manager) readCapped(path, relPath, empty string) string {
 	}
 	if max := m.cfg.MaxFileChars; max > 0 {
 		if r := []rune(content); len(r) > max {
-			return string(r[:max]) + fmt.Sprintf("\n[truncated — read %s for the rest]", relPath)
+			return string(r[:max]) + fmt.Sprintf("\n[truncated — read %s for the rest]", path)
 		}
 	}
 	return content

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -57,12 +57,13 @@ func TestBuildContextIncludesFiles(t *testing.T) {
 	got := m.BuildContext(now)
 	for _, want := range []string{
 		"## Persistent Memory",
-		"memory/2026-07-02.md",
+		m.TodayNotePath(now), // absolute path — relative "memory/..." resolves to the CLI's own memory dir
 		"- user is ngoc",
 		"- today note",
-		"### Yesterday (memory/2026-07-01.md)",
+		"### Yesterday (" + m.TodayNotePath(now.AddDate(0, 0, -1)) + ")",
 		"- yesterday note",
-		"grep -ri",
+		"grep -ri \"<keyword>\" " + m.NotesDir() + " " + m.MemoryFilePath(),
+		"Do NOT write these notes into any ~/.claude/projects",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("BuildContext missing %q", want)
@@ -98,7 +99,7 @@ func TestBuildContextPerFileCap(t *testing.T) {
 	os.WriteFile(m.MemoryFilePath(), []byte(strings.Repeat("x", 500)), 0644)
 
 	got := m.BuildContext(now)
-	if !strings.Contains(got, "[truncated — read MEMORY.md for the rest]") {
+	if !strings.Contains(got, "[truncated — read "+m.MemoryFilePath()+" for the rest]") {
 		t.Error("missing per-file truncation marker")
 	}
 	if strings.Contains(got, strings.Repeat("x", 200)) {
@@ -115,8 +116,9 @@ func TestBuildContextTotalCap(t *testing.T) {
 	if !strings.Contains(got, "[memory truncated") {
 		t.Error("missing total truncation marker")
 	}
-	if len([]rune(got)) > 600 {
-		t.Errorf("block not capped: %d chars", len([]rune(got)))
+	marker := "\n[memory truncated — read " + m.MemoryFilePath() + " and " + m.NotesDir() + " for full contents]\n"
+	if maxLen := 500 + len([]rune(marker)); len([]rune(got)) > maxLen {
+		t.Errorf("block not capped: %d chars, want <= %d", len([]rune(got)), maxLen)
 	}
 }
 
@@ -152,16 +154,20 @@ func TestFlushPrompt(t *testing.T) {
 	now := time.Date(2026, 7, 2, 10, 0, 0, 0, time.Local)
 
 	got := m.FlushPrompt(now)
-	if !strings.Contains(got, "memory/2026-07-02.md") {
-		t.Errorf("flush prompt missing today path: %q", got)
+	if !strings.Contains(got, m.TodayNotePath(now)) {
+		t.Errorf("flush prompt missing absolute today path: %q", got)
+	}
+	if !strings.Contains(got, m.MemoryFilePath()) {
+		t.Errorf("flush prompt missing absolute MEMORY.md path: %q", got)
 	}
 	if !strings.Contains(got, NoReplySentinel) {
 		t.Error("flush prompt missing sentinel")
 	}
 
 	custom := testManager(t, Config{FlushPrompt: "save to {today} please"})
-	if got := custom.FlushPrompt(now); got != "save to memory/2026-07-02.md please" {
-		t.Errorf("custom prompt: %q", got)
+	want := "save to " + custom.TodayNotePath(now) + " please"
+	if got := custom.FlushPrompt(now); got != want {
+		t.Errorf("custom prompt: %q, want %q", got, want)
 	}
 }
 

--- a/internal/memory/prompts.go
+++ b/internal/memory/prompts.go
@@ -11,28 +11,34 @@ import (
 const NoReplySentinel = "NO_REPLY"
 
 // policyHeader is the memory usage policy injected at the top of the memory
-// block. The %s placeholder is today's workspace-relative note path.
+// block. All paths are ABSOLUTE: the Claude CLI has its own built-in memory
+// feature pointing at ~/.claude/projects/<cwd>/memory/, and relative paths
+// like "memory/..." get resolved against that store instead of the workspace.
+// Placeholders: %[1]s = MEMORY.md path, %[2]s = notes dir, %[3]s = today's note.
 const policyHeader = `
 
 ## Persistent Memory
 
-You have persistent memory stored as markdown in your workspace:
-- MEMORY.md — curated long-term memory (stable facts, preferences, active projects, key decisions). Keep it lean (< ~200 lines).
-- memory/YYYY-MM-DD.md — append-only daily notes. Today's file: %s
+You have persistent memory stored as markdown files:
+- %[1]s — curated long-term memory (stable facts, preferences, active projects, key decisions). Keep it lean (< ~200 lines).
+- %[2]s/YYYY-MM-DD.md — append-only daily notes. Today's file: %[3]s
 
 Rules:
-1. MANDATORY: before answering questions about prior work, decisions, dates, people, preferences, or TODOs not visible in this conversation, search memory first: grep -ri "<keyword>" memory/ MEMORY.md
-2. When an important fact emerges (a decision, preference, project state change, follow-up), silently append a short bullet to today's note. Do not announce it or ask permission.
-3. Periodically synthesize durable facts from daily notes into MEMORY.md; remove stale entries.
+1. MANDATORY: before answering questions about prior work, decisions, dates, people, preferences, or TODOs not visible in this conversation, search memory first: grep -ri "<keyword>" %[2]s %[1]s
+2. When an important fact emerges (a decision, preference, project state change, follow-up), silently append a short bullet to %[3]s. Do not announce it or ask permission.
+3. Periodically synthesize durable facts from daily notes into %[1]s; remove stale entries.
 4. Never store secrets (tokens, passwords, keys) in memory files.
+5. These EXACT absolute paths are the bot's memory store. Do NOT write these notes into any ~/.claude/projects/.../memory/ directory or other memory location.
 `
 
 // defaultFlushPrompt is sent as a user turn on the resumed session right
-// before it is reset. The %s placeholders are today's relative note path.
+// before it is reset. Placeholders: %[1]s = today's note (absolute),
+// %[2]s = MEMORY.md (absolute).
 const defaultFlushPrompt = `[Memory flush — session is about to be reset; its context will be lost]
-Review this conversation and append anything worth remembering to %s:
+Review this conversation and append anything worth remembering to %[1]s (create it if missing):
 decisions made, current task state and next steps, new facts about the user or projects, open TODOs.
-Use short markdown bullets under a "## HH:MM" heading. Update MEMORY.md only if a durable long-term fact emerged.
+Use short markdown bullets under a "## HH:MM" heading. Update %[2]s only if a durable long-term fact emerged.
+Write ONLY to those exact absolute paths — not to any ~/.claude/projects/.../memory/ directory.
 If nothing is worth saving, write nothing. Do not address the user. When done, reply with exactly: ` + NoReplySentinel + "\n"
 
 // memorySeed is the initial MEMORY.md created by Bootstrap.
@@ -47,13 +53,13 @@ Sections you may want: User, Preferences, Active Projects, Decisions.
 `
 
 // FlushPrompt returns the prompt for a silent memory-flush turn. A custom
-// prompt from config may embed {today} which expands to the relative path of
+// prompt from config may embed {today} which expands to the ABSOLUTE path of
 // today's daily note.
 func (m *Manager) FlushPrompt(now time.Time) string {
 	if p := strings.TrimSpace(m.cfg.FlushPrompt); p != "" {
-		return strings.ReplaceAll(p, "{today}", m.relNote(now))
+		return strings.ReplaceAll(p, "{today}", m.TodayNotePath(now))
 	}
-	return fmt.Sprintf(defaultFlushPrompt, m.relNote(now))
+	return fmt.Sprintf(defaultFlushPrompt, m.TodayNotePath(now), m.MemoryFilePath())
 }
 
 // IsNoReply reports whether a flush reply is the bare NO_REPLY sentinel.


### PR DESCRIPTION
## Problem

Memory flushes were writing to `~/.claude/projects/-Users-ngocp-goterm-workspace/memory/` instead of `~/goterm-workspace/memory/`. The Claude CLI's own built-in memory feature injects an absolute path to its per-project memory dir, so our relative paths ("memory/2026-07-03.md") in the policy header and flush prompt were resolved against that store. Result: workspace memory stayed empty, `BuildContext` injected nothing into new sessions, and `/memory` reported no data — while notes silently accumulated in the CLI's hidden store.

## Fix

- All memory paths in prompts are now **absolute**: policy rules, grep instruction, section headers, flush prompt, truncation markers, and the `{today}` placeholder in custom flush prompts.
- Added an explicit rule: do NOT write bot notes into any `~/.claude/projects/.../memory/` directory.
- Misplaced notes already written (daily note + user fact + index) were migrated to the workspace store on the host.

## Test plan

- [x] Unit tests updated for absolute paths (context block, flush prompt, truncation markers) — all pass
- [x] `go build ./cmd/bomclaw`
- [ ] After deploy: `/reset` → flush section appears in `~/goterm-workspace/memory/2026-07-04.md`, not in `~/.claude/projects/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)