### PR TITLE
fix(cli): piped password input for bomclaw user commands

### DIFF
--- a/cmd/bomclaw/users.go
+++ b/cmd/bomclaw/users.go
@@ -118,6 +118,10 @@ func mustReadPasswordHash() string {
 	return hash
 }
 
+// stdinReader is shared across readPassword calls: a fresh bufio.Reader per
+// call would buffer ahead and swallow the second (confirm) line of piped input.
+var stdinReader = bufio.NewReader(os.Stdin)
+
 func readPassword(prompt string) string {
 	fmt.Print(prompt)
 	if term.IsTerminal(int(syscall.Stdin)) {
@@ -129,7 +133,7 @@ func readPassword(prompt string) string {
 		return strings.TrimSpace(string(b))
 	}
 	// Non-TTY (piped) input — read a line.
-	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	line, err := stdinReader.ReadString('\n')
 	if err != nil && line == "" {
 		log.Fatalf("read password: %v", err)
 	}


### PR DESCRIPTION
A fresh bufio.Reader per readPassword call buffered ahead and swallowed
the confirm line of piped input, so non-TTY 'user add' always failed
with EOF / mismatch.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
