### PR TITLE
feat(trace): trace commands issued from the web and CLI

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/storage"
 	"github.com/ngocp/goterm-control/internal/tools"
+	"github.com/ngocp/goterm-control/internal/trace"
 )
 
 // loadEnv reads KEY=VALUE pairs from a .env file into the process environment.
@@ -202,6 +203,11 @@ func runGateway(args []string) {
 	// Create model provider: codex CLI, claude CLI (OAuth), or direct API key.
 	provider := buildProvider(cfg)
 
+	// Recorder for the gateway's own command path (dashboard, `bomclaw send`,
+	// a peer agent). The bot keeps its own for the Telegram path; both write
+	// to the same shared database.
+	var gwTrace *trace.Recorder
+
 	// Model resolver
 	resolver := models.NewResolver(cfg.Models.Default, cfg.Models.Custom)
 
@@ -229,6 +235,8 @@ func runGateway(args []string) {
 			defer coordDB.Close()
 			log.Printf("coord: shared database at %s (agent=%s)", coordDB.Path(), cfg.Agent.ID)
 			startCoordUpkeep(ctx, coordDB, cfg, *bind, *port, resolver.Default())
+			gwTrace = trace.New(coordDB, cfg.Agent.ID)
+			defer gwTrace.Close()
 		}
 	}
 
@@ -263,14 +271,16 @@ func runGateway(args []string) {
 	}
 
 	deps := gateway.Deps{
-		Sessions: sessions,
-		Resolver: resolver,
-		Provider: provider,
-		System:   cfg.Claude.SystemPrompt,
-		DataDir:  cfg.Session.DataDir,
-		Uptime:   func() time.Duration { return time.Since(startTime) },
-		Coord:    coordDB,
-		AgentID:  cfg.Agent.ID,
+		Sessions:     sessions,
+		Resolver:     resolver,
+		Provider:     provider,
+		System:       cfg.Claude.SystemPrompt,
+		DataDir:      cfg.Session.DataDir,
+		Uptime:       func() time.Duration { return time.Since(startTime) },
+		Coord:        coordDB,
+		AgentID:      cfg.Agent.ID,
+		ProviderName: cfg.Provider,
+		Trace:        gwTrace,
 	}
 	if tgBot != nil {
 		deps.Runs = func() []gateway.RunInfo {
@@ -587,7 +597,7 @@ func runChat(args []string) {
 		ctxEngine.SetMessages(result.Messages)
 
 		fmt.Println() // newline after streaming
-		return nil     // already printed via OnText
+		return nil    // already printed via OnText
 	})
 }
 
@@ -957,7 +967,7 @@ func findToolSchema(name string) map[string]any {
 		"open_app": {"type": "object", "properties": map[string]any{
 			"name": map[string]any{"type": "string", "description": "App name or path"},
 		}, "required": []string{"name"}},
-		"get_system_info":  {"type": "object", "properties": map[string]any{}},
+		"get_system_info": {"type": "object", "properties": map[string]any{}},
 		"list_processes": {"type": "object", "properties": map[string]any{
 			"filter":  map[string]any{"type": "string", "description": "Filter by name"},
 			"sort_by": map[string]any{"type": "string", "description": "Sort by: cpu, memory, pid"},

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -38,6 +38,18 @@ func RunAgent(ctx context.Context, params RunParams) (*RunResult, error) {
 			}, ctx.Err()
 		}
 
+		// Span this model call, if the caller is tracing.
+		var endIteration func(string, *Usage, error)
+		if params.OnIteration != nil {
+			endIteration = params.OnIteration(iteration)
+		}
+		finish := func(text string, u *Usage, err error) {
+			if endIteration != nil {
+				endIteration(text, u, err)
+				endIteration = nil // a retry opens its own span
+			}
+		}
+
 		// Stream model response
 		events, err := params.Provider.Stream(ctx, StreamParams{
 			Model:        params.ModelID,
@@ -47,6 +59,7 @@ func RunAgent(ctx context.Context, params RunParams) (*RunResult, error) {
 			MaxTokens:    params.MaxTokens,
 		})
 		if err != nil {
+			finish("", nil, err)
 			if isContextOverflow(err) {
 				log.Printf("agent: context overflow at iteration %d, trimming history", iteration)
 				messages = trimOldMessages(messages, len(messages)/2)
@@ -91,12 +104,14 @@ func RunAgent(ctx context.Context, params RunParams) (*RunResult, error) {
 				usage = ev.Usage
 				stopReason = ev.StopReason
 			case "error":
+				finish(textBuf.String(), usage, ev.Error)
 				return nil, ev.Error
 			}
 		}
 
 		responseText := textBuf.String()
 		lastText = responseText
+		finish(responseText, usage, nil)
 
 		// Accumulate usage
 		if usage != nil {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -98,6 +98,15 @@ type RunParams struct {
 	OnText       OnTextFunc
 	OnToolCall   OnToolCallFunc
 	OnToolResult OnToolResultFunc
+
+	// OnIteration is called just before each model call with the 0-based
+	// iteration number. The function it returns is called once that call
+	// finishes, with whatever the model produced. Either may be nil.
+	//
+	// This exists so a caller can span each model call separately: the loop
+	// makes one call per tool round trip, and a single span over the whole
+	// run would hide where the time actually went.
+	OnIteration func(iteration int) func(text string, usage *Usage, err error)
 }
 
 // RunResult is returned after the agent loop completes.

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/coord"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/trace"
 	"github.com/ngocp/goterm-control/internal/transcript"
 )
 
@@ -33,8 +34,10 @@ type Deps struct {
 	// Coord is the shared coordination database (traces, tasks, inter-agent
 	// messages). Nil when coordination is disabled — every admin.* method
 	// then reports that rather than failing obscurely.
-	Coord   *coord.DB
-	AgentID string
+	Coord        *coord.DB
+	AgentID      string
+	ProviderName string          // "claude" | "codex", for trace metadata
+	Trace        *trace.Recorder // nil-safe: nil disables tracing on this path
 }
 
 // NewMethodHandler creates a MethodHandler that routes to the appropriate handler.
@@ -498,6 +501,22 @@ func handleSend(ctx context.Context, deps Deps, params json.RawMessage) (json.Ra
 		maxTokens = m.MaxTokens
 	}
 
+	// Trace this command the same way a Telegram turn is traced, so the admin
+	// page shows one timeline whether the instruction came from the dashboard,
+	// the CLI, or a peer agent.
+	span := deps.Trace.StartTrace("gateway.send", coord.RunTypeChain, trace.Meta{
+		SessionID: sessionID,
+		Model:     modelID,
+		Provider:  deps.ProviderName,
+	})
+	span.SetInputs(p.Message)
+
+	// Tool calls and results arrive as separate callbacks carrying only the
+	// tool name, so pair them FIFO per name — the loop runs tools in order.
+	var toolMu sync.Mutex
+	openTools := map[string][]*trace.Span{}
+	var current *trace.Span
+
 	result, err := agent.RunAgent(ctx, agent.RunParams{
 		Provider:     deps.Provider,
 		ToolExecutor: deps.ToolExecutor,
@@ -506,10 +525,51 @@ func handleSend(ctx context.Context, deps Deps, params json.RawMessage) (json.Ra
 		UserMessage:  p.Message,
 		Tools:        deps.Tools,
 		MaxTokens:    maxTokens,
+
+		OnIteration: func(iteration int) func(string, *agent.Usage, error) {
+			toolMu.Lock()
+			current = span.Child(fmt.Sprintf("%s #%d", deps.ProviderName, iteration+1), coord.RunTypeLLM)
+			call := current
+			toolMu.Unlock()
+			return func(text string, u *agent.Usage, err error) {
+				in, out := 0, 0
+				if u != nil {
+					in, out = u.InputTokens, u.OutputTokens
+				}
+				call.EndWithTokens(text, err, in, out)
+			}
+		},
+		OnToolCall: func(name, input string) {
+			toolMu.Lock()
+			defer toolMu.Unlock()
+			sp := current.Child(name, coord.RunTypeTool)
+			if sp == nil {
+				return
+			}
+			sp.SetInputs(input)
+			openTools[name] = append(openTools[name], sp)
+		},
+		OnToolResult: func(name, content string, isErr bool) {
+			toolMu.Lock()
+			defer toolMu.Unlock()
+			q := openTools[name]
+			if len(q) == 0 {
+				return
+			}
+			sp := q[0]
+			openTools[name] = q[1:]
+			var toolErr error
+			if isErr {
+				toolErr = fmt.Errorf("%s failed", name)
+			}
+			sp.End(content, toolErr)
+		},
 	})
 	if err != nil {
+		span.End("", err)
 		return nil, err
 	}
+	span.EndWithTokens(result.Text, nil, result.Usage.InputTokens, result.Usage.OutputTokens)
 
 	// Persist transcript
 	tw := transcript.NewWriter(filepath.Join(deps.DataDir, "transcripts"))


### PR DESCRIPTION
## Vấn đề

PR #66 chỉ trace đường Telegram. Nhưng ô chat trên dashboard, `bomclaw send`, và agent gọi agent đều đi qua RPC `send` → `agent.RunAgent` — **đường hoàn toàn khác**. Nên lệnh ra từ web không để lại trace nào, đúng cái mà admin page cần giải thích nhất.

## Thay đổi

**`agent.RunParams.OnIteration`** — gọi trước mỗi model call, trả về hàm được gọi khi call đó xong. Vòng lặp agent gọi model một lần cho mỗi vòng tool, nên một span phủ cả run sẽ giấu mất thời gian thực sự đi đâu.

**Handler `send`** giờ mở root run + một con cho mỗi model call + một con cho mỗi tool — đúng hình dạng đường Telegram đã sinh ra. Một timeline duy nhất bất kể lệnh đến từ đâu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)