### PR TITLE
feat(sessions): auto-name sessions, sort newest first, persist user messages immediately

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -230,7 +230,9 @@ func runGateway(args []string) {
 	// live run state (menu bar tray polls /api/status).
 	var tgBot *bot.Bot
 	if cfg.Telegram.Token != "" {
-		tgBot, err = bot.New(cfg)
+		// Share db + session manager with the gateway so session renames and
+		// turn counters show up in the dashboard without a reload.
+		tgBot, err = bot.New(cfg, db, sessions)
 		if err != nil {
 			log.Printf("gateway: telegram bot init failed: %v", err)
 			tgBot = nil

--- a/dashboard/src/components/SessionList.tsx
+++ b/dashboard/src/components/SessionList.tsx
@@ -11,7 +11,11 @@ function timeAgo(dateStr: string): string {
 }
 
 export default function SessionList({ call }: { call: (m: string, p?: any) => Promise<any> }) {
-  const sessions = useStore(s => s.sessions)
+  const rawSessions = useStore(s => s.sessions)
+  // Newest first — the server already sorts, but keep the invariant client-side too.
+  const sessions = [...rawSessions].sort(
+    (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+  )
   const setActiveSessionId = useStore(s => s.setActiveSessionId)
   const setMessages = useStore(s => s.setMessages)
   const setTab = useStore(s => s.setTab)
@@ -87,11 +91,12 @@ export default function SessionList({ call }: { call: (m: string, p?: any) => Pr
           >
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <span className="font-mono text-sm text-gray-300">{s.id}</span>
-                <span className="text-xs text-gray-500">{s.message_count} turns</span>
+                <span className="text-sm text-gray-200 truncate">{s.label || s.id}</span>
+                <span className="text-xs text-gray-500 shrink-0">{s.message_count} turns</span>
               </div>
-              <div className="text-xs text-gray-500 mt-0.5">
+              <div className="text-xs text-gray-500 mt-0.5 truncate">
                 {timeAgo(s.updated_at)} · {s.input_tokens + s.output_tokens} tokens
+                {s.label ? <span className="font-mono"> · {s.id}</span> : null}
               </div>
             </div>
             <button

--- a/dashboard/src/stores/store.ts
+++ b/dashboard/src/stores/store.ts
@@ -9,6 +9,8 @@ export type Session = {
   output_tokens: number
   created_at: string
   updated_at: string
+  label?: string
+  seq?: number
 }
 
 export type TranscriptEvent = {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -1,12 +1,14 @@
 package bot
 
 import (
-	"fmt"
 	"log"
 	"path/filepath"
+	"strings"
 	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/ngocp/goterm-control/internal/agent"
+	anthropicClient "github.com/ngocp/goterm-control/internal/anthropic"
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/execution"
@@ -15,6 +17,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/msgqueue"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/storage"
+	"github.com/ngocp/goterm-control/internal/titler"
 	"github.com/ngocp/goterm-control/internal/tools"
 	"github.com/ngocp/goterm-control/internal/transcript"
 )
@@ -31,8 +34,10 @@ type Bot struct {
 	typing    *TypingIndicator
 }
 
-// New creates and initialises the bot.
-func New(cfg *config.Config) (*Bot, error) {
+// New creates and initialises the bot. db and sessions are shared with the
+// gateway so label renames and turn counters are visible to the dashboard
+// immediately (two managers on one SQLite file would clobber each other).
+func New(cfg *config.Config, db *storage.DB, sessions *session.Manager) (*Bot, error) {
 	api, err := tgbotapi.NewBotAPI(cfg.Telegram.Token)
 	if err != nil {
 		return nil, err
@@ -69,15 +74,6 @@ func New(cfg *config.Config) (*Bot, error) {
 		MaxOutputBytes: cfg.Tools.MaxOutputBytes,
 		AllowedPaths:   cfg.Tools.AllowedPaths,
 	})
-
-	// Storage — SQLite database
-	db, err := storage.Open(filepath.Join(cfg.Session.DataDir, "goterm.db"))
-	if err != nil {
-		return nil, fmt.Errorf("storage: %w", err)
-	}
-
-	// Session persistence (SQLite-backed) — sessions persist until /reset.
-	sessions := session.NewManager(storage.NewSessionStore(db))
 
 	// Transcript writer (JSONL audit trail — kept alongside SQLite)
 	transcriptWriter := transcript.NewWriter(filepath.Join(cfg.Session.DataDir, "transcripts"))
@@ -117,6 +113,21 @@ func New(cfg *config.Config) (*Bot, error) {
 		}
 	}
 
+	// Session titler — renames sessions to a content summary after each turn.
+	// Uses the direct API when an API key is configured; otherwise falls back
+	// to the claude CLI (which the bot already requires for OAuth tokens).
+	var titleProvider agent.ModelProvider
+	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-api") {
+		titleProvider = anthropicClient.New(cfg.Claude.APIKey)
+	} else {
+		titleProvider = claude.NewCLIProvider()
+	}
+	titleModel := resolver.Default()
+	if m := resolver.Lookup("haiku"); m != nil {
+		titleModel = m.ID
+	}
+	sessionTitler := titler.New(titleProvider, titleModel)
+
 	// Build handler first (queue needs handler.executeMessage as callback)
 	handler := &Handler{
 		bot:              api,
@@ -128,6 +139,7 @@ func New(cfg *config.Config) (*Bot, error) {
 		messages:         messageStore,
 		resolver:         resolver,
 		memory:           memManager,
+		titler:           sessionTitler,
 		approvalRequests: make(map[string]chan bool),
 		indicator:        indicator,
 		typing:           typing,

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/msgqueue"
 	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/titler"
 	"github.com/ngocp/goterm-control/internal/tools"
 	"github.com/ngocp/goterm-control/internal/transcript"
 )
@@ -43,6 +44,7 @@ type Handler struct {
 	indicator  *NameIndicator
 	typing     *TypingIndicator
 	memory     *memory.Manager // markdown persistent memory (nil-safe)
+	titler     *titler.Titler  // async session auto-naming (nil-safe)
 
 	// approvalRequests maps callbackData → channel to signal approval/cancel
 	approvalMu       sync.Mutex
@@ -581,8 +583,22 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		eventsMu.Unlock()
 	}
 
-	// Record user message
-	addEvent(transcript.Event{Type: transcript.EventUserMessage, Content: userText})
+	// Persist the user message immediately (transcript + SQLite) so it
+	// survives a crash mid-run instead of waiting for the reply to finish.
+	if h.transcript != nil {
+		err := h.transcript.Append(sess.ID, transcript.Event{
+			Type: transcript.EventUserMessage, Timestamp: time.Now(),
+			SessionID: sess.ID, ChatID: chatID, Content: userText,
+		})
+		if err != nil {
+			log.Printf("handler: transcript write error: %v", err)
+		}
+	}
+	if h.messages != nil {
+		if err := h.messages.Append(sess.ID, agent.Message{Role: "user", Content: userText}); err != nil {
+			log.Printf("handler: message store user error: %v", err)
+		}
+	}
 
 	// assistantText accumulates ALL turns (for storage); turnText resets per
 	// iteration so the auto-continue heuristic only inspects the latest turn.
@@ -711,28 +727,43 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		}
 	}
 
-	// Persist messages to SQLite (queryable history)
-	if h.messages != nil {
-		if err := h.messages.Append(sess.ID, agent.Message{Role: "user", Content: userText}); err != nil {
-			log.Printf("handler: message store user error: %v", err)
-		}
-		if respText != "" {
-			if err := h.messages.Append(sess.ID, agent.Message{Role: "assistant", Content: respText}); err != nil {
-				log.Printf("handler: message store assistant error: %v", err)
-			}
+	// Persist assistant response to SQLite (the user message was already
+	// stored at the start of the run).
+	if h.messages != nil && respText != "" {
+		if err := h.messages.Append(sess.ID, agent.Message{Role: "assistant", Content: respText}); err != nil {
+			log.Printf("handler: message store assistant error: %v", err)
 		}
 	}
 
-	// Auto-label session from first user message
+	// Label the session: instant fallback from the first user message, then
+	// an async rename to a summary of the whole conversation.
 	if sess.GetLabel() == "" && userText != "" {
 		sess.SetLabel(truncateLabel(userText, 40))
 	}
+	h.refreshSessionLabel(sess)
 
 	// Mark session dirty for persistence
 	h.sessions.MarkDirty()
 
 	result.EndedAt = time.Now()
 	return result, nil
+}
+
+// refreshSessionLabel regenerates the session label as a short summary of
+// recent conversation content. Runs async; keeps the old label on failure.
+func (h *Handler) refreshSessionLabel(sess *session.Session) {
+	if h.titler == nil || h.messages == nil {
+		return
+	}
+	msgs, err := h.messages.LoadHistory(sess.ID, 8)
+	if err != nil || len(msgs) == 0 {
+		return
+	}
+	h.titler.Refresh(sess.ID, msgs, func(title string) {
+		sess.SetLabel(title)
+		h.sessions.MarkDirty()
+		log.Printf("titler: session %s renamed to %q", sess.ID, title)
+	})
 }
 
 func (h *Handler) handleCallback(cb *tgbotapi.CallbackQuery) {

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -135,6 +136,11 @@ func handleSessionsList(deps Deps) (json.RawMessage, error) {
 			all = append(all, s)
 		}
 	}
+
+	// Newest sessions first (stubs without timestamps sink to the bottom).
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].UpdatedAt.After(all[j].UpdatedAt)
+	})
 
 	infos := make([]SessionInfo, 0, len(all))
 	for _, s := range all {

--- a/internal/titler/titler.go
+++ b/internal/titler/titler.go
@@ -1,0 +1,143 @@
+// Package titler generates short human-readable session titles by
+// summarizing recent conversation content with a cheap model call.
+package titler
+
+import (
+	"context"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/agent"
+)
+
+// Titler renames sessions asynchronously after each completed turn.
+// Failures are logged and swallowed — the previous label is kept.
+type Titler struct {
+	provider agent.ModelProvider
+	modelID  string
+
+	mu       sync.Mutex
+	inflight map[string]bool // session IDs with a refresh already running
+}
+
+// New creates a titler that summarizes with the given provider and model.
+func New(provider agent.ModelProvider, modelID string) *Titler {
+	return &Titler{
+		provider: provider,
+		modelID:  modelID,
+		inflight: make(map[string]bool),
+	}
+}
+
+const systemPrompt = "You generate short titles for chat sessions. " +
+	"Reply with ONLY the title: at most 8 words, in the same language as the conversation, " +
+	"no quotes, no trailing punctuation, no explanations."
+
+// maxTitleRunes keeps titles short enough for Telegram inline buttons and
+// the dashboard session list.
+const maxTitleRunes = 48
+
+// generateTimeout bounds one title call — the CLI provider spawns a
+// subprocess, so allow for slow cold starts.
+const generateTimeout = 60 * time.Second
+
+// Refresh summarizes the conversation into a title on a background goroutine
+// and hands it to apply. No-op when a refresh for the same session is already
+// in flight, so back-to-back turns don't stack model calls.
+func (t *Titler) Refresh(sessionID string, msgs []agent.Message, apply func(title string)) {
+	if t == nil || t.provider == nil || len(msgs) == 0 {
+		return
+	}
+	t.mu.Lock()
+	if t.inflight[sessionID] {
+		t.mu.Unlock()
+		return
+	}
+	t.inflight[sessionID] = true
+	t.mu.Unlock()
+
+	go func() {
+		defer func() {
+			t.mu.Lock()
+			delete(t.inflight, sessionID)
+			t.mu.Unlock()
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), generateTimeout)
+		defer cancel()
+
+		title, err := t.generate(ctx, msgs)
+		if err != nil {
+			log.Printf("titler: %s: %v", sessionID, err)
+			return
+		}
+		if title == "" {
+			return
+		}
+		apply(title)
+	}()
+}
+
+func (t *Titler) generate(ctx context.Context, msgs []agent.Message) (string, error) {
+	ch, err := t.provider.Stream(ctx, agent.StreamParams{
+		Model:        t.modelID,
+		SystemPrompt: systemPrompt,
+		Messages:     []agent.Message{{Role: "user", Content: buildPrompt(msgs)}},
+		MaxTokens:    64,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	for ev := range ch {
+		switch ev.Type {
+		case "text":
+			sb.WriteString(ev.Text)
+		case "error":
+			return "", ev.Error
+		}
+	}
+	return sanitize(sb.String()), nil
+}
+
+// buildPrompt renders the last few turns; that is enough signal for a title
+// while keeping the request cheap.
+func buildPrompt(msgs []agent.Message) string {
+	if len(msgs) > 6 {
+		msgs = msgs[len(msgs)-6:]
+	}
+	var sb strings.Builder
+	sb.WriteString("Summarize this conversation as a session title:\n\n")
+	for _, m := range msgs {
+		if m.Content == "" {
+			continue
+		}
+		role := "User"
+		if m.Role == "assistant" {
+			role = "Assistant"
+		}
+		content := m.Content
+		if r := []rune(content); len(r) > 300 {
+			content = string(r[:300]) + "…"
+		}
+		sb.WriteString(role + ": " + content + "\n")
+	}
+	return sb.String()
+}
+
+// sanitize reduces a model reply to a single clean title line.
+func sanitize(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = strings.TrimSpace(s[:idx])
+	}
+	s = strings.Trim(s, `"'“”‘’`)
+	s = strings.TrimRight(s, ".。!?")
+	if r := []rune(s); len(r) > maxTitleRunes {
+		s = strings.TrimSpace(string(r[:maxTitleRunes])) + "…"
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/titler/titler_test.go
+++ b/internal/titler/titler_test.go
@@ -1,0 +1,93 @@
+package titler
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/agent"
+)
+
+// fakeProvider streams a fixed reply after an optional delay.
+type fakeProvider struct {
+	reply string
+	delay time.Duration
+	calls int
+}
+
+func (f *fakeProvider) Stream(_ context.Context, _ agent.StreamParams) (<-chan agent.StreamEvent, error) {
+	f.calls++
+	ch := make(chan agent.StreamEvent, 2)
+	go func() {
+		time.Sleep(f.delay)
+		ch <- agent.StreamEvent{Type: "text", Text: f.reply}
+		ch <- agent.StreamEvent{Type: "end", StopReason: "end_turn"}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func waitFor(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for title")
+		return ""
+	}
+}
+
+func TestRefreshAppliesSanitizedTitle(t *testing.T) {
+	p := &fakeProvider{reply: "\"Fix telegram bot restart conflict.\"\nextra line"}
+	tl := New(p, "test-model")
+
+	got := make(chan string, 1)
+	tl.Refresh("chat_1", []agent.Message{{Role: "user", Content: "hello"}}, func(title string) {
+		got <- title
+	})
+
+	if title := waitFor(t, got); title != "Fix telegram bot restart conflict" {
+		t.Errorf("title = %q", title)
+	}
+}
+
+func TestRefreshDedupesInflight(t *testing.T) {
+	p := &fakeProvider{reply: "Title", delay: 100 * time.Millisecond}
+	tl := New(p, "test-model")
+
+	got := make(chan string, 2)
+	msgs := []agent.Message{{Role: "user", Content: "hello"}}
+	apply := func(title string) { got <- title }
+
+	tl.Refresh("chat_1", msgs, apply)
+	tl.Refresh("chat_1", msgs, apply) // second call while first is in flight
+
+	waitFor(t, got)
+	if p.calls != 1 {
+		t.Errorf("provider called %d times, want 1", p.calls)
+	}
+
+	// After the first refresh completes, a new one is allowed again.
+	tl.Refresh("chat_1", msgs, apply)
+	waitFor(t, got)
+	if p.calls != 2 {
+		t.Errorf("provider called %d times, want 2", p.calls)
+	}
+}
+
+func TestSanitizeTruncatesLongTitles(t *testing.T) {
+	long := strings.Repeat("từ ", 40)
+	out := sanitize(long)
+	if r := []rune(out); len(r) > maxTitleRunes+1 { // +1 for the ellipsis
+		t.Errorf("sanitized title too long: %d runes (%q)", len(r), out)
+	}
+}
+
+func TestNilTitlerIsSafe(t *testing.T) {
+	var tl *Titler
+	tl.Refresh("chat_1", []agent.Message{{Role: "user", Content: "x"}}, func(string) {
+		t.Error("apply must not be called on nil titler")
+	})
+}


### PR DESCRIPTION
## Summary
- **Auto-naming**: new `internal/titler` package — after each completed turn, an async haiku call summarizes recent conversation into a short session title (same language as the chat). Per-session in-flight dedup; failures keep the previous label. Instant fallback label from the first user message still applies.
- **Persist user messages immediately**: the Telegram bot now writes the user message to transcript JSONL + SQLite at the start of the run instead of after the reply, so a mid-run crash no longer loses it.
- **Newest sessions first**: gateway `sessions.list` sorts by `updated_at` descending; the dashboard shows the session label instead of the raw ID and keeps the sort client-side.
- **Shared session manager**: gateway and bot previously created two `session.Manager` instances over the same SQLite file — saves clobbered each other and label renames never reached the dashboard. `bot.New` now takes the shared `db` + `sessions`.

## Test plan
- `go build ./...` and `go test ./...` pass (new tests in `internal/titler/titler_test.go`: sanitize, in-flight dedup, nil-safety)
- `tsc --noEmit` + `vite build` pass; `dashboard/dist` rebuilt locally (dist is gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)