### PR TITLE
feat(provider): run an agent on the OpenAI Codex CLI

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/bot"
 	"github.com/ngocp/goterm-control/internal/channel"
 	"github.com/ngocp/goterm-control/internal/claude"
+	"github.com/ngocp/goterm-control/internal/codex"
 	"github.com/ngocp/goterm-control/internal/config"
 	agentctx "github.com/ngocp/goterm-control/internal/context"
 	"github.com/ngocp/goterm-control/internal/daemon"
@@ -185,17 +186,8 @@ func runGateway(args []string) {
 		cancel()
 	}()
 
-	// Create model provider: use CLI for OAuth tokens, direct API for API keys
-	var provider agent.ModelProvider
-	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-oat") {
-		// OAuth subscription token — must use claude CLI subprocess
-		log.Println("gateway: using Claude CLI provider (OAuth token detected)")
-		provider = claude.NewCLIProvider(cfg.Claude.Workspace)
-	} else {
-		// Direct API key (sk-ant-api03-...)
-		log.Println("gateway: using direct Anthropic API provider")
-		provider = anthropicClient.New(cfg.Claude.APIKey)
-	}
+	// Create model provider: codex CLI, claude CLI (OAuth), or direct API key.
+	provider := buildProvider(cfg)
 
 	// Model resolver
 	resolver := models.NewResolver(cfg.Models.Default, cfg.Models.Custom)
@@ -382,6 +374,23 @@ func runModels(_ []string) {
 	}
 }
 
+// buildProvider picks the model backend for one-shot text calls, following
+// cfg.Provider first and then the shape of the Anthropic credential.
+func buildProvider(cfg *config.Config) agent.ModelProvider {
+	if cfg.Provider == config.ProviderCodex {
+		log.Println("gateway: using Codex CLI provider")
+		return codex.NewCLIProvider(cfg.Claude.Workspace)
+	}
+	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-oat") {
+		// OAuth subscription token — must use claude CLI subprocess
+		log.Println("gateway: using Claude CLI provider (OAuth token detected)")
+		return claude.NewCLIProvider(cfg.Claude.Workspace)
+	}
+	// Direct API key (sk-ant-api03-...)
+	log.Println("gateway: using direct Anthropic API provider")
+	return anthropicClient.New(cfg.Claude.APIKey)
+}
+
 // --- chat command (direct, no gateway) ---
 
 func runChat(args []string) {
@@ -398,12 +407,7 @@ func runChat(args []string) {
 		log.Fatalf("config: %v", err)
 	}
 
-	var chatProvider agent.ModelProvider
-	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-oat") {
-		chatProvider = claude.NewCLIProvider(cfg.Claude.Workspace)
-	} else {
-		chatProvider = anthropicClient.New(cfg.Claude.APIKey)
-	}
+	chatProvider := buildProvider(cfg)
 	resolver := models.NewResolver(cfg.Models.Default, cfg.Models.Custom)
 
 	modelID := resolver.Default()

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,9 @@
+# Chat backend for this agent: "claude" (Claude Code CLI, default) or "codex"
+# (OpenAI Codex CLI). Each authenticates itself — claude via its OAuth login,
+# codex via `codex login`. Switching this requires a matching models.default:
+# codex only accepts models with api: codex-cli (e.g. gpt-6-astra).
+provider: "claude"
+
 telegram:
   token: ""        # set via TELEGRAM_TOKEN env var
   timeout: 60      # polling timeout in seconds

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -9,7 +9,9 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/ngocp/goterm-control/internal/agent"
 	anthropicClient "github.com/ngocp/goterm-control/internal/anthropic"
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/claude"
+	"github.com/ngocp/goterm-control/internal/codex"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/memory"
@@ -85,8 +87,19 @@ func New(cfg *config.Config, db *storage.DB, sessions *session.Manager) (*Bot, e
 		log.Printf("bot: default model=%s (%s)", defaultModel.ID, defaultModel.Name)
 	}
 
-	claudeClient := claude.New(cfg.Claude.SystemPrompt, executor)
-	claudeClient.SetWorkspace(cfg.Claude.Workspace)
+	// Chat backend — one CLI subprocess family per agent, chosen by config.
+	// Both keep their own conversation state (claude session / codex thread);
+	// the session row records which one owns the stored id.
+	var llm chat.Client
+	if cfg.Provider == config.ProviderCodex {
+		codexClient := codex.New(cfg.Claude.SystemPrompt)
+		codexClient.SetWorkspace(cfg.Claude.Workspace)
+		llm = codexClient
+	} else {
+		claudeClient := claude.New(cfg.Claude.SystemPrompt, executor)
+		claudeClient.SetWorkspace(cfg.Claude.Workspace)
+		llm = claudeClient
+	}
 
 	// Message store (SQLite — conversation history)
 	messageStore := storage.NewMessageStore(db)
@@ -117,14 +130,22 @@ func New(cfg *config.Config, db *storage.DB, sessions *session.Manager) (*Bot, e
 	// Uses the direct API when an API key is configured; otherwise falls back
 	// to the claude CLI (which the bot already requires for OAuth tokens).
 	var titleProvider agent.ModelProvider
-	if strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-api") {
-		titleProvider = anthropicClient.New(cfg.Claude.APIKey)
-	} else {
-		titleProvider = claude.NewCLIProvider(cfg.Claude.Workspace)
-	}
 	titleModel := resolver.Default()
-	if m := resolver.Lookup("haiku"); m != nil {
-		titleModel = m.ID
+	switch {
+	case cfg.Provider == config.ProviderCodex:
+		// Stay on the codex side: a claude model id would be rejected, and the
+		// agent may not have Anthropic credentials at all.
+		titleProvider = codex.NewCLIProvider(cfg.Claude.Workspace)
+	case strings.HasPrefix(cfg.Claude.APIKey, "sk-ant-api"):
+		titleProvider = anthropicClient.New(cfg.Claude.APIKey)
+		if m := resolver.Lookup("haiku"); m != nil {
+			titleModel = m.ID
+		}
+	default:
+		titleProvider = claude.NewCLIProvider(cfg.Claude.Workspace)
+		if m := resolver.Lookup("haiku"); m != nil {
+			titleModel = m.ID
+		}
 	}
 	sessionTitler := titler.New(titleProvider, titleModel)
 
@@ -132,7 +153,7 @@ func New(cfg *config.Config, db *storage.DB, sessions *session.Manager) (*Bot, e
 	handler := &Handler{
 		bot:              api,
 		sessions:         sessions,
-		claude:           claudeClient,
+		llm:              llm,
 		cfg:              cfg,
 		engine:           engine,
 		transcript:       transcriptWriter,

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -12,7 +12,7 @@ import (
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/ngocp/goterm-control/internal/agent"
-	"github.com/ngocp/goterm-control/internal/claude"
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/memory"
@@ -34,7 +34,7 @@ type MessageStore interface {
 type Handler struct {
 	bot        *tgbotapi.BotAPI
 	sessions   *session.Manager
-	claude     *claude.Client
+	llm        chat.Client // claude or codex CLI, chosen by cfg.Provider
 	cfg        *config.Config
 	engine     *execution.Engine
 	transcript *transcript.Writer
@@ -54,7 +54,7 @@ type Handler struct {
 func NewHandler(
 	bot *tgbotapi.BotAPI,
 	sessions *session.Manager,
-	claudeClient *claude.Client,
+	llm chat.Client,
 	cfg *config.Config,
 	engine *execution.Engine,
 	transcriptWriter *transcript.Writer,
@@ -66,7 +66,7 @@ func NewHandler(
 	return &Handler{
 		bot:              bot,
 		sessions:         sessions,
-		claude:           claudeClient,
+		llm:              llm,
 		cfg:              cfg,
 		engine:           engine,
 		transcript:       transcriptWriter,
@@ -449,7 +449,7 @@ func (h *Handler) runFlush(ctx context.Context, sess *session.Session, modelID s
 	defer sess.MarkIdle()
 
 	var reply strings.Builder
-	cb := claude.StreamCallbacks{
+	cb := chat.StreamCallbacks{
 		OnText: func(chunk string) { reply.WriteString(chunk) },
 		OnToolCall: func(name, inputJSON string) {
 			sess.NoteTool(name)
@@ -462,7 +462,7 @@ func (h *Handler) runFlush(ctx context.Context, sess *session.Session, modelID s
 		StartedAt: time.Now(),
 		Status:    execution.RunSuccess,
 	}
-	err := h.claude.SendMessage(ctx, sess, modelID, h.memory.FlushPrompt(time.Now()), "", cb)
+	err := h.llm.SendMessage(ctx, sess, modelID, h.memory.FlushPrompt(time.Now()), "", cb)
 	result.EndedAt = time.Now()
 	if err != nil {
 		result.Status = execution.RunFailed
@@ -622,7 +622,7 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 	// still take the lock for consistency with the other shared state).
 	var latestTodos []todoItem
 
-	cb := claude.StreamCallbacks{
+	cb := chat.StreamCallbacks{
 		OnText: func(chunk string) {
 			textMu.Lock()
 			assistantText.WriteString(chunk)
@@ -675,7 +675,7 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		turnText.Reset()
 		textMu.Unlock()
 
-		if err := h.claude.SendMessage(ctx, sess, modelID, currentText, currentMemory, cb); err != nil {
+		if err := h.llm.SendMessage(ctx, sess, modelID, currentText, currentMemory, cb); err != nil {
 			if ctx.Err() != nil {
 				if ctx.Err() == context.DeadlineExceeded {
 					streamer.Write("\n\n⏰ Task timed out.")
@@ -684,7 +684,7 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 				streamer.Finalize()
 				return result, nil
 			}
-			log.Printf("claude error: %v", err)
+			log.Printf("%s error: %v", h.llm.Name(), err)
 			streamer.Write(fmt.Sprintf("\n\n❌ Error: %v", err))
 			result.Status = execution.RunFailed
 			result.Error = err

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -1,0 +1,54 @@
+// Package chat holds the provider-agnostic contract between the bot layer and
+// a CLI-backed chat client (claude, codex). It exists so internal/bot does not
+// have to import a specific provider package just to name its callback type.
+package chat
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/tools"
+)
+
+// StreamCallbacks lets the bot layer react to provider events as they arrive.
+type StreamCallbacks struct {
+	OnText       func(chunk string)
+	OnToolCall   func(name string, inputJSON string)
+	OnToolResult func(name string, result tools.ToolResult)
+}
+
+// Client is one turn of conversation against a CLI-backed model.
+// Implementations own their own session/thread resume semantics; they read the
+// provider session id from sess and write it back on the first turn.
+type Client interface {
+	// SendMessage sends userText and streams the reply through cb.
+	// modelID is the already-resolved model. memoryContext is cross-session
+	// memory, injected on new sessions only (a resumed session already carries
+	// the history, so re-injecting it pollutes the context).
+	SendMessage(ctx context.Context, sess *session.Session, modelID string,
+		userText string, memoryContext string, cb StreamCallbacks) error
+
+	// Name returns the provider key stored on the session ("claude", "codex").
+	Name() string
+}
+
+// ExtractScreenshotPath finds the .png/.jpg path in a screencapture command so
+// the bot can send the file as a photo instead of echoing the shell output.
+// Handles quoted paths like screencapture -x "/tmp/foo.png".
+func ExtractScreenshotPath(cmd string) string {
+	for _, p := range strings.Fields(cmd) {
+		if strings.HasPrefix(p, "-") {
+			continue
+		}
+		if p == "screencapture" {
+			continue
+		}
+		if strings.Contains(p, ".png") || strings.Contains(p, ".jpg") {
+			// Strip surrounding quotes the model sometimes adds.
+			p = strings.Trim(p, `"'`)
+			return p
+		}
+	}
+	return ""
+}

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -26,11 +27,8 @@ var envVarsToRemove = []string{"ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"}
 const emptyMCPConfig = `{"mcpServers":{}}`
 
 // StreamCallbacks lets the bot layer react to Claude events.
-type StreamCallbacks struct {
-	OnText       func(chunk string)
-	OnToolCall   func(name string, inputJSON string)
-	OnToolResult func(name string, result tools.ToolResult)
-}
+// Aliased to the shared type so the bot can hold any chat.Client.
+type StreamCallbacks = chat.StreamCallbacks
 
 // Client wraps the claude CLI subprocess.
 type Client struct {
@@ -53,6 +51,12 @@ func New(systemPrompt string, executor *tools.Executor) *Client {
 func (c *Client) SetWorkspace(dir string) {
 	c.workspace = dir
 }
+
+// Name identifies this provider in session storage.
+func (c *Client) Name() string { return ProviderName }
+
+// ProviderName is the session-storage key for the Claude CLI provider.
+const ProviderName = "claude"
 
 // --- stream-json event types from claude CLI ---
 
@@ -220,7 +224,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 				}
 				// Screenshot detection: bash ran screencapture → send as photo.
 				if strings.Contains(p.command, "screencapture") {
-					if path := extractScreenshotPath(p.command); path != "" {
+					if path := chat.ExtractScreenshotPath(p.command); path != "" {
 						result.IsImage = true
 						result.ImagePath = path
 						result.Output = "screenshot at " + path
@@ -304,25 +308,6 @@ func filteredEnv(remove []string) []string {
 		}
 	}
 	return env
-}
-
-// extractScreenshotPath finds the .png/.jpg path in a screencapture command.
-// Handles quoted paths like screencapture -x "/tmp/foo.png" or /tmp/foo.png".
-func extractScreenshotPath(cmd string) string {
-	for _, p := range strings.Fields(cmd) {
-		if strings.HasPrefix(p, "-") {
-			continue
-		}
-		if p == "screencapture" {
-			continue
-		}
-		if strings.Contains(p, ".png") || strings.Contains(p, ".jpg") {
-			// Strip surrounding single/double quotes that Claude sometimes adds.
-			p = strings.Trim(p, `"'`)
-			return p
-		}
-	}
-	return ""
 }
 
 func formatInput(raw json.RawMessage) string {

--- a/internal/codex/client.go
+++ b/internal/codex/client.go
@@ -1,0 +1,353 @@
+// Package codex drives the OpenAI Codex CLI (`codex exec`) as a chat backend,
+// mirroring internal/claude so the bot can run either one.
+//
+// Event contract: `codex exec --json` writes one JSON object per line. Top-level
+// events are thread.started / turn.started / turn.completed / turn.failed /
+// item.{started,updated,completed} / error; the item payload carries its own
+// `type` (agent_message, reasoning, command_execution, file_change,
+// mcp_tool_call, web_search, todo_list, error). Verified against codex-cli
+// 0.153.4.
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/tools"
+)
+
+// codexBin is the name of the Codex CLI binary.
+const codexBin = "codex"
+
+// ProviderName is the session-storage key for the Codex CLI provider.
+const ProviderName = "codex"
+
+// Client wraps the codex CLI subprocess.
+type Client struct {
+	systemPrompt string
+	workspace    string // working directory for the CLI subprocess
+}
+
+// New creates a Codex client backed by the codex CLI subprocess.
+// The CLI manages its own auth (`codex login`) and its own tool loop.
+func New(systemPrompt string) *Client {
+	log.Printf("codex: subprocess client initialized")
+	return &Client{systemPrompt: systemPrompt}
+}
+
+// SetWorkspace sets the working directory for spawned CLI processes.
+func (c *Client) SetWorkspace(dir string) { c.workspace = dir }
+
+// Name identifies this provider in session storage.
+func (c *Client) Name() string { return ProviderName }
+
+// SendMessage sends userText to the codex CLI and streams events via callbacks.
+//
+// Codex has no equivalent of claude's --append-system-prompt, so on a new thread
+// the system prompt and memory are folded into the first user message; the
+// thread carries them in its history from then on. (A future option is writing
+// them to <workspace>/AGENTS.md, which codex loads automatically — that writes
+// into the user's workspace, so it is deliberately not done here.)
+func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID string,
+	userText string, memoryContext string, cb chat.StreamCallbacks) error {
+
+	threadID := sess.GetSessionID()
+	// A thread started by another CLI cannot be resumed by codex — a provider
+	// switch must begin a fresh thread rather than fail every turn.
+	isNewThread := threadID == "" || sess.GetProvider() != ProviderName
+
+	prompt := userText
+	if isNewThread {
+		prompt = c.firstTurnPrompt(userText, memoryContext)
+	}
+
+	args := buildArgs(modelID, threadID, isNewThread)
+
+	cmd := exec.CommandContext(ctx, codexBin, args...)
+	if c.workspace != "" {
+		_ = os.MkdirAll(c.workspace, 0755)
+		cmd.Dir = c.workspace
+	}
+	cmd.Stdin = strings.NewReader(prompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start codex: %w", err)
+	}
+
+	// Drain stderr to logs. Codex logs auth/model diagnostics here; the last
+	// lines are the only clue when a turn dies before emitting any event.
+	var lastErrLine string
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		s := bufio.NewScanner(stderr)
+		for s.Scan() {
+			line := s.Text()
+			if line == "" {
+				continue
+			}
+			lastErrLine = line
+			log.Printf("codex stderr: %s", line)
+		}
+	}()
+
+	// command_execution items arrive as started → completed; keep the command
+	// text so the completion can be reported (and screenshots detected).
+	pending := map[string]string{}
+	sawTurn := false
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			_ = cmd.Process.Kill()
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var ev event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "thread.started":
+			if ev.ThreadID != "" && isNewThread {
+				sess.SetSessionID(ev.ThreadID)
+				sess.SetProvider(ProviderName)
+				log.Printf("codex: thread_id=%s", ev.ThreadID)
+			}
+
+		case "item.started":
+			if ev.Item == nil {
+				continue
+			}
+			switch ev.Item.Type {
+			case "command_execution":
+				pending[ev.Item.ID] = ev.Item.Command
+				if cb.OnToolCall != nil {
+					cb.OnToolCall("Bash", ev.Item.Command)
+				}
+			case "mcp_tool_call":
+				if cb.OnToolCall != nil {
+					cb.OnToolCall(mcpToolName(ev.Item), formatInput(ev.Item.Arguments))
+				}
+			}
+
+		case "item.completed":
+			if ev.Item == nil {
+				continue
+			}
+			c.handleCompletedItem(ev.Item, pending, cb)
+
+		case "turn.completed":
+			sawTurn = true
+			sess.IncrementMessages()
+			if ev.Usage != nil {
+				sess.AddTokens(ev.Usage.InputTokens, ev.Usage.OutputTokens)
+				// Context size proxy for the threshold memory flush: what this
+				// call actually carried, cached prompt tokens included.
+				sess.SetLastContextTokens(ev.Usage.InputTokens + ev.Usage.CachedInputTokens)
+			}
+
+		case "turn.failed":
+			msg := "turn failed"
+			if ev.Error != nil && ev.Error.Message != "" {
+				msg = ev.Error.Message
+			}
+			return fmt.Errorf("codex error: %s", msg)
+
+		case "error":
+			if ev.Message != "" {
+				return fmt.Errorf("codex error: %s", ev.Message)
+			}
+			return fmt.Errorf("codex error: unspecified stream error")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan: %w", err)
+	}
+
+	waitErr := cmd.Wait()
+	<-stderrDone
+
+	// A non-zero exit with no turn.completed means codex died before doing any
+	// work (bad auth, unknown model). Surface the stderr tail — without it the
+	// user only sees "exit status 1".
+	if waitErr != nil && !sawTurn {
+		if lastErrLine != "" {
+			return fmt.Errorf("codex error: %s", lastErrLine)
+		}
+		return fmt.Errorf("codex: %w", waitErr)
+	}
+	return waitErr
+}
+
+// handleCompletedItem maps one finished codex item onto the bot callbacks.
+func (c *Client) handleCompletedItem(it *threadItem, pending map[string]string, cb chat.StreamCallbacks) {
+	switch it.Type {
+	case "agent_message", "assistant_message":
+		// Codex emits the reply as one completed item rather than deltas, so
+		// this fires once per turn with the full text.
+		if it.Text != "" && cb.OnText != nil {
+			cb.OnText(it.Text)
+		}
+
+	case "command_execution":
+		command := pending[it.ID]
+		if command == "" {
+			command = it.Command
+		}
+		delete(pending, it.ID)
+
+		result := tools.ToolResult{
+			Output:  it.AggregatedOutput,
+			IsError: it.Status == "failed" || (it.ExitCode != nil && *it.ExitCode != 0),
+		}
+		// Screenshot detection: a shell screencapture → send the file as a photo.
+		if strings.Contains(command, "screencapture") {
+			if path := chat.ExtractScreenshotPath(command); path != "" {
+				result.IsImage = true
+				result.ImagePath = path
+				result.Output = "screenshot at " + path
+			}
+		}
+		if cb.OnToolResult != nil {
+			cb.OnToolResult("Bash", result)
+		}
+
+	case "file_change":
+		if cb.OnToolResult == nil {
+			return
+		}
+		var b strings.Builder
+		for _, ch := range it.Changes {
+			fmt.Fprintf(&b, "%s %s\n", ch.Kind, ch.Path)
+		}
+		cb.OnToolResult("Edit", tools.ToolResult{
+			Output:  strings.TrimRight(b.String(), "\n"),
+			IsError: it.Status == "failed",
+		})
+
+	case "mcp_tool_call":
+		if cb.OnToolResult == nil {
+			return
+		}
+		out := string(it.Result)
+		if it.Error != "" {
+			out = it.Error
+		}
+		cb.OnToolResult(mcpToolName(it), tools.ToolResult{
+			Output:  out,
+			IsError: it.Status == "failed" || it.Error != "",
+		})
+
+	case "web_search":
+		if cb.OnToolCall != nil {
+			cb.OnToolCall("WebSearch", it.Query)
+		}
+
+	case "error":
+		// Item-level errors are warnings (e.g. model metadata missing); the
+		// turn continues, so log rather than abort.
+		log.Printf("codex item error: %s", it.Message)
+	}
+}
+
+// firstTurnPrompt folds the operating instructions and cross-session memory
+// into the opening message of a new thread.
+func (c *Client) firstTurnPrompt(userText, memoryContext string) string {
+	var b strings.Builder
+	if c.systemPrompt != "" {
+		b.WriteString("# Operating instructions\n\n")
+		b.WriteString(c.systemPrompt)
+		b.WriteString(fsGuardPrompt)
+		if memoryContext != "" {
+			b.WriteString("\n")
+			b.WriteString(memoryContext)
+		}
+		b.WriteString("\n\n---\n\n# Message\n\n")
+	}
+	b.WriteString(userText)
+	return b.String()
+}
+
+// buildArgs constructs the codex CLI argument list.
+// The trailing "-" makes codex read the prompt from stdin, which is safe for
+// arbitrary text (a prompt passed as argv would hit ARG_MAX and quoting bugs).
+func buildArgs(model, threadID string, isNew bool) []string {
+	args := []string{"exec"}
+	if !isNew {
+		args = append(args, "resume", threadID)
+	}
+	args = append(args,
+		"--json",
+		// The workspace is not necessarily a git repo; without this codex
+		// refuses to run outside one.
+		"--skip-git-repo-check",
+		// Parity with the claude path's --permission-mode bypassPermissions:
+		// this is a headless agent that is expected to drive the machine.
+		"--dangerously-bypass-approvals-and-sandbox",
+	)
+	if model != "" {
+		args = append(args, "-m", model)
+	}
+	return append(args, "-")
+}
+
+// fsGuardPrompt keeps the CLI's own file tools away from macOS TCC-protected
+// folders. The gateway runs headless under launchd, so a stray recursive scan
+// of $HOME pops permission dialogs the user cannot see the reason for.
+const fsGuardPrompt = "\n\n## File access\n" +
+	"- Never scan, list, or search ~/Music, ~/Pictures, ~/Movies, or ~/Downloads " +
+	"unless the user explicitly asks for a file there.\n" +
+	"- Avoid recursive searches rooted at the home directory (~); root them at the " +
+	"workspace or a specific project directory instead.\n"
+
+func mcpToolName(it *threadItem) string {
+	if it.Server == "" {
+		return it.Tool
+	}
+	return it.Server + "." + it.Tool
+}
+
+func formatInput(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var pretty map[string]any
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return string(raw)
+	}
+	b, _ := json.MarshalIndent(pretty, "", "  ")
+	return string(b)
+}
+
+// defaultWorkspace is used when no workspace is configured.
+func defaultWorkspace() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "goterm-workspace")
+}

--- a/internal/codex/client_live_test.go
+++ b/internal/codex/client_live_test.go
@@ -1,0 +1,113 @@
+package codex
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+// TestLiveSendMessageAndResume drives the real codex CLI. It needs `codex login`
+// and burns subscription quota, so it only runs with CODEX_LIVE=1.
+//
+//	CODEX_LIVE=1 go test ./internal/codex/ -run Live -v
+func TestLiveSendMessageAndResume(t *testing.T) {
+	if os.Getenv("CODEX_LIVE") != "1" {
+		t.Skip("set CODEX_LIVE=1 to run against the real codex CLI")
+	}
+
+	c := New("You are a test fixture. Answer in as few words as possible.")
+	c.SetWorkspace(t.TempDir())
+
+	sess := session.New(999)
+	model := os.Getenv("CODEX_LIVE_MODEL") // empty → CLI default
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// --- turn 1: new thread -------------------------------------------------
+	var first strings.Builder
+	err := c.SendMessage(ctx, sess, model,
+		"Remember the number 4271. Reply with exactly: STORED", "", chat.StreamCallbacks{
+			OnText: func(chunk string) { first.WriteString(chunk) },
+		})
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if !strings.Contains(first.String(), "STORED") {
+		t.Errorf("turn 1 reply = %q, want it to contain STORED", first.String())
+	}
+
+	threadID := sess.GetSessionID()
+	if threadID == "" {
+		t.Fatal("turn 1 did not record a thread id — resume would start over every turn")
+	}
+	if got := sess.GetProvider(); got != ProviderName {
+		t.Errorf("session provider = %q, want %q", got, ProviderName)
+	}
+	if sess.GetMessageCount() != 1 {
+		t.Errorf("message count = %d, want 1", sess.GetMessageCount())
+	}
+	if sess.LastContextTokens() == 0 {
+		t.Error("turn.completed usage was not recorded — the memory flush threshold would never fire")
+	}
+
+	// --- turn 2: resume the same thread -------------------------------------
+	var second strings.Builder
+	err = c.SendMessage(ctx, sess, model,
+		"What number did I ask you to remember? Reply with just the number.", "", chat.StreamCallbacks{
+			OnText: func(chunk string) { second.WriteString(chunk) },
+		})
+	if err != nil {
+		t.Fatalf("turn 2 (resume): %v", err)
+	}
+	if !strings.Contains(second.String(), "4271") {
+		t.Errorf("resume lost the thread history: reply = %q, want it to contain 4271", second.String())
+	}
+	if sess.GetSessionID() != threadID {
+		t.Errorf("thread id changed on resume: %q → %q", threadID, sess.GetSessionID())
+	}
+	if sess.GetMessageCount() != 2 {
+		t.Errorf("message count = %d, want 2", sess.GetMessageCount())
+	}
+}
+
+// TestLiveProviderSwitchStartsFreshThread proves a session carrying another
+// CLI's id is not handed to `codex exec resume`, which would fail every turn.
+func TestLiveProviderSwitchStartsFreshThread(t *testing.T) {
+	if os.Getenv("CODEX_LIVE") != "1" {
+		t.Skip("set CODEX_LIVE=1 to run against the real codex CLI")
+	}
+
+	c := New("You are a test fixture.")
+	c.SetWorkspace(t.TempDir())
+
+	// A session left behind by the claude backend.
+	sess := session.New(998)
+	sess.SetSessionID("03a07538-d859-4daf-9f9a-f2f5121600d9")
+	sess.SetProvider("claude")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	var out strings.Builder
+	if err := c.SendMessage(ctx, sess, os.Getenv("CODEX_LIVE_MODEL"),
+		"Reply with exactly: FRESH", "", chat.StreamCallbacks{
+			OnText: func(chunk string) { out.WriteString(chunk) },
+		}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if !strings.Contains(out.String(), "FRESH") {
+		t.Errorf("reply = %q", out.String())
+	}
+	if sess.GetSessionID() == "03a07538-d859-4daf-9f9a-f2f5121600d9" {
+		t.Error("the claude thread id survived — codex must have started its own thread")
+	}
+	if got := sess.GetProvider(); got != ProviderName {
+		t.Errorf("provider = %q, want %q", got, ProviderName)
+	}
+}

--- a/internal/codex/client_test.go
+++ b/internal/codex/client_test.go
@@ -1,0 +1,130 @@
+package codex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/tools"
+)
+
+func TestBuildArgsNewThread(t *testing.T) {
+	got := strings.Join(buildArgs("gpt-6-astra", "", true), " ")
+	want := "exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox -m gpt-6-astra -"
+	if got != want {
+		t.Errorf("new thread args:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildArgsResume(t *testing.T) {
+	got := strings.Join(buildArgs("gpt-6-astra", "01a06f8b-86c6-7960", false), " ")
+	if !strings.HasPrefix(got, "exec resume 01a06f8b-86c6-7960 ") {
+		t.Errorf("resume must put the thread id right after the subcommand, got %q", got)
+	}
+	if !strings.HasSuffix(got, " -") {
+		t.Errorf("prompt must still come from stdin, got %q", got)
+	}
+}
+
+func TestBuildArgsOmitsEmptyModel(t *testing.T) {
+	if got := strings.Join(buildArgs("", "", true), " "); strings.Contains(got, "-m") {
+		t.Errorf("empty model must fall through to the CLI default, got %q", got)
+	}
+}
+
+// Event lines captured from codex-cli 0.153.4 (`codex exec --json`).
+const realAgentMessage = `{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"PONG"}}`
+
+func TestParseRealAgentMessage(t *testing.T) {
+	var ev event
+	if err := json.Unmarshal([]byte(realAgentMessage), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Type != "item.completed" || ev.Item == nil || ev.Item.Type != "agent_message" {
+		t.Fatalf("unexpected parse: %+v", ev)
+	}
+
+	var got string
+	(&Client{}).handleCompletedItem(ev.Item, map[string]string{}, chat.StreamCallbacks{
+		OnText: func(chunk string) { got += chunk },
+	})
+	if got != "PONG" {
+		t.Errorf("OnText got %q, want %q", got, "PONG")
+	}
+}
+
+func TestParseRealTurnCompletedUsage(t *testing.T) {
+	line := `{"type":"turn.completed","usage":{"input_tokens":14690,"cached_input_tokens":11520,` +
+		`"cache_write_input_tokens":0,"output_tokens":6,"reasoning_output_tokens":0}}`
+	var ev event
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Usage == nil || ev.Usage.InputTokens != 14690 || ev.Usage.CachedInputTokens != 11520 || ev.Usage.OutputTokens != 6 {
+		t.Fatalf("usage parsed wrong: %+v", ev.Usage)
+	}
+}
+
+func TestCommandExecutionFailureIsAnError(t *testing.T) {
+	exit := 1
+	it := &threadItem{
+		ID:               "item_3",
+		Type:             "command_execution",
+		Command:          "ls /nope",
+		AggregatedOutput: "No such file or directory",
+		ExitCode:         &exit,
+		Status:           "failed",
+	}
+	var got tools.ToolResult
+	var name string
+	(&Client{}).handleCompletedItem(it, map[string]string{}, chat.StreamCallbacks{
+		OnToolResult: func(n string, r tools.ToolResult) { name, got = n, r },
+	})
+	if name != "Bash" {
+		t.Errorf("tool name = %q, want Bash", name)
+	}
+	if !got.IsError {
+		t.Error("non-zero exit must be reported as an error")
+	}
+	if got.Output != "No such file or directory" {
+		t.Errorf("output = %q", got.Output)
+	}
+}
+
+func TestScreenshotBecomesImage(t *testing.T) {
+	pending := map[string]string{"item_5": `screencapture -x "/tmp/shot2.png"`}
+	it := &threadItem{ID: "item_5", Type: "command_execution", Status: "completed"}
+
+	var got tools.ToolResult
+	(&Client{}).handleCompletedItem(it, pending, chat.StreamCallbacks{
+		OnToolResult: func(_ string, r tools.ToolResult) { got = r },
+	})
+	if !got.IsImage || got.ImagePath != "/tmp/shot2.png" {
+		t.Errorf("screenshot not detected: %+v", got)
+	}
+}
+
+func TestFirstTurnPromptCarriesInstructionsAndMemory(t *testing.T) {
+	c := &Client{systemPrompt: "You are AGENT 2."}
+	got := c.firstTurnPrompt("what time is it?", "## Memory\nuser likes brevity")
+
+	for _, want := range []string{"You are AGENT 2.", "## File access", "user likes brevity", "what time is it?"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("first-turn prompt missing %q\n---\n%s", want, got)
+		}
+	}
+	// The actual message must come last so it is not buried in instructions.
+	if !strings.HasSuffix(got, "what time is it?") {
+		t.Errorf("user text must end the prompt, got:\n%s", got)
+	}
+}
+
+func TestResumedTurnSendsRawUserText(t *testing.T) {
+	c := &Client{systemPrompt: "You are AGENT 2."}
+	// A resumed thread already holds the instructions; SendMessage only calls
+	// firstTurnPrompt for new threads, so the raw text is what goes over stdin.
+	if got := c.firstTurnPrompt("hello", ""); strings.Contains(got, "## Memory") {
+		t.Errorf("empty memory must not add a memory section: %q", got)
+	}
+}

--- a/internal/codex/events.go
+++ b/internal/codex/events.go
@@ -1,0 +1,62 @@
+package codex
+
+import "encoding/json"
+
+// event is one line of `codex exec --json` output.
+type event struct {
+	Type     string        `json:"type"`
+	ThreadID string        `json:"thread_id"`
+	Item     *threadItem   `json:"item"`
+	Usage    *usage        `json:"usage"`
+	Error    *errorPayload `json:"error"`
+	Message  string        `json:"message"`
+}
+
+// threadItem is the union of every item payload codex emits. Fields not
+// relevant to an item's type are simply absent.
+type threadItem struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+
+	// agent_message, reasoning
+	Text string `json:"text"`
+
+	// command_execution
+	Command          string `json:"command"`
+	AggregatedOutput string `json:"aggregated_output"`
+	ExitCode         *int   `json:"exit_code"`
+
+	// file_change
+	Changes []fileChange `json:"changes"`
+
+	// mcp_tool_call
+	Server    string          `json:"server"`
+	Tool      string          `json:"tool"`
+	Arguments json.RawMessage `json:"arguments"`
+	Result    json.RawMessage `json:"result"`
+	Error     string          `json:"error"`
+
+	// web_search
+	Query string `json:"query"`
+
+	// error (item-level warning)
+	Message string `json:"message"`
+
+	// command_execution, file_change, mcp_tool_call
+	Status string `json:"status"` // in_progress | completed | failed
+}
+
+type fileChange struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"` // add | delete | update
+}
+
+type usage struct {
+	InputTokens       int `json:"input_tokens"`
+	CachedInputTokens int `json:"cached_input_tokens"`
+	OutputTokens      int `json:"output_tokens"`
+}
+
+type errorPayload struct {
+	Message string `json:"message"`
+}

--- a/internal/codex/provider.go
+++ b/internal/codex/provider.go
@@ -1,0 +1,166 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/ngocp/goterm-control/internal/agent"
+)
+
+// CLIProvider implements agent.ModelProvider using the codex CLI subprocess.
+//
+// This is the one-shot text path used by the session titler and the `chat`
+// command — not the conversational bot path (that is Client, which keeps a
+// codex thread alive across turns). Because callers here only want text back,
+// the subprocess runs read-only: it must not execute commands to answer.
+type CLIProvider struct {
+	// workspace is the CLI subprocess working directory, so codex reads the
+	// agent's own project context rather than the launchd cwd ("/").
+	workspace string
+}
+
+// NewCLIProvider creates a provider whose CLI subprocesses run in workspace.
+// An empty workspace falls back to ~/goterm-workspace.
+func NewCLIProvider(workspace string) *CLIProvider {
+	if workspace == "" {
+		workspace = defaultWorkspace()
+	}
+	return &CLIProvider{workspace: workspace}
+}
+
+// Stream spawns `codex exec --json` and emits events. Every call starts a fresh
+// ephemeral thread: there is no session to resume, and persisting throwaway
+// title-generation threads would clutter the user's codex history.
+func (p *CLIProvider) Stream(ctx context.Context, params agent.StreamParams) (<-chan agent.StreamEvent, error) {
+	prompt := lastUserMessage(params.Messages)
+	if prompt == "" {
+		return nil, fmt.Errorf("no user message found")
+	}
+	if params.SystemPrompt != "" {
+		prompt = params.SystemPrompt + fsGuardPrompt + "\n\n---\n\n" + prompt
+	}
+
+	args := []string{
+		"exec",
+		"--json",
+		"--skip-git-repo-check",
+		// Text-only callers: no shell, no writes, no approval prompts to hang on.
+		"--sandbox", "read-only",
+		// Do not leave a saved session behind for a one-shot call.
+		"--ephemeral",
+	}
+	if params.Model != "" {
+		args = append(args, "-m", params.Model)
+	}
+	args = append(args, "-")
+
+	cmd := exec.CommandContext(ctx, codexBin, args...)
+	_ = os.MkdirAll(p.workspace, 0755)
+	cmd.Dir = p.workspace
+	cmd.Stdin = strings.NewReader(prompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start codex: %w", err)
+	}
+
+	go func() {
+		s := bufio.NewScanner(stderr)
+		for s.Scan() {
+			log.Printf("codex-cli stderr: %s", s.Text())
+		}
+	}()
+
+	ch := make(chan agent.StreamEvent, 64)
+	go func() {
+		defer close(ch)
+		defer cmd.Wait()
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+
+		for scanner.Scan() {
+			if ctx.Err() != nil {
+				_ = cmd.Process.Kill()
+				return
+			}
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var ev event
+			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				continue
+			}
+
+			switch ev.Type {
+			case "item.completed":
+				if ev.Item == nil {
+					continue
+				}
+				switch ev.Item.Type {
+				case "agent_message", "assistant_message":
+					if ev.Item.Text != "" {
+						ch <- agent.StreamEvent{Type: "text", Text: ev.Item.Text}
+					}
+				case "error":
+					log.Printf("codex item error: %s", ev.Item.Message)
+				}
+
+			case "turn.completed":
+				end := agent.StreamEvent{Type: "end", StopReason: "end_turn"}
+				if ev.Usage != nil {
+					end.Usage = &agent.Usage{
+						InputTokens:  ev.Usage.InputTokens,
+						OutputTokens: ev.Usage.OutputTokens,
+						CacheRead:    ev.Usage.CachedInputTokens,
+					}
+				}
+				ch <- end
+				return
+
+			case "turn.failed":
+				msg := "turn failed"
+				if ev.Error != nil && ev.Error.Message != "" {
+					msg = ev.Error.Message
+				}
+				ch <- agent.StreamEvent{Type: "error", Error: fmt.Errorf("codex: %s", msg)}
+				return
+
+			case "error":
+				ch <- agent.StreamEvent{Type: "error", Error: fmt.Errorf("codex: %s", ev.Message)}
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- agent.StreamEvent{Type: "error", Error: fmt.Errorf("scan: %w", err)}
+		}
+	}()
+
+	return ch, nil
+}
+
+func lastUserMessage(messages []agent.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" && messages[i].Content != "" {
+			return messages[i].Content
+		}
+	}
+	return ""
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,11 @@ import (
 )
 
 type Config struct {
+	// Provider selects the CLI backend that answers messages:
+	// "claude" (Claude Code CLI, default) or "codex" (OpenAI Codex CLI).
+	// Each has its own auth; see docs/design/shared-agent-memory.md §13 Q1.
+	Provider string `yaml:"provider"`
+
 	Telegram TelegramConfig `yaml:"telegram"`
 	Claude   ClaudeConfig   `yaml:"claude"`
 	Models   ModelsConfig   `yaml:"models"`
@@ -129,6 +134,9 @@ func Load(path string) (*Config, error) {
 	}
 
 	// Defaults
+	if cfg.Provider == "" {
+		cfg.Provider = ProviderClaude
+	}
 	if cfg.Telegram.Timeout == 0 {
 		cfg.Telegram.Timeout = 60
 	}
@@ -207,12 +215,37 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// Supported provider keys.
+const (
+	ProviderClaude = "claude"
+	ProviderCodex  = "codex"
+)
+
 func (c *Config) Validate() error {
 	if c.Telegram.Token == "" {
 		return fmt.Errorf("telegram.token is required (set TELEGRAM_TOKEN env var or config)")
 	}
-	if c.Claude.APIKey == "" {
-		return fmt.Errorf("claude.api_key is required (set ANTHROPIC_API_KEY env var or config)")
+	switch c.Provider {
+	case ProviderClaude:
+		if c.Claude.APIKey == "" {
+			return fmt.Errorf("claude.api_key is required (set ANTHROPIC_API_KEY env var or config)")
+		}
+	case ProviderCodex:
+		// Codex authenticates itself via `codex login`; no key lives here.
+		// Guard the model though: NewResolver silently falls back to the first
+		// builtin (a claude model) when the configured id is unknown, and the
+		// codex CLI would then reject every turn with a 400.
+		want := c.Models.Default
+		if want == "" {
+			want = c.Claude.Model
+		}
+		m := models.NewResolver(want, c.Models.Custom).Lookup(want)
+		if m == nil || m.API != models.APICodexCLI {
+			return fmt.Errorf("provider %q needs a codex model, but models.default/claude.model is %q; "+
+				"use a model with api: codex-cli (e.g. gpt-6-astra)", ProviderCodex, want)
+		}
+	default:
+		return fmt.Errorf("provider must be %q or %q, got %q", ProviderClaude, ProviderCodex, c.Provider)
 	}
 	return nil
 }

--- a/internal/models/catalog.go
+++ b/internal/models/catalog.go
@@ -4,9 +4,10 @@ package models
 type ModelAPI string
 
 const (
-	APIClaudeCLI    ModelAPI = "claude-cli"    // Claude Code CLI subprocess
-	APIAnthropic    ModelAPI = "anthropic"     // Anthropic Messages API (future)
-	APIOpenAI       ModelAPI = "openai"        // OpenAI-compatible completions (future)
+	APIClaudeCLI ModelAPI = "claude-cli" // Claude Code CLI subprocess
+	APICodexCLI  ModelAPI = "codex-cli"  // OpenAI Codex CLI subprocess
+	APIAnthropic ModelAPI = "anthropic"  // Anthropic Messages API (future)
+	APIOpenAI    ModelAPI = "openai"     // OpenAI-compatible completions (future)
 )
 
 // InputType describes what a model can accept.
@@ -91,6 +92,28 @@ func BuiltinModels() []Model {
 			Reasoning:     false,
 			Input:         []InputType{InputText, InputImage, InputDocument},
 			Cost:          ModelCost{Input: 0.8, Output: 4.0, CacheRead: 0.08, CacheWrite: 1.0},
+		},
+
+		// --- Codex CLI models (provider: codex) ---
+		// Verified against codex-cli 0.153.4 on a ChatGPT-account login
+		// (2026-09-05): gpt-6-astra is what the CLI selects by default and the
+		// only slug this auth mode accepts — gpt-5-codex and gpt-5.3-codex both
+		// return 400 "not supported when using Codex with a ChatGPT account".
+		// Context window is the CLI's own model_context_window for the turn.
+		//
+		// Cost stays zero on purpose: ChatGPT-subscription auth is not billed
+		// per token, so any figure here would be invented. Running codex on an
+		// API key instead? Add the model under models.custom with real pricing.
+		{
+			ID:            "gpt-6-astra",
+			Name:          "GPT-6 Astra (Codex)",
+			Provider:      "openai",
+			API:           APICodexCLI,
+			Aliases:       []string{"codex", "astra"},
+			ContextWindow: 258_400,
+			MaxTokens:     128_000,
+			Reasoning:     true,
+			Input:         []InputType{InputText, InputImage},
 		},
 	}
 }

--- a/internal/models/resolver_test.go
+++ b/internal/models/resolver_test.go
@@ -6,8 +6,8 @@ func TestResolverBuiltinModels(t *testing.T) {
 	r := NewResolver("claude-sonnet-4-6", nil)
 
 	all := r.List()
-	if len(all) != 4 {
-		t.Fatalf("expected 4 builtin models, got %d", len(all))
+	if len(all) != len(BuiltinModels()) {
+		t.Fatalf("expected %d builtin models, got %d", len(BuiltinModels()), len(all))
 	}
 
 	// Default resolution
@@ -107,9 +107,9 @@ func TestResolverCustomModel(t *testing.T) {
 
 	r := NewResolver("deepseek-r1", custom)
 
-	// Should have 5 models (4 builtin + 1 custom)
-	if len(r.List()) != 5 {
-		t.Fatalf("expected 5 models, got %d", len(r.List()))
+	// Should have every builtin plus the one custom model
+	if want := len(BuiltinModels()) + 1; len(r.List()) != want {
+		t.Fatalf("expected %d models, got %d", want, len(r.List()))
 	}
 
 	// Default should be custom model

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -13,6 +13,7 @@ type Session struct {
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
 	ClaudeSessionID string    `json:"claude_session_id,omitempty"`
+	Provider        string    `json:"provider,omitempty"` // CLI that owns ClaudeSessionID ("claude", "codex")
 	MessageCount    int       `json:"message_count"`
 	InputTokens     int       `json:"input_tokens"`
 	OutputTokens    int       `json:"output_tokens"`
@@ -55,6 +56,7 @@ type SessionSnapshot struct {
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	ClaudeSessionID string
+	Provider        string
 	MessageCount    int
 	InputTokens     int
 	OutputTokens    int
@@ -94,11 +96,32 @@ func (s *Session) GetSessionID() string {
 	return s.ClaudeSessionID
 }
 
-// SetSessionID stores the claude CLI session ID returned on first message.
+// SetSessionID stores the CLI session/thread ID returned on the first message.
 func (s *Session) SetSessionID(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ClaudeSessionID = id
+	s.UpdatedAt = time.Now()
+}
+
+// GetProvider returns the CLI that owns the stored session ID. Empty means the
+// session predates provider tracking — callers treat that as "claude".
+func (s *Session) GetProvider() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Provider == "" {
+		return "claude"
+	}
+	return s.Provider
+}
+
+// SetProvider records which CLI produced the stored session ID. A session
+// started by one CLI cannot be resumed by another, so the chat client compares
+// this against its own name and starts fresh on a mismatch.
+func (s *Session) SetProvider(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Provider = name
 	s.UpdatedAt = time.Now()
 }
 
@@ -147,6 +170,7 @@ func (s *Session) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ClaudeSessionID = ""
+	s.Provider = ""
 	s.MessageCount = 0
 	s.MemoryFlushed = false
 	s.lastContextTokens = 0
@@ -273,6 +297,7 @@ func (s *Session) Snapshot() SessionSnapshot {
 		CreatedAt:       s.CreatedAt,
 		UpdatedAt:       s.UpdatedAt,
 		ClaudeSessionID: s.ClaudeSessionID,
+		Provider:        s.Provider,
 		MessageCount:    s.MessageCount,
 		InputTokens:     s.InputTokens,
 		OutputTokens:    s.OutputTokens,

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -2,7 +2,7 @@ package storage
 
 import "fmt"
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 // DDL statements executed in order for fresh installs.
 var ddl = []string{
@@ -23,7 +23,8 @@ var ddl = []string{
 		compact_summary   TEXT DEFAULT '',
 		label             TEXT DEFAULT '',
 		seq               INTEGER DEFAULT 0,
-		memory_flushed    INTEGER DEFAULT 0
+		memory_flushed    INTEGER DEFAULT 0,
+		provider          TEXT DEFAULT 'claude'
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_sessions_chat ON sessions(chat_id)`,
 
@@ -98,9 +99,27 @@ func (db *DB) migrate() error {
 		if err := db.migrateV3ToV4(); err != nil {
 			return fmt.Errorf("migrate v3→v4: %w", err)
 		}
-		return db.setVersion(4)
+		if err := db.setVersion(4); err != nil {
+			return err
+		}
+		ver = 4
+	}
+	if ver < 5 {
+		if err := db.migrateV4ToV5(); err != nil {
+			return fmt.Errorf("migrate v4→v5: %w", err)
+		}
+		return db.setVersion(5)
 	}
 	return nil
+}
+
+// migrateV4ToV5 adds the provider column. It records which CLI produced
+// claude_session_id, so switching an agent between the claude and codex
+// backends starts a fresh CLI session instead of resuming with the wrong one.
+// Existing rows were all produced by the claude CLI.
+func (db *DB) migrateV4ToV5() error {
+	_, err := db.conn.Exec(`ALTER TABLE sessions ADD COLUMN provider TEXT DEFAULT 'claude'`)
+	return err
 }
 
 // migrateV3ToV4 adds the users and web_sessions tables for dashboard auth.

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -23,7 +23,7 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 	rows, err := s.db.conn.Query(`SELECT
 		id, chat_id, created_at, updated_at, claude_session_id,
 		message_count, input_tokens, output_tokens, compact_summary,
-		label, seq, memory_flushed
+		label, seq, memory_flushed, provider
 		FROM sessions`)
 	if err != nil {
 		return nil, fmt.Errorf("query sessions: %w", err)
@@ -38,9 +38,11 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 			createdStr, updatedStr       string
 			msgCount, inTok, outTok, seq int
 			memFlushed                   int
+			provider                     string
 		)
 		if err := rows.Scan(&id, &chatID, &createdStr, &updatedStr, &claudeID,
-			&msgCount, &inTok, &outTok, &summary, &label, &seq, &memFlushed); err != nil {
+			&msgCount, &inTok, &outTok, &summary, &label, &seq, &memFlushed,
+			&provider); err != nil {
 			continue
 		}
 
@@ -48,6 +50,7 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 		updated, _ := time.Parse(time.RFC3339, updatedStr)
 
 		sess := session.NewFromDB(id, chatID, created, updated, claudeID, msgCount, inTok, outTok, summary, label, seq, memFlushed != 0)
+		sess.Provider = provider
 
 		cs, ok := chats[chatID]
 		if !ok {
@@ -112,11 +115,12 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 	sessStmt, err := tx.Prepare(`INSERT INTO sessions
 		(id, chat_id, created_at, updated_at, claude_session_id,
 		 message_count, input_tokens, output_tokens, compact_summary, label, seq,
-		 memory_flushed)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 memory_flushed, provider)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			updated_at = excluded.updated_at,
 			claude_session_id = excluded.claude_session_id,
+			provider = excluded.provider,
 			message_count = excluded.message_count,
 			input_tokens = excluded.input_tokens,
 			output_tokens = excluded.output_tokens,
@@ -151,7 +155,7 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 				snap.CreatedAt.Format(time.RFC3339), snap.UpdatedAt.Format(time.RFC3339),
 				snap.ClaudeSessionID, snap.MessageCount,
 				snap.InputTokens, snap.OutputTokens, snap.CompactSummary,
-				snap.Label, snap.Seq, memFlushed,
+				snap.Label, snap.Seq, memFlushed, snap.Provider,
 			)
 			if err != nil {
 				return fmt.Errorf("upsert session %s: %w", snap.ID, err)


### PR DESCRIPTION
## Mục đích

Cho phép một agent chạy bằng **OpenAI Codex CLI** thay vì Claude Code CLI, để agent thứ hai không phải dùng chung phiên OAuth Claude với agent thứ nhất. Chọn bằng `provider: codex` trong config; mặc định vẫn là `claude`.

## Thay đổi

| Thành phần | Nội dung |
|---|---|
| `internal/chat` | `StreamCallbacks` + interface `Client` dùng chung, để `internal/bot` không phải import thẳng một backend cụ thể. `ExtractScreenshotPath` chuyển về đây vì cả hai backend đều cần |
| `internal/codex/client.go` | Đường hội thoại — `codex exec --json`, resume thread qua các lượt, map `command_execution` / `file_change` / `mcp_tool_call` / `web_search` sang callback của bot |
| `internal/codex/provider.go` | Đường một-lượt cho titler — `--sandbox read-only --ephemeral`: gọi đặt tên session thì không được chạy lệnh, cũng không để lại session rác |
| schema v5 | Cột `sessions.provider` ghi CLI nào tạo ra session id |
| config | `provider: claude\|codex` + validate model |

### Ba điểm đáng chú ý

**Session không được resume nhầm CLI.** Session do claude tạo mà đưa cho `codex exec resume` sẽ hỏng mọi lượt. Cột `provider` giải quyết: lệch provider → mở thread mới thay vì fail.

**Codex không có `--append-system-prompt`.** System prompt và memory được gộp vào tin nhắn đầu của thread mới; các lượt sau thread tự mang theo. (Cách khác là ghi `AGENTS.md` vào workspace — cố ý không làm vì nó ghi file vào workspace người dùng.)

**Model guard.** `NewResolver` âm thầm rơi về builtin đầu tiên (`claude-opus-4-8`) khi id không có trong catalog. Không chặn thì agent codex sẽ gửi model claude sang codex và ăn 400 mọi lượt, nên `Validate()` báo lỗi ngay lúc khởi động.

## Model catalog

Đo trên codex-cli 0.153.4 với login tài khoản ChatGPT (2026-09-05): **`gpt-6-astra` là slug duy nhất auth mode này chấp nhận**. `gpt-5-codex` và `gpt-5.3-codex` đều trả:

```
400 invalid_request_error: The '<model>' model is not supported
     when using Codex with a ChatGPT account.
```

nên catalog chỉ có một entry. `Cost` để 0 vì auth theo subscription không tính tiền theo token — điền số nào cũng là bịa.

## Kiểm chứng

Unit test dựa trên đúng JSONL đã ghi lại từ CLI thật, cộng bộ test live chạy CLI thật (bỏ qua nếu không có `CODEX_LIVE=1`):

```
CODEX_LIVE=1 CODEX_LIVE_MODEL=gpt-6-astra go test ./internal/codex/ -run Live -v
--- PASS: TestLiveSendMessageAndResume (12.55s)
--- PASS: TestLiveProviderSwitchStartsFreshThread (5.57s)
```

Test resume kiểm tra thật: lượt 1 bảo nhớ số 4271, lượt 2 hỏi lại — trả đúng, tức thread history sống qua các lượt.

`go vet ./...` và `go test ./...` xanh.

## Chưa làm

Không đổi tên `claude_session_id` → `provider_session_id`. Tên đó nằm trong JSON của gateway RPC và `dashboard/src/stores/store.ts`; đổi bây giờ là phá wire format lần một rồi đợt gộp DB phá lần hai. Gộp vào đợt migrate đó — xem `docs/design/shared-agent-memory.md` §13 Q1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)