### PR TITLE
fix(macos): stop TCC permission prompts; snapshot in-progress replies every 10s

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
-import { useStore, ChatMessage } from './stores/store'
+import { useStore } from './stores/store'
 import { useGateway } from './hooks/useGateway'
+import { eventsToMessages } from './lib/transcript'
 import SessionList from './components/SessionList'
 import ChatView from './components/ChatView'
 import StatusBar from './components/StatusBar'
@@ -123,25 +124,3 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
   )
 }
 
-function eventsToMessages(events: any[]): ChatMessage[] {
-  const msgs: ChatMessage[] = []
-  let currentTools: string[] = []
-  for (const ev of events) {
-    switch (ev.type) {
-      case 'user_message':
-        msgs.push({ role: 'user', content: ev.content || '', timestamp: ev.ts })
-        break
-      case 'tool_call':
-        currentTools.push(ev.tool_name || '')
-        break
-      case 'assistant_text':
-        msgs.push({
-          role: 'assistant', content: ev.content || '', timestamp: ev.ts,
-          tools: currentTools.length > 0 ? [...currentTools] : undefined,
-        })
-        currentTools = []
-        break
-    }
-  }
-  return msgs
-}

--- a/dashboard/src/components/ChatView.tsx
+++ b/dashboard/src/components/ChatView.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect } from 'react'
 import { useStore, ChatMessage } from '../stores/store'
+import { eventsToMessages } from '../lib/transcript'
 import Markdown from 'react-markdown'
 
 export default function ChatView({ call }: { call: (m: string, p?: any) => Promise<any> }) {
   const messages = useStore(s => s.messages)
   const addMessage = useStore(s => s.addMessage)
+  const setMessages = useStore(s => s.setMessages)
   const sending = useStore(s => s.sending)
   const setSending = useStore(s => s.setSending)
   const activeSessionId = useStore(s => s.activeSessionId)
@@ -21,6 +23,20 @@ export default function ChatView({ call }: { call: (m: string, p?: any) => Promi
   useEffect(() => {
     inputRef.current?.focus()
   }, [activeSessionId])
+
+  // While the last message is a partial snapshot (bot still replying after a
+  // page reload), poll the transcript every 10s to show fresh progress.
+  useEffect(() => {
+    const last = messages[messages.length - 1]
+    if (!last?.partial || !activeSessionId || sending) return
+    const t = setInterval(async () => {
+      try {
+        const events = await call('transcript.get', { session_id: activeSessionId })
+        if (Array.isArray(events)) setMessages(eventsToMessages(events))
+      } catch {}
+    }, 10_000)
+    return () => clearInterval(t)
+  }, [messages, activeSessionId, sending, call, setMessages])
 
   const resetStreaming = useStore(s => s.resetStreaming)
   const streamingText = useStore(s => s.streamingText)
@@ -161,6 +177,11 @@ function MessageBubble({ message }: { message: ChatMessage }) {
         <div className="prose prose-sm prose-invert max-w-none [&_pre]:bg-gray-900 [&_pre]:rounded-lg [&_pre]:p-2 [&_code]:text-violet-300 [&_p]:my-1">
           <Markdown>{message.content}</Markdown>
         </div>
+        {message.partial && (
+          <div className="text-xs text-yellow-500/80 mt-1 animate-pulse">
+            ⏳ đang trả lời… (bản lưu tạm mỗi 10s)
+          </div>
+        )}
         <div className="text-[10px] text-gray-500 mt-1">
           {new Date(message.timestamp).toLocaleTimeString()}
         </div>

--- a/dashboard/src/components/SessionList.tsx
+++ b/dashboard/src/components/SessionList.tsx
@@ -1,4 +1,5 @@
 import { useStore, Session } from '../stores/store'
+import { eventsToMessages } from '../lib/transcript'
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -112,28 +113,3 @@ export default function SessionList({ call }: { call: (m: string, p?: any) => Pr
   )
 }
 
-function eventsToMessages(events: any[]) {
-  const msgs: any[] = []
-  let currentTools: string[] = []
-
-  for (const ev of events) {
-    switch (ev.type) {
-      case 'user_message':
-        msgs.push({ role: 'user', content: ev.content || '', timestamp: ev.ts })
-        break
-      case 'tool_call':
-        currentTools.push(ev.tool_name || '')
-        break
-      case 'assistant_text':
-        msgs.push({
-          role: 'assistant',
-          content: ev.content || '',
-          timestamp: ev.ts,
-          tools: currentTools.length > 0 ? [...currentTools] : undefined,
-        })
-        currentTools = []
-        break
-    }
-  }
-  return msgs
-}

--- a/dashboard/src/lib/transcript.ts
+++ b/dashboard/src/lib/transcript.ts
@@ -1,0 +1,51 @@
+import { ChatMessage, TranscriptEvent } from '../stores/store'
+
+// Converts transcript events to chat messages. assistant_partial events are
+// periodic snapshots of an in-progress reply: the final assistant_text of the
+// turn supersedes them, so only a trailing partial (reply still streaming, or
+// run interrupted) is shown — flagged with `partial: true`.
+export function eventsToMessages(events: TranscriptEvent[]): ChatMessage[] {
+  const msgs: ChatMessage[] = []
+  let currentTools: string[] = []
+  let partial: ChatMessage | null = null
+
+  const flushPartial = () => {
+    if (partial) {
+      msgs.push(partial)
+      partial = null
+    }
+  }
+
+  for (const ev of events) {
+    switch (ev.type) {
+      case 'user_message':
+        flushPartial()
+        msgs.push({ role: 'user', content: ev.content || '', timestamp: ev.ts })
+        break
+      case 'tool_call':
+        currentTools.push(ev.tool_name || '')
+        break
+      case 'assistant_partial':
+        partial = {
+          role: 'assistant',
+          content: ev.content || '',
+          timestamp: ev.ts,
+          tools: currentTools.length > 0 ? [...currentTools] : undefined,
+          partial: true,
+        }
+        break
+      case 'assistant_text':
+        partial = null // final supersedes this turn's partials
+        msgs.push({
+          role: 'assistant',
+          content: ev.content || '',
+          timestamp: ev.ts,
+          tools: currentTools.length > 0 ? [...currentTools] : undefined,
+        })
+        currentTools = []
+        break
+    }
+  }
+  flushPartial()
+  return msgs
+}

--- a/dashboard/src/stores/store.ts
+++ b/dashboard/src/stores/store.ts
@@ -14,7 +14,7 @@ export type Session = {
 }
 
 export type TranscriptEvent = {
-  type: 'user_message' | 'assistant_text' | 'tool_call' | 'tool_result' | 'session_start' | 'session_reset'
+  type: 'user_message' | 'assistant_text' | 'assistant_partial' | 'tool_call' | 'tool_result' | 'session_start' | 'session_reset'
   ts: string
   session_id?: string
   chat_id?: number
@@ -29,6 +29,7 @@ export type ChatMessage = {
   content: string
   timestamp: string
   tools?: string[]
+  partial?: boolean // reply still streaming (or interrupted) — snapshot only
 }
 
 type Tab = 'chat' | 'sessions' | 'status'

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -606,6 +606,15 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 	var turnText strings.Builder
 	var textMu sync.Mutex
 
+	// Snapshot the in-progress reply every 10s so a dashboard reload mid-run
+	// shows how far the bot has gotten (and a crash keeps the last prefix).
+	stopPartial := h.startPartialSaver(sess.ID, chatID, func() string {
+		textMu.Lock()
+		defer textMu.Unlock()
+		return assistantText.String()
+	})
+	defer stopPartial()
+
 	// latestTodos holds the most recent TodoWrite snapshot from the model.
 	// Updated under textMu since OnToolCall and the loop body that reads it
 	// are technically separate happens-before edges (the CLI scanner goroutine
@@ -714,6 +723,10 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 
 	streamer.Finalize()
 
+	// Stop the partial saver before writing the final assistant_text so no
+	// partial snapshot lands after the event that supersedes it.
+	stopPartial()
+
 	// Record assistant response
 	respText := assistantText.String()
 	if respText != "" {
@@ -747,6 +760,46 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 
 	result.EndedAt = time.Now()
 	return result, nil
+}
+
+// partialSaveInterval is how often an in-progress reply is snapshotted to
+// the transcript so reloads mid-run show current progress.
+const partialSaveInterval = 10 * time.Second
+
+// startPartialSaver periodically appends an assistant_partial snapshot of
+// the streaming reply to the transcript. snapshot must be safe to call from
+// another goroutine. The returned stop function is idempotent and must be
+// called before the final assistant_text is written.
+func (h *Handler) startPartialSaver(sessionID string, chatID int64, snapshot func() string) func() {
+	if h.transcript == nil {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(partialSaveInterval)
+		defer ticker.Stop()
+		lastLen := 0
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				snap := snapshot()
+				if snap == "" || len(snap) == lastLen {
+					continue
+				}
+				lastLen = len(snap)
+				err := h.transcript.Append(sessionID, transcript.Event{
+					Type: transcript.EventAssistantPartial, Timestamp: time.Now(),
+					SessionID: sessionID, ChatID: chatID, Content: snap,
+				})
+				if err != nil {
+					log.Printf("handler: partial save error: %v", err)
+				}
+			}
+		}
+	}()
+	return sync.OnceFunc(func() { close(done) })
 }
 
 // refreshSessionLabel regenerates the session label as a short summary of

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -106,7 +106,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	// Resumed sessions already carry full conversation history in the CLI,
 	// so injecting memory again causes context pollution (e.g. old topics
 	// overriding the user's current intent).
-	systemPrompt := c.systemPrompt
+	systemPrompt := c.systemPrompt + fsGuardPrompt
 	if memoryContext != "" && isNewSession {
 		systemPrompt += memoryContext
 	}
@@ -252,6 +252,16 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 
 	return cmd.Wait()
 }
+
+// fsGuardPrompt keeps the CLI's own file tools (Glob, Grep, Bash find …)
+// away from macOS TCC-protected folders. The gateway runs headless under
+// launchd, so a stray recursive scan of $HOME pops permission dialogs the
+// user cannot see the reason for.
+const fsGuardPrompt = "\n\n## File access\n" +
+	"- Never scan, list, or search ~/Music, ~/Pictures, ~/Movies, or ~/Downloads " +
+	"unless the user explicitly asks for a file there.\n" +
+	"- Avoid recursive searches rooted at the home directory (~); root them at the " +
+	"workspace or a specific project directory instead.\n"
 
 // buildArgs constructs the claude CLI argument list.
 func buildArgs(model, sessionID string, isNew bool, systemPrompt string) []string {

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ngocp/goterm-control/internal/agent"
@@ -286,6 +287,36 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 
 		// Track streamed text for persistence
 		var streamedText strings.Builder
+		var streamMu sync.Mutex
+
+		// Snapshot the in-progress reply every 10s so a dashboard reload
+		// mid-run shows current progress instead of a blank bubble.
+		partialDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(10 * time.Second)
+			defer ticker.Stop()
+			lastLen := 0
+			for {
+				select {
+				case <-partialDone:
+					return
+				case <-ticker.C:
+					streamMu.Lock()
+					snap := streamedText.String()
+					streamMu.Unlock()
+					if snap == "" || len(snap) == lastLen {
+						continue
+					}
+					lastLen = len(snap)
+					tw.Append(sessionID, transcript.Event{
+						Type: transcript.EventAssistantPartial, Timestamp: time.Now(),
+						SessionID: sessionID, Content: snap,
+					})
+				}
+			}
+		}()
+		stopPartial := sync.OnceFunc(func() { close(partialDone) })
+		defer stopPartial()
 
 		result, err := agent.RunAgent(agentCtx, agent.RunParams{
 			Provider:     deps.Provider,
@@ -297,7 +328,9 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			Tools:        deps.Tools,
 			MaxTokens:    maxTokens,
 			OnText: func(text string) {
+				streamMu.Lock()
 				streamedText.WriteString(text)
+				streamMu.Unlock()
 				emit(StreamEvent{Type: "stream", Event: "text", Data: text})
 			},
 			OnToolCall: func(name, input string) {
@@ -305,6 +338,9 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 				emit(StreamEvent{Type: "stream", Event: "tool", Data: summary})
 			},
 		})
+
+		// Stop snapshotting before the final assistant_text is written.
+		stopPartial()
 
 		// Persist assistant response
 		responseText := ""
@@ -338,21 +374,37 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 	}
 }
 
-// transcriptToMessages converts transcript events to agent.Message for context injection.
+// transcriptToMessages converts transcript events to agent.Message for context
+// injection. Partial snapshots are superseded by the final assistant_text of
+// their turn; only a trailing partial (interrupted run) is kept.
 func transcriptToMessages(events []transcript.Event) []agent.Message {
 	var msgs []agent.Message
+	var lastPartial string
+	flushPartial := func() {
+		if lastPartial != "" {
+			msgs = append(msgs, agent.Message{Role: "assistant", Content: lastPartial})
+			lastPartial = ""
+		}
+	}
 	for _, ev := range events {
 		switch ev.Type {
 		case transcript.EventUserMessage:
+			flushPartial()
 			if ev.Content != "" {
 				msgs = append(msgs, agent.Message{Role: "user", Content: ev.Content})
 			}
 		case transcript.EventAssistantText:
+			lastPartial = "" // final supersedes this turn's partials
 			if ev.Content != "" {
 				msgs = append(msgs, agent.Message{Role: "assistant", Content: ev.Content})
 			}
+		case transcript.EventAssistantPartial:
+			if ev.Content != "" {
+				lastPartial = ev.Content
+			}
 		}
 	}
+	flushPartial()
 	return msgs
 }
 

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -251,17 +251,18 @@ func (t *FileSystemTool) SearchFiles(ctx context.Context, raw json.RawMessage) (
 	searchPath := resolvePath(inp.Path)
 
 	if inp.SearchContent {
-		// Use grep for content search
-		args := []string{"-r", "--include=" + inp.FilePattern, "-n", "-m", "5", inp.Pattern, searchPath}
-		if inp.FilePattern == "" {
-			args = []string{"-r", "-n", "-m", "5", inp.Pattern, searchPath}
+		// Use grep for content search. Home-rooted searches exclude
+		// TCC-protected dirs (Music, Pictures, …) to avoid macOS
+		// permission dialogs.
+		excludes := strings.Join(grepExcludeDirs(searchPath), " ")
+		if excludes != "" {
+			excludes += " "
 		}
 		shell := &ShellTool{DefaultTimeout: 30, MaxOutputBytes: 4096}
-		cmd := fmt.Sprintf("grep -r -n --include='%s' -m 5 %q %q 2>/dev/null | head -100", inp.FilePattern, inp.Pattern, searchPath)
+		cmd := fmt.Sprintf("grep -r -n %s--include='%s' -m 5 %q %q 2>/dev/null | head -100", excludes, inp.FilePattern, inp.Pattern, searchPath)
 		if inp.FilePattern == "" {
-			cmd = fmt.Sprintf("grep -r -n -m 5 %q %q 2>/dev/null | head -100", inp.Pattern, searchPath)
+			cmd = fmt.Sprintf("grep -r -n %s-m 5 %q %q 2>/dev/null | head -100", excludes, inp.Pattern, searchPath)
 		}
-		_ = args
 		return shell.Run(ctx, mustJSON(map[string]interface{}{
 			"command": cmd,
 		}))

--- a/internal/tools/skipdir_darwin.go
+++ b/internal/tools/skipdir_darwin.go
@@ -4,6 +4,8 @@ package tools
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -20,15 +22,60 @@ var networkFSTypes = map[string]bool{
 	"macfuse":  true, // macFUSE v4
 }
 
-// walkFilter detects network-mounted directories during filepath.Walk
-// using device IDs to minimize syscalls.
+// tccProtectedNames are home subdirectories guarded by macOS TCC — first
+// access from a background service pops a permission dialog ("bomclaw wants
+// to access your Downloads folder"). Walks that merely pass through (e.g.
+// a search rooted at $HOME) skip them; explicitly rooting a search inside
+// one is treated as user intent and allowed.
+var tccProtectedNames = []string{"Music", "Pictures", "Movies", "Downloads"}
+
+// tccProtectedDirs returns the absolute protected paths to skip for a walk
+// rooted at root. A protected dir containing root is excluded — the caller
+// asked for it explicitly.
+func tccProtectedDirs(root string) map[string]bool {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return nil
+	}
+	out := make(map[string]bool, len(tccProtectedNames))
+	for _, name := range tccProtectedNames {
+		dir := filepath.Join(home, name)
+		if root == dir || strings.HasPrefix(root, dir+string(filepath.Separator)) {
+			continue
+		}
+		out[dir] = true
+	}
+	return out
+}
+
+// grepExcludeDirs returns grep --exclude-dir flags for content searches
+// rooted at $HOME, so grep -r does not descend into TCC-protected folders.
+// Searches rooted elsewhere get no excludes (a project dir named "Music"
+// must stay searchable).
+func grepExcludeDirs(root string) []string {
+	if root == "" || root != os.Getenv("HOME") {
+		return nil
+	}
+	args := make([]string, 0, len(tccProtectedNames))
+	for _, name := range tccProtectedNames {
+		args = append(args, "--exclude-dir="+name)
+	}
+	return args
+}
+
+// walkFilter detects network-mounted and TCC-protected directories during
+// filepath.Walk using device IDs to minimize syscalls.
 type walkFilter struct {
-	rootDev int32
-	cache   map[int32]bool // device ID → is network mount
+	rootDev   int32
+	cache     map[int32]bool  // device ID → is network mount
+	protected map[string]bool // absolute paths of TCC dirs to skip
 }
 
 func newWalkFilter(root string) *walkFilter {
-	wf := &walkFilter{cache: make(map[int32]bool)}
+	wf := &walkFilter{
+		cache:     make(map[int32]bool),
+		protected: tccProtectedDirs(root),
+	}
 	var stat syscall.Stat_t
 	if err := syscall.Stat(root, &stat); err == nil {
 		wf.rootDev = stat.Dev
@@ -37,9 +84,13 @@ func newWalkFilter(root string) *walkFilter {
 	return wf
 }
 
-// shouldSkip returns true if the directory at path is on a network filesystem.
-// It uses the device ID from info.Sys() to avoid redundant syscalls.
+// shouldSkip returns true if the directory at path is TCC-protected or on a
+// network filesystem. It uses the device ID from info.Sys() to avoid
+// redundant syscalls.
 func (wf *walkFilter) shouldSkip(path string, info os.FileInfo) bool {
+	if wf.protected[path] {
+		return true
+	}
 	sys := info.Sys()
 	if sys == nil {
 		return false

--- a/internal/tools/skipdir_darwin_test.go
+++ b/internal/tools/skipdir_darwin_test.go
@@ -69,3 +69,44 @@ func TestWalkFilter_CachesDeviceID(t *testing.T) {
 		t.Errorf("expected 1 cache entry (root device), got %d", len(wf.cache))
 	}
 }
+
+func TestTCCProtectedDirs_HomeWalk(t *testing.T) {
+	home := os.Getenv("HOME")
+	protected := tccProtectedDirs(home)
+	for _, name := range tccProtectedNames {
+		if !protected[filepath.Join(home, name)] {
+			t.Errorf("expected %s to be protected for a home-rooted walk", name)
+		}
+	}
+}
+
+func TestTCCProtectedDirs_ExplicitRootAllowed(t *testing.T) {
+	home := os.Getenv("HOME")
+	downloads := filepath.Join(home, "Downloads")
+
+	// Walk rooted at ~/Downloads itself: Downloads must NOT be skipped.
+	protected := tccProtectedDirs(downloads)
+	if protected[downloads] {
+		t.Error("walk rooted at ~/Downloads must not skip its own root")
+	}
+	// Other protected dirs still skipped.
+	if !protected[filepath.Join(home, "Music")] {
+		t.Error("Music should still be protected when walking ~/Downloads")
+	}
+
+	// Walk rooted deeper inside a protected dir.
+	protected = tccProtectedDirs(filepath.Join(downloads, "sub"))
+	if protected[downloads] {
+		t.Error("walk rooted inside ~/Downloads must not skip ~/Downloads")
+	}
+}
+
+func TestGrepExcludeDirs(t *testing.T) {
+	home := os.Getenv("HOME")
+	if got := grepExcludeDirs(home); len(got) != len(tccProtectedNames) {
+		t.Errorf("home-rooted grep should exclude %d dirs, got %v", len(tccProtectedNames), got)
+	}
+	if got := grepExcludeDirs(filepath.Join(home, "Documents", "projects")); got != nil {
+		t.Errorf("project-rooted grep should have no excludes, got %v", got)
+	}
+}

--- a/internal/tools/skipdir_other.go
+++ b/internal/tools/skipdir_other.go
@@ -15,3 +15,8 @@ func newWalkFilter(_ string) *walkFilter {
 func (wf *walkFilter) shouldSkip(_ string, _ os.FileInfo) bool {
 	return false
 }
+
+// grepExcludeDirs is a no-op on non-macOS platforms.
+func grepExcludeDirs(_ string) []string {
+	return nil
+}

--- a/internal/transcript/event.go
+++ b/internal/transcript/event.go
@@ -12,6 +12,12 @@ const (
 	EventToolResult    EventType = "tool_result"
 	EventSessionStart  EventType = "session_start"
 	EventSessionReset  EventType = "session_reset"
+
+	// EventAssistantPartial is a periodic full snapshot of an in-progress
+	// reply, written every ~10s while the agent streams. Readers show the
+	// last partial only when no final assistant_text follows it — the final
+	// event supersedes all partials of that turn.
+	EventAssistantPartial EventType = "assistant_partial"
 )
 
 // Event is a single transcript entry, serialized as one JSON line.


### PR DESCRIPTION
## Summary

### Stop macOS permission dialogs (Music / Pictures / Downloads)
- Root cause: `list_dir --recursive` and `search_files` default to `$HOME` and walk through `~/Music`, `~/Pictures`, `~/Downloads` — each first touch pops a TCC dialog for the launchd service.
- `walkFilter` now skips `~/Music`, `~/Pictures`, `~/Movies`, `~/Downloads` on pass-through walks; a search explicitly rooted inside one of them is treated as user intent and allowed.
- Home-rooted `grep -r` content searches get `--exclude-dir` flags for the same dirs (project-rooted searches unaffected — a project folder named `Music` stays searchable).
- The claude CLI system prompt gains a **File access** section keeping its own tools (Glob/Grep/Bash find) out of those dirs and away from home-wide recursive scans.

### Snapshot in-progress replies every 10s
- New `assistant_partial` transcript event: while a reply streams, both the Telegram bot path and the dashboard gateway path append a full snapshot every 10s; the final `assistant_text` supersedes all partials of its turn.
- Reloading the dashboard mid-run now shows the reply so far with a pulsing "đang trả lời…" badge, and ChatView polls the transcript every 10s until the final text lands. A crashed run keeps its last snapshot (also used for context injection).
- Merged the three duplicated `eventsToMessages` copies into `dashboard/src/lib/transcript.ts`.

## Test plan
- `go build ./...` + `go test ./...` pass; new tests cover TCC skip-list semantics (pass-through vs explicit root) and grep excludes.
- `tsc --noEmit` + `vite build` pass; dist rebuilt locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)