### PR TITLE
feat(tray): bomtray macOS menu bar companion with Awake mode

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -191,6 +191,17 @@ func runGateway(args []string) {
 	addr := fmt.Sprintf("%s:%d", *bind, *port)
 	startTime := time.Now()
 
+	// Create the Telegram bot first so the gateway status RPC can report its
+	// live run state (menu bar tray polls /api/status).
+	var tgBot *bot.Bot
+	if cfg.Telegram.Token != "" {
+		tgBot, err = bot.New(cfg)
+		if err != nil {
+			log.Printf("gateway: telegram bot init failed: %v", err)
+			tgBot = nil
+		}
+	}
+
 	deps := gateway.Deps{
 		Sessions: sessions,
 		Resolver: resolver,
@@ -199,21 +210,37 @@ func runGateway(args []string) {
 		DataDir:  cfg.Session.DataDir,
 		Uptime:   func() time.Duration { return time.Since(startTime) },
 	}
+	if tgBot != nil {
+		deps.Runs = func() []gateway.RunInfo {
+			var out []gateway.RunInfo
+			for _, s := range tgBot.Sessions().List() {
+				info := s.RunInfo()
+				if !info.Running {
+					continue
+				}
+				out = append(out, gateway.RunInfo{
+					ChatID:    s.ChatID,
+					SessionID: s.ID,
+					Label:     s.GetLabel(),
+					Task:      info.CurrentTask,
+					LastTool:  info.LastTool,
+					ToolCount: info.ToolCount,
+					StartedAt: info.StartedAt.Format(time.RFC3339),
+				})
+			}
+			return out
+		}
+	}
 
 	srv := gateway.NewServer(addr, gateway.NewMethodHandler(deps), gateway.NewStreamSendHandler(deps), "dashboard/dist")
 
-	// Start Telegram bot in background if configured
-	if cfg.Telegram.Token != "" {
-		tgBot, err := bot.New(cfg)
-		if err != nil {
-			log.Printf("gateway: telegram bot init failed: %v", err)
-		} else {
-			go func() {
-				log.Println("gateway: starting Telegram bot")
-				tgBot.Run()
-			}()
-			defer tgBot.Shutdown()
-		}
+	// Start Telegram bot polling in background
+	if tgBot != nil {
+		go func() {
+			log.Println("gateway: starting Telegram bot")
+			tgBot.Run()
+		}()
+		defer tgBot.Shutdown()
 	}
 
 	// Kill any stale process holding our port (prevents "address already in use"

--- a/cmd/bomtray/actions_darwin.go
+++ b/cmd/bomtray/actions_darwin.go
@@ -1,0 +1,49 @@
+//go:build darwin
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// openPath opens a file, directory, or URL with the default handler.
+func openPath(target string) {
+	if err := exec.Command("open", target).Run(); err != nil {
+		log.Printf("bomtray: open %s: %v", target, err)
+	}
+}
+
+// openTerminalTail opens Terminal.app tailing the given log file.
+func openTerminalTail(logPath string) {
+	script := fmt.Sprintf(`tell application "Terminal"
+	activate
+	do script "tail -f %s"
+end tell`, logPath)
+	if err := exec.Command("osascript", "-e", script).Run(); err != nil {
+		log.Printf("bomtray: tail logs: %v", err)
+	}
+}
+
+// restartGateway restarts the launchd service (KeepAlive-safe).
+func restartGateway(label string) {
+	target := fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
+	if err := exec.Command("launchctl", "kickstart", "-k", target).Run(); err != nil {
+		log.Printf("bomtray: restart gateway: %v", err)
+		notify("Bomclaw", "Restart failed — check logs")
+		return
+	}
+	notify("Bomclaw", "Gateway restarting...")
+}
+
+// notify shows a macOS notification via osascript.
+func notify(title, message string) {
+	esc := func(s string) string { return strings.ReplaceAll(s, `"`, `\"`) }
+	script := fmt.Sprintf(`display notification "%s" with title "%s"`, esc(message), esc(title))
+	if err := exec.Command("osascript", "-e", script).Run(); err != nil {
+		log.Printf("bomtray: notify: %v", err)
+	}
+}

--- a/cmd/bomtray/awake_darwin.go
+++ b/cmd/bomtray/awake_darwin.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework IOKit
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
+
+static IOReturn bomtrayCreateAssertion(IOPMAssertionID *id) {
+	return IOPMAssertionCreateWithName(
+		kIOPMAssertionTypePreventUserIdleSystemSleep,
+		kIOPMAssertionLevelOn,
+		CFSTR("bomclaw: agent task in progress"),
+		id);
+}
+
+static IOReturn bomtrayReleaseAssertion(IOPMAssertionID id) {
+	return IOPMAssertionRelease(id);
+}
+*/
+import "C"
+
+import "fmt"
+
+// awake holds/releases an IOKit power assertion to keep the Mac awake
+// (kwota pattern — direct assertion, no caffeinate child process).
+// PreventUserIdleSystemSleep lets the display sleep but keeps the system
+// running, which is what a background agent needs.
+type awake struct {
+	id   C.IOPMAssertionID
+	held bool
+}
+
+// Hold acquires the assertion (idempotent).
+func (a *awake) Hold() error {
+	if a.held {
+		return nil
+	}
+	if ret := C.bomtrayCreateAssertion(&a.id); ret != C.kIOReturnSuccess {
+		return fmt.Errorf("IOPMAssertionCreateWithName failed: 0x%x", uint32(ret))
+	}
+	a.held = true
+	return nil
+}
+
+// Release drops the assertion (idempotent).
+func (a *awake) Release() {
+	if !a.held {
+		return
+	}
+	C.bomtrayReleaseAssertion(a.id)
+	a.held = false
+}
+
+// Held reports whether the assertion is currently active.
+func (a *awake) Held() bool { return a.held }

--- a/cmd/bomtray/install_darwin.go
+++ b/cmd/bomtray/install_darwin.go
@@ -1,0 +1,77 @@
+//go:build darwin
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const trayAgentLabel = "com.bomclaw.tray"
+
+const trayPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>%s</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>LimitLoadToSessionType</key>
+	<string>Aqua</string>
+	<key>StandardErrorPath</key>
+	<string>%s</string>
+</dict>
+</plist>
+`
+
+func trayPlistPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library/LaunchAgents", trayAgentLabel+".plist")
+}
+
+// runInstall writes the LaunchAgent plist and loads it so the tray starts
+// now and at every login.
+func runInstall() {
+	binPath, err := os.Executable()
+	if err != nil {
+		log.Fatalf("bomtray: resolve executable: %v", err)
+	}
+	binPath, _ = filepath.EvalSymlinks(binPath)
+
+	home, _ := os.UserHomeDir()
+	logPath := filepath.Join(home, ".goterm/logs/tray.err.log")
+	_ = os.MkdirAll(filepath.Dir(logPath), 0755)
+
+	plist := fmt.Sprintf(trayPlistTemplate, trayAgentLabel, binPath, logPath)
+	path := trayPlistPath()
+	if err := os.WriteFile(path, []byte(plist), 0644); err != nil {
+		log.Fatalf("bomtray: write plist: %v", err)
+	}
+
+	// Reload: unload first in case an older version is loaded.
+	_ = exec.Command("launchctl", "unload", path).Run()
+	if err := exec.Command("launchctl", "load", path).Run(); err != nil {
+		log.Fatalf("bomtray: launchctl load: %v", err)
+	}
+	fmt.Printf("bomtray installed: %s\n(the 🤖 icon should appear in your menu bar)\n", path)
+}
+
+// runUninstall unloads and removes the LaunchAgent.
+func runUninstall() {
+	path := trayPlistPath()
+	_ = exec.Command("launchctl", "unload", path).Run()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Fatalf("bomtray: remove plist: %v", err)
+	}
+	fmt.Println("bomtray uninstalled")
+}

--- a/cmd/bomtray/main.go
+++ b/cmd/bomtray/main.go
@@ -1,0 +1,337 @@
+//go:build darwin
+
+// bomtray is a macOS menu bar companion for the bomclaw gateway.
+// It polls the gateway's /api/status endpoint, shows live agent state in the
+// menu bar, exposes quick actions, and can keep the Mac awake while the
+// agent is running (IOKit power assertion, kwota pattern).
+//
+// It is a separate binary on purpose: when the gateway dies, the tray icon
+// survives and turns red instead of vanishing.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"fyne.io/systray"
+	"github.com/ngocp/goterm-control/internal/gateway"
+	"github.com/ngocp/goterm-control/internal/memory"
+)
+
+type awakeMode string
+
+const (
+	awakeOff    awakeMode = "off"
+	awakeAuto   awakeMode = "auto" // hold only while the agent is running
+	awakeAlways awakeMode = "always"
+)
+
+type app struct {
+	url          string
+	workspace    string
+	gatewayLabel string
+	logPath      string
+	interval     time.Duration
+
+	mem   *memory.Manager
+	awake *awake
+	mode  awakeMode
+
+	statusItem *systray.MenuItem
+	runItem    *systray.MenuItem
+	memItem    *systray.MenuItem
+	modeOff    *systray.MenuItem
+	modeAuto   *systray.MenuItem
+	modeAlways *systray.MenuItem
+
+	// previous poll state, for transition notifications
+	upKnown    bool
+	wasUp      bool
+	prevTask   string
+	prevRunning bool
+}
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "install":
+			runInstall()
+			return
+		case "uninstall":
+			runUninstall()
+			return
+		}
+	}
+
+	home, _ := os.UserHomeDir()
+	url := flag.String("url", "http://127.0.0.1:18789", "Gateway base URL")
+	workspace := flag.String("workspace", filepath.Join(home, "goterm-workspace"), "Agent workspace (memory files)")
+	label := flag.String("gateway-label", "com.nanoclaw.gateway", "launchd label of the gateway service")
+	logPath := flag.String("log", filepath.Join(home, ".goterm/logs/gateway.err.log"), "Gateway log file for Tail Logs")
+	interval := flag.Int("interval", 3, "Poll interval in seconds")
+	flag.Parse()
+
+	a := &app{
+		url:          strings.TrimRight(*url, "/"),
+		workspace:    *workspace,
+		gatewayLabel: *label,
+		logPath:      *logPath,
+		interval:     time.Duration(*interval) * time.Second,
+		awake:        &awake{},
+		mode:         loadAwakeMode(),
+		mem: memory.NewManager(memory.Config{
+			Enabled: true,
+			Dir:     *workspace,
+		}),
+	}
+
+	systray.Run(a.onReady, a.onExit)
+}
+
+func (a *app) onReady() {
+	systray.SetTitle("🤖")
+	systray.SetTooltip("bomclaw gateway")
+
+	a.statusItem = systray.AddMenuItem("⏳ Connecting...", "")
+	a.statusItem.Disable()
+	a.runItem = systray.AddMenuItem("💤 Idle", "")
+	a.runItem.Disable()
+	a.memItem = systray.AddMenuItem("💾 Memory: ...", "Open MEMORY.md")
+
+	systray.AddSeparator()
+	awakeMenu := systray.AddMenuItem("Keep Mac Awake", "Prevent system sleep (display may still sleep)")
+	a.modeOff = awakeMenu.AddSubMenuItemCheckbox("Off", "", a.mode == awakeOff)
+	a.modeAuto = awakeMenu.AddSubMenuItemCheckbox("While bot is running", "Hold a power assertion only during agent runs", a.mode == awakeAuto)
+	a.modeAlways = awakeMenu.AddSubMenuItemCheckbox("Always", "", a.mode == awakeAlways)
+
+	systray.AddSeparator()
+	openDash := systray.AddMenuItem("Open Dashboard", "")
+	openWs := systray.AddMenuItem("Open Workspace", "")
+	tailLogs := systray.AddMenuItem("Tail Logs", "Open Terminal tailing the gateway log")
+	restart := systray.AddMenuItem("Restart Gateway", "launchctl kickstart -k")
+
+	systray.AddSeparator()
+	quit := systray.AddMenuItem("Quit bomtray", "")
+
+	// Click handler loop
+	go func() {
+		for {
+			select {
+			case <-a.memItem.ClickedCh:
+				openPath(filepath.Join(a.workspace, "MEMORY.md"))
+			case <-a.modeOff.ClickedCh:
+				a.setMode(awakeOff)
+			case <-a.modeAuto.ClickedCh:
+				a.setMode(awakeAuto)
+			case <-a.modeAlways.ClickedCh:
+				a.setMode(awakeAlways)
+			case <-openDash.ClickedCh:
+				openPath(a.url)
+			case <-openWs.ClickedCh:
+				openPath(a.workspace)
+			case <-tailLogs.ClickedCh:
+				openTerminalTail(a.logPath)
+			case <-restart.ClickedCh:
+				restartGateway(a.gatewayLabel)
+			case <-quit.ClickedCh:
+				systray.Quit()
+				return
+			}
+		}
+	}()
+
+	// Poll loop
+	go func() {
+		a.poll()
+		ticker := time.NewTicker(a.interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			a.poll()
+		}
+	}()
+}
+
+func (a *app) onExit() {
+	a.awake.Release()
+}
+
+// poll fetches gateway status and updates the menu, awake assertion, and
+// transition notifications.
+func (a *app) poll() {
+	st, err := fetchStatus(a.url)
+	up := err == nil
+	running := up && len(st.Runs) > 0
+
+	// --- transition notifications ---
+	if a.upKnown && up != a.wasUp {
+		if up {
+			notify("Bomclaw", "Gateway is back up ✅")
+		} else {
+			notify("Bomclaw", "Gateway is DOWN ⛔")
+		}
+	}
+	if a.prevRunning && !running && up {
+		task := a.prevTask
+		if task == "" {
+			task = "agent task"
+		}
+		notify("Bomclaw", "✅ Done: "+task)
+	}
+	a.upKnown = true
+	a.wasUp = up
+	a.prevRunning = running
+	if running {
+		a.prevTask = st.Runs[0].Task
+	}
+
+	// --- awake assertion ---
+	switch a.mode {
+	case awakeAlways:
+		a.holdAwake()
+	case awakeAuto:
+		if running {
+			a.holdAwake()
+		} else {
+			a.awake.Release()
+		}
+	default:
+		a.awake.Release()
+	}
+
+	// --- menu bar title ---
+	title := "🤖"
+	switch {
+	case !up:
+		title = "🤖⛔"
+	case running:
+		title = "🤖⚡"
+	}
+	if a.awake.Held() {
+		title += "☕"
+	}
+	systray.SetTitle(title)
+
+	// --- menu items ---
+	if up {
+		a.statusItem.SetTitle(fmt.Sprintf("🟢 Gateway up · %s · %s", st.Uptime, st.DefaultModel))
+	} else {
+		a.statusItem.SetTitle("🔴 Gateway down")
+	}
+
+	if running {
+		r := st.Runs[0]
+		line := fmt.Sprintf("⚡ %s · %d tools", truncate(r.Task, 40), r.ToolCount)
+		if r.LastTool != "" {
+			line += " · " + truncate(r.LastTool, 20)
+		}
+		a.runItem.SetTitle(line)
+	} else {
+		a.runItem.SetTitle("💤 Idle")
+	}
+
+	if stats, err := a.mem.Stats(time.Now()); err == nil {
+		a.memItem.SetTitle(fmt.Sprintf("💾 Memory: %s · %d notes", humanBytes(stats.MemoryMDBytes), stats.DailyNoteCount))
+	}
+}
+
+func (a *app) holdAwake() {
+	if err := a.awake.Hold(); err != nil {
+		log.Printf("bomtray: awake: %v", err)
+	}
+}
+
+// setMode switches the awake mode, updates checkboxes, and persists it.
+func (a *app) setMode(m awakeMode) {
+	a.mode = m
+	a.modeOff.Uncheck()
+	a.modeAuto.Uncheck()
+	a.modeAlways.Uncheck()
+	switch m {
+	case awakeOff:
+		a.modeOff.Check()
+	case awakeAuto:
+		a.modeAuto.Check()
+	case awakeAlways:
+		a.modeAlways.Check()
+	}
+	saveAwakeMode(m)
+	a.poll() // apply immediately
+}
+
+// fetchStatus GETs /api/status with a short timeout.
+func fetchStatus(baseURL string) (*gateway.StatusResult, error) {
+	client := &http.Client{Timeout: 2500 * time.Millisecond}
+	resp, err := client.Get(baseURL + "/api/status")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var st gateway.StatusResult
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// --- awake mode persistence (~/.goterm/tray.json) ---
+
+func trayStatePath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".goterm", "tray.json")
+}
+
+func loadAwakeMode() awakeMode {
+	data, err := os.ReadFile(trayStatePath())
+	if err != nil {
+		return awakeOff
+	}
+	var s struct {
+		AwakeMode string `json:"awake_mode"`
+	}
+	if json.Unmarshal(data, &s) != nil {
+		return awakeOff
+	}
+	switch awakeMode(s.AwakeMode) {
+	case awakeAuto, awakeAlways:
+		return awakeMode(s.AwakeMode)
+	}
+	return awakeOff
+}
+
+func saveAwakeMode(m awakeMode) {
+	path := trayStatePath()
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	data, _ := json.Marshal(map[string]string{"awake_mode": string(m)})
+	_ = os.WriteFile(path, data, 0644)
+}
+
+// --- helpers ---
+
+func truncate(s string, max int) string {
+	r := []rune(strings.TrimSpace(s))
+	if len(r) > max {
+		return string(r[:max]) + "…"
+	}
+	return s
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/cmd/bomtray/main_other.go
+++ b/cmd/bomtray/main_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+// bomtray is macOS-only: it renders a menu bar (NSStatusItem) icon and holds
+// IOKit power assertions, both of which require Cocoa/IOKit.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "bomtray is macOS-only (build and run it on darwin)")
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 )
 
 require (
+	fyne.io/systray v1.12.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+fyne.io/systray v1.12.2 h1:Y8DZxgLHsVQt6rY9Zrkkg+j67S7vv/1F2viOWKPpVeA=
+fyne.io/systray v1.12.2/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/anthropics/anthropic-sdk-go v1.29.0 h1:7h1ZyRflhtxyuFkdwkVuJ1LdFAYdmizvgg0gd1uvOfI=
 github.com/anthropics/anthropic-sdk-go v1.29.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -8,6 +10,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -149,6 +149,12 @@ func New(cfg *config.Config) (*Bot, error) {
 	}, nil
 }
 
+// Sessions exposes the bot's live session manager (read-only use: the
+// gateway status RPC reports in-flight run info from it).
+func (b *Bot) Sessions() *session.Manager {
+	return b.sessions
+}
+
 // Run starts the long-polling loop. Blocks until ctx is done.
 func (b *Bot) Run() {
 	u := tgbotapi.NewUpdate(0)

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -25,6 +25,7 @@ type Deps struct {
 	System        string // system prompt
 	DataDir       string // data directory for transcripts
 	Uptime        func() time.Duration
+	Runs          func() []RunInfo // live in-flight runs (nil when no bot attached)
 }
 
 // NewMethodHandler creates a MethodHandler that routes to the appropriate handler.
@@ -61,6 +62,9 @@ func handleStatus(deps Deps) (json.RawMessage, error) {
 		DefaultModel:   deps.Resolver.Default(),
 		ActiveSessions: len(sessions),
 		Channels:       []string{"telegram", "gateway", "dashboard"},
+	}
+	if deps.Runs != nil {
+		result.Runs = deps.Runs()
 	}
 	return json.Marshal(result)
 }

--- a/internal/gateway/protocol.go
+++ b/internal/gateway/protocol.go
@@ -45,4 +45,17 @@ type StatusResult struct {
 	DefaultModel  string   `json:"default_model"`
 	ActiveSessions int     `json:"active_sessions"`
 	Channels      []string `json:"channels"`
+	Runs          []RunInfo `json:"runs,omitempty"` // in-flight agent runs (live)
+}
+
+// RunInfo describes one in-flight agent run for status consumers
+// (dashboard, menu bar tray).
+type RunInfo struct {
+	ChatID    int64  `json:"chat_id"`
+	SessionID string `json:"session_id"`
+	Label     string `json:"label,omitempty"`
+	Task      string `json:"task,omitempty"`
+	LastTool  string `json:"last_tool,omitempty"`
+	ToolCount int    `json:"tool_count"`
+	StartedAt string `json:"started_at"`
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -56,6 +56,18 @@ func (s *Server) Start(ctx context.Context) error {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `{"status":"ok","uptime":"%s"}`, time.Since(s.startedAt).Round(time.Second))
 	})
+	// Plain HTTP mirror of the "status" RPC method — lets simple pollers
+	// (menu bar tray) avoid the WebSocket handshake.
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		res, err := s.handler(r.Context(), "status", nil)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(res)
+	})
 
 	if s.dashboardDir != "" {
 		fs := http.FileServer(http.Dir(s.dashboardDir))


### PR DESCRIPTION
## Summary

Adds `bomtray` — a macOS menu bar (system tray) companion for the bomclaw gateway, inspired by [thanhhaudev/kwota](https://github.com/thanhhaudev/kwota).

**Why a separate binary:** if the tray lived inside the gateway it would vanish exactly when you need it — a companion process keeps the icon alive and turns it red when the gateway dies. It also keeps cgo/Cocoa out of the daemon.

### Tray features
- **Live status**: polls `GET /api/status` every 3s. Title: `🤖` idle · `🤖⚡` running · `🤖⛔` gateway down · `☕` suffix while holding a power assertion. Menu shows uptime/model, current task + last tool + tool count, and memory stats (click opens MEMORY.md).
- **Keep Mac Awake** (kwota pattern): Off / **While bot is running** / Always. Holds an IOKit `PreventUserIdleSystemSleep` assertion directly via cgo — no `caffeinate` child process; display can still sleep. Auto mode holds it only during agent runs so long Claude tasks never die to system sleep. Mode persisted in `~/.goterm/tray.json`.
- **Quick actions**: Open Dashboard, Open Workspace, Tail Logs (Terminal), Restart Gateway (`launchctl kickstart -k`).
- **Notifications**: gateway down/up transitions and task completion via `osascript`.
- **`bomtray install`/`uninstall`**: manages a `com.bomclaw.tray` LaunchAgent (Aqua session, RunAtLoad, KeepAlive).

### Gateway changes
- New `GET /api/status` — plain-HTTP mirror of the `status` RPC for simple pollers.
- `StatusResult` gains `runs[]` (live in-flight runs: task, last tool, tool count, started_at), wired from the Telegram bot's session manager via a nil-safe `Deps.Runs` closure (bot is now constructed before gateway deps in `runGateway`).

### Platform
darwin-only via build tags (`//go:build darwin`); non-darwin `go build ./...` compiles a stub that exits with a message. Verified: darwin/arm64 Mach-O build + GOOS=linux stub build.

## Test plan
- [x] `go build ./cmd/bomtray` (arm64) + `GOOS=linux go build` (stub)
- [x] `go vet` + full unit test suite pass
- [ ] After deploy: icon appears, shows 🟢 status; send bot a task → ⚡ + task line; enable "While bot is running" → ☕ appears during run, assertion visible in `pmset -g assertions`; kill gateway → icon ⛔ + notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)