### PR TITLE
fix(config): expand ~/ in session.data_dir

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,9 @@ func Load(path string) (*Config, error) {
 	if cfg.Session.DataDir == "" {
 		home, _ := os.UserHomeDir()
 		cfg.Session.DataDir = home + "/.goterm/data"
+	} else if strings.HasPrefix(cfg.Session.DataDir, "~/") {
+		home, _ := os.UserHomeDir()
+		cfg.Session.DataDir = home + cfg.Session.DataDir[1:]
 	}
 	if cfg.Session.Reset.DailyAt == "" {
 		cfg.Session.Reset.DailyAt = "04:00"


### PR DESCRIPTION
## Vấn đề

`claude.workspace` và `memory.dir` đều expand `~/`, riêng `session.data_dir` thì không. Config dùng `data_dir: "~/.goterm2/data"` vì thế tạo ra một thư mục tên `~` literal dưới cwd của tiến trình.

Cụ thể trên máy này, DB của agent 2 nằm ở:

```
/Users/ngocp/.bomclaw2/~/.goterm2/data/goterm.db     ← sai
/Users/ngocp/.goterm2/data/goterm.db                 ← đúng
```

## Thay đổi

Thêm nhánh expand `~/` cho `session.data_dir`, đúng theo cách hai field kia đang làm.

## Ảnh hưởng

Agent 1 không đụng gì: `data_dir` của nó để rỗng nên rơi vào default tuyệt đối (`$HOME/.goterm/data`).

Agent 2 sẽ trỏ sang đường dẫn đúng — khi deploy cần move DB cũ sang chỗ mới để giữ lịch sử chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)