### PR TITLE
fix(gateway): run CLIProvider subprocesses in the workspace so deny rules apply

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -189,7 +189,7 @@ func runGateway(args []string) {
 	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-oat") {
 		// OAuth subscription token — must use claude CLI subprocess
 		log.Println("gateway: using Claude CLI provider (OAuth token detected)")
-		provider = claude.NewCLIProvider()
+		provider = claude.NewCLIProvider(cfg.Claude.Workspace)
 	} else {
 		// Direct API key (sk-ant-api03-...)
 		log.Println("gateway: using direct Anthropic API provider")
@@ -399,7 +399,7 @@ func runChat(args []string) {
 
 	var chatProvider agent.ModelProvider
 	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-oat") {
-		chatProvider = claude.NewCLIProvider()
+		chatProvider = claude.NewCLIProvider(cfg.Claude.Workspace)
 	} else {
 		chatProvider = anthropicClient.New(cfg.Claude.APIKey)
 	}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -120,7 +120,7 @@ func New(cfg *config.Config, db *storage.DB, sessions *session.Manager) (*Bot, e
 	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-api") {
 		titleProvider = anthropicClient.New(cfg.Claude.APIKey)
 	} else {
-		titleProvider = claude.NewCLIProvider()
+		titleProvider = claude.NewCLIProvider(cfg.Claude.Workspace)
 	}
 	titleModel := resolver.Default()
 	if m := resolver.Lookup("haiku"); m != nil {

--- a/internal/claude/provider.go
+++ b/internal/claude/provider.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/ngocp/goterm-control/internal/agent"
@@ -20,10 +22,22 @@ import (
 // Bash, Read, Edit etc. on its own. Our browser_* tools are NOT available to the
 // CLI directly. For browser automation with OAuth tokens, the agent loop should
 // use this provider for text generation, and execute browser tools locally.
-type CLIProvider struct{}
+type CLIProvider struct {
+	// workspace is the CLI subprocess working directory. Critical on macOS:
+	// project-level permission deny rules (.claude/settings.json) load from
+	// the cwd, and file searches root there — a launchd-inherited cwd of "/"
+	// would skip the deny rules and scan TCC-protected folders.
+	workspace string
+}
 
-func NewCLIProvider() *CLIProvider {
-	return &CLIProvider{}
+// NewCLIProvider creates a provider whose CLI subprocesses run in workspace.
+// An empty workspace falls back to ~/goterm-workspace.
+func NewCLIProvider(workspace string) *CLIProvider {
+	if workspace == "" {
+		home, _ := os.UserHomeDir()
+		workspace = filepath.Join(home, "goterm-workspace")
+	}
+	return &CLIProvider{workspace: workspace}
 }
 
 // Stream spawns `claude -p --output-format stream-json` and emits events.
@@ -47,11 +61,15 @@ func (p *CLIProvider) Stream(ctx context.Context, params agent.StreamParams) (<-
 		"--strict-mcp-config",
 	}
 
-	if params.SystemPrompt != "" {
-		args = append(args, "--append-system-prompt", params.SystemPrompt)
-	}
+	// Always carry the file-access guard so the CLI's own tools stay out of
+	// TCC-protected folders (same rule as the bot path in client.go).
+	args = append(args, "--append-system-prompt", params.SystemPrompt+fsGuardPrompt)
 
 	cmd := exec.CommandContext(ctx, claudeBin, args...)
+	// Run in the workspace so its .claude/settings.json deny rules apply and
+	// searches root there instead of the launchd cwd ("/").
+	_ = os.MkdirAll(p.workspace, 0755)
+	cmd.Dir = p.workspace
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = filteredEnv(envVarsToRemove)
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -83,7 +83,7 @@ func requireEnv(t *testing.T, key string) string {
 // OAuth tokens (sk-ant-oat...) use CLI subprocess; API keys use direct API.
 func makeProvider(apiKey string) agent.ModelProvider {
 	if strings.HasPrefix(apiKey, "sk-ant-oat") {
-		return claude.NewCLIProvider()
+		return claude.NewCLIProvider("")
 	}
 	return anthropicClient.New(apiKey)
 }


### PR DESCRIPTION
The dashboard send path (and the session titler) spawn the claude CLI via
CLIProvider without cmd.Dir, so under launchd the subprocess ran with cwd=/:
the workspace's .claude/settings.json permission deny rules never loaded and
file searches rooted at home — triggering macOS TCC prompts (Music/Pictures/
Downloads) that the Telegram bot path already avoids.

CLIProvider now takes the workspace dir, runs the CLI there, and appends the
same fsGuardPrompt file-access guard used by the bot path.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
