### PR TITLE
chore(deploy): service now runs from ~/.bomclaw — TCC blocks launchd reads of ~/Documents

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,82 +1,93 @@
 ---
-allowed-tools: Bash(go build *), Bash(git *), Bash(launchctl *), Bash(pgrep *), Bash(pkill *), Bash(kill *), Bash(curl *), Bash(sleep *), Bash(tail *), Bash(cat *), Read
-description: "Checkout main, pull latest, build bomclaw, and reload the macOS gateway service"
+allowed-tools: Bash(go build *), Bash(git *), Bash(launchctl *), Bash(pgrep *), Bash(pkill *), Bash(kill *), Bash(curl *), Bash(sleep *), Bash(tail *), Bash(cat *), Bash(cp *), Bash(codesign *), Bash(npm *), Read
+description: "Checkout main, pull latest, build bomclaw, install artifacts to ~/.bomclaw, and reload the macOS gateway service"
 ---
 
-# /deploy — Pull, Build & Reload Gateway
+# /deploy — Pull, Build, Install to ~/.bomclaw & Reload Gateway
 
-Checkout main, pull latest code, build the bomclaw binary, and restart the launchd gateway service on macOS.
+The gateway service **runs from `~/.bomclaw/`, NOT from the repo**. macOS TCC
+blocks launchd jobs from reading `~/Documents/**` (the binary hangs forever in
+`dyld → open()` with no logs), so deploy = build in the repo, then copy the
+artifacts into `~/.bomclaw/` and restart.
 
 ## Steps
 
-1. **Checkout main & pull latest**:
+1. **Checkout main & pull latest** (fetch + ff-only survives dirty docs files):
    ```bash
    cd /Users/ngocp/Documents/projects/meClaw/goterm-control
    git checkout main
-   git pull origin main
+   git fetch origin && git merge --ff-only origin/main
    ```
 
-2. **Build** the binary:
+2. **Build** the binary (and dashboard if `dashboard/src` changed):
    ```bash
-   cd /Users/ngocp/Documents/projects/meClaw/goterm-control
    go build -o bomclaw ./cmd/bomclaw/
+   # only if dashboard/src changed:
+   cd dashboard && npm run build && cd ..
    ```
 
-3. **Stop** the running gateway service:
+3. **Install artifacts to ~/.bomclaw** and re-sign (launchd refuses unsigned
+   swaps; identifier keeps TCC/LWCR identity stable):
    ```bash
-   launchctl stop com.nanoclaw.gateway
+   cp bomclaw ~/.bomclaw/bomclaw
+   codesign -f -s - --identifier com.bomclaw.gateway ~/.bomclaw/bomclaw
+   cp config.yaml ~/.bomclaw/config.yaml
+   cp .env ~/.bomclaw/.env
+   rm -rf ~/.bomclaw/dashboard/dist && cp -R dashboard/dist ~/.bomclaw/dashboard/dist
    ```
 
-4. **Kill stale processes** — any leftover bomclaw/nanoclaw or claude subprocesses:
+4. **Stop** the gateway and kill stale processes (orphaned `claude --resume`
+   subprocesses hold Telegram's getUpdates poll and cause Conflict errors):
    ```bash
+   launchctl stop com.bomclaw.gateway
    sleep 1
    pkill -f "bomclaw gateway" 2>/dev/null || true
-   pkill -f "nanoclaw gateway" 2>/dev/null || true
-   pkill -f "./goterm" 2>/dev/null || true
    pkill -f "claude.*--resume" 2>/dev/null || true
    sleep 1
    ```
-   Verify no stale processes remain:
-   ```bash
-   pgrep -lf "bomclaw|nanoclaw|goterm" || echo "clean — no stale processes"
-   ```
 
-5. **Start** the gateway service:
+5. **Start** (KeepAlive usually respawns on its own — start is idempotent):
    ```bash
-   launchctl start com.nanoclaw.gateway
+   launchctl start com.bomclaw.gateway
+   sleep 3
+   pgrep -lf "bomclaw gateway"
    ```
+   The process command line must show `/Users/ngocp/.bomclaw/bomclaw`.
 
-6. **Verify** the service is running:
-   ```bash
-   sleep 2
-   pgrep -lf bomclaw
-   ```
-
-7. **Health check** — confirm the gateway responds:
+6. **Health check**:
    ```bash
    curl -s http://127.0.0.1:18789/health
    ```
+   Note: `bomclaw status` reports "offline" when dashboard auth is enabled
+   (it dials /ws unauthenticated) — the health endpoint is the source of truth.
 
-8. **Show recent logs** if health check fails:
+7. **If health fails**, check logs and the dyld-stall signature:
    ```bash
-   tail -20 ~/.goterm/logs/gateway.log
-   tail -10 ~/.goterm/logs/gateway.err.log
+   tail -20 ~/.goterm/logs/gateway.err.log
    ```
+   - No startup lines at all + process alive + no TCP sockets → dyld stall.
+     Verify the process runs from `~/.bomclaw` (NOT the repo path). Diagnose
+     with: `launchctl submit -l t -o /tmp/t.out -- <binary> help` — if a repo
+     path stalls but a `~/.bomclaw` copy prints usage, it's the TCC block.
+   - `Conflict: terminated by other getUpdates` → redo step 4, then
+     `curl "https://api.telegram.org/bot${TOKEN}/deleteWebhook?drop_pending_updates=true"`
 
 ## Expected output
 
 Report:
 - Git: branch, commit hash, pull result
-- Build status (success/fail)
-- Stale processes killed (if any)
-- New PID
+- Build status (Go + dashboard if built)
+- Artifacts copied + codesign status
+- New PID (must be under ~/.bomclaw)
 - Health check result
-- If anything failed, show the relevant logs
 
 ## Notes
 
-- The launchd service label is `com.nanoclaw.gateway` (will migrate to `com.bomclaw.gateway` after reinstall)
-- Binary output path: `/Users/ngocp/Documents/projects/meClaw/goterm-control/bomclaw`
-- Config: `/Users/ngocp/Documents/projects/meClaw/goterm-control/config.yaml`
-- Logs: `~/.goterm/logs/gateway.log` and `gateway.err.log`
-- Stale claude subprocesses (from `client.go` spawning `claude -p --resume`) are also killed to prevent Telegram polling conflicts
+- Service label: `com.bomclaw.gateway` (plist: `~/Library/LaunchAgents/com.bomclaw.gateway.plist`)
+- Runtime layout: `~/.bomclaw/{bomclaw,config.yaml,.env,dashboard/dist}`
+- Data/logs stay in `~/.goterm/`; workspace in `~/goterm-workspace` — all outside TCC paths
+- NEVER point the LaunchAgent at a binary/config inside `~/Documents` — TCC
+  blocks launchd reads there (Apple-signed tools get EPERM; ad-hoc binaries
+  hang in dyld with zero logs)
+- Re-install from scratch if the plist is missing:
+  `cd ~/.bomclaw && ./bomclaw gateway install --config ~/.bomclaw/config.yaml --env ~/.bomclaw/.env`


### PR DESCRIPTION
macOS TCC denies launchd jobs access to ~/Documents: Apple-signed tools get
EPERM, ad-hoc Go binaries hang forever in dyld open() of their own executable
(no logs, no listen). Verified via launchctl submit from both paths.

Deploy now: build in repo -> copy binary/config/.env/dashboard-dist to
~/.bomclaw -> codesign (identifier com.bomclaw.gateway) -> restart the
com.bomclaw.gateway LaunchAgent (old com.nanoclaw.gateway plist removed).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
