### PR TITLE
fix(session): auto-prune oldest sessions instead of failing at the cap

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -24,6 +24,13 @@ type SessionPersister interface {
 	Save(chats map[int64]*ChatState) error
 }
 
+// SessionDeleter is an optional SessionPersister extension for backends that
+// can delete individual sessions (needed because Save only upserts — without
+// a real delete, pruned sessions would resurrect from disk on next Load).
+type SessionDeleter interface {
+	DeleteSession(sessionID string) error
+}
+
 // Manager stores sessions keyed by chat ID with disk persistence.
 type Manager struct {
 	mu    sync.RWMutex
@@ -174,8 +181,17 @@ func (m *Manager) NewSession(chatID int64) (*Session, error) {
 		return s, nil
 	}
 
+	// At the cap: evict the oldest idle sessions instead of failing, so
+	// /new always works. Their SQLite rows (and messages, via FK cascade)
+	// are deleted; transcript JSONL files stay on disk as the audit trail.
 	if len(cs.Sessions) >= MaxSessionsPerChat {
-		return nil, fmt.Errorf("session limit reached (%d)", MaxSessionsPerChat)
+		evicted := m.pruneOldestLocked(cs, MaxSessionsPerChat-1)
+		if len(evicted) > 0 {
+			log.Printf("session: pruned %d oldest session(s) for chat %d: %v", len(evicted), chatID, evicted)
+		}
+		if len(cs.Sessions) >= MaxSessionsPerChat {
+			return nil, fmt.Errorf("session limit reached (%d) and no session is evictable", MaxSessionsPerChat)
+		}
 	}
 
 	seq := cs.NextSeq
@@ -185,6 +201,38 @@ func (m *Manager) NewSession(chatID int64) (*Session, error) {
 	cs.NextSeq = seq + 1
 	m.scheduleSave()
 	return s, nil
+}
+
+// pruneOldestLocked evicts the least-recently-updated sessions from cs until
+// at most keep remain. The active session and any session with an in-flight
+// run are never evicted. Returns the evicted session IDs. Caller holds m.mu.
+func (m *Manager) pruneOldestLocked(cs *ChatState, keep int) []string {
+	candidates := make([]*Session, 0, len(cs.Sessions))
+	for id, s := range cs.Sessions {
+		if id == cs.ActiveSessionID || s.IsRunning() {
+			continue
+		}
+		candidates = append(candidates, s)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].UpdatedAt.Before(candidates[j].UpdatedAt)
+	})
+
+	deleter, _ := m.store.(SessionDeleter)
+	var evicted []string
+	for _, s := range candidates {
+		if len(cs.Sessions) <= keep {
+			break
+		}
+		delete(cs.Sessions, s.ID)
+		evicted = append(evicted, s.ID)
+		if deleter != nil {
+			if err := deleter.DeleteSession(s.ID); err != nil {
+				log.Printf("session: delete %s from store: %v", s.ID, err)
+			}
+		}
+	}
+	return evicted
 }
 
 // SwitchActive changes the active session for a chat.

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -177,19 +177,48 @@ func TestManagerGetRecoversFromStaleActiveID(t *testing.T) {
 	}
 }
 
-func TestManagerSessionLimit(t *testing.T) {
+func TestManagerSessionLimitPrunesOldest(t *testing.T) {
 	mgr := NewManager(nil) // in-memory only
 
-	mgr.Get(100) // creates first session
+	first := mgr.Get(100) // creates first session (oldest)
 	for i := 1; i < MaxSessionsPerChat; i++ {
 		if _, err := mgr.NewSession(100); err != nil {
 			t.Fatalf("NewSession %d: %v", i, err)
 		}
 	}
 
-	// Should fail at the limit
-	_, err := mgr.NewSession(100)
-	if err == nil {
-		t.Error("expected error at session limit")
+	// At the limit: NewSession must evict the oldest idle session, not fail.
+	s, err := mgr.NewSession(100)
+	if err != nil {
+		t.Fatalf("NewSession at limit: %v", err)
+	}
+	if got := len(mgr.ListForChat(100)); got > MaxSessionsPerChat {
+		t.Errorf("sessions = %d, want <= %d", got, MaxSessionsPerChat)
+	}
+	if mgr.GetByID(first.ID) != nil {
+		t.Errorf("oldest session %s should have been pruned", first.ID)
+	}
+	// The new session is active.
+	if mgr.ActiveSessionID(100) != s.ID {
+		t.Errorf("active = %s, want %s", mgr.ActiveSessionID(100), s.ID)
+	}
+}
+
+func TestManagerPruneSkipsRunningSessions(t *testing.T) {
+	mgr := NewManager(nil)
+
+	first := mgr.Get(100)
+	first.MarkRunning("long task") // oldest but busy — must not be evicted
+	for i := 1; i < MaxSessionsPerChat; i++ {
+		if _, err := mgr.NewSession(100); err != nil {
+			t.Fatalf("NewSession %d: %v", i, err)
+		}
+	}
+
+	if _, err := mgr.NewSession(100); err != nil {
+		t.Fatalf("NewSession at limit: %v", err)
+	}
+	if mgr.GetByID(first.ID) == nil {
+		t.Error("running session was evicted")
 	}
 }

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -401,3 +401,42 @@ func TestMigrateV2ToV3(t *testing.T) {
 		t.Error("memory_flushed flag did not persist")
 	}
 }
+
+func TestSessionStoreDeleteSession(t *testing.T) {
+	db := testDB(t)
+	store := NewSessionStore(db)
+	msgStore := NewMessageStore(db)
+
+	s1 := session.NewFromDB("chat_100", 100, time.Now(), time.Now(), "c1", 1, 0, 0, "", "", 0, false)
+	s2 := session.NewFromDB("chat_100_1", 100, time.Now(), time.Now(), "c2", 1, 0, 0, "", "", 1, false)
+	chats := map[int64]*session.ChatState{
+		100: {
+			ActiveSessionID: "chat_100_1",
+			NextSeq:         2,
+			Sessions:        map[string]*session.Session{"chat_100": s1, "chat_100_1": s2},
+		},
+	}
+	if err := store.Save(chats); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	msgStore.Append("chat_100", agent.Message{Role: "user", Content: "old"})
+
+	if err := store.DeleteSession("chat_100"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, exists := loaded[100].Sessions["chat_100"]; exists {
+		t.Error("deleted session still present after Load")
+	}
+	if _, exists := loaded[100].Sessions["chat_100_1"]; !exists {
+		t.Error("surviving session lost")
+	}
+	// Messages must cascade with the session row.
+	if count, _ := msgStore.Count("chat_100"); count != 0 {
+		t.Errorf("messages not cascaded: count = %d", count)
+	}
+}

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -165,6 +165,13 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 	return tx.Commit()
 }
 
+// DeleteSession removes a session row; its messages go with it via the
+// ON DELETE CASCADE foreign key. Implements session.SessionDeleter.
+func (s *SQLiteSessionStore) DeleteSession(sessionID string) error {
+	_, err := s.db.conn.Exec(`DELETE FROM sessions WHERE id = ?`, sessionID)
+	return err
+}
+
 // pickMostRecent returns the ID of the most recently updated session.
 func pickMostRecent(sessions map[string]*session.Session) string {
 	var bestID string


### PR DESCRIPTION
/new was replying "session limit reached (20)" once a chat accumulated
MaxSessionsPerChat sessions. Now NewSession evicts the least-recently-
updated idle sessions (never the active one or one with an in-flight run)
until under the cap, then creates the new session as usual.

Eviction needs a real store delete — Save only upserts, so map-only removal
would resurrect rows on next Load. New optional session.SessionDeleter
interface, implemented by SQLiteSessionStore; messages go with the session
via the existing ON DELETE CASCADE FK. Transcript JSONL files remain on
disk as the audit trail.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
