### PR TITLE
fix(trace): trace the streaming send path, and stop double-counting tokens

### DIFF
--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -86,6 +86,15 @@ func NewMethodHandler(deps Deps) MethodHandler {
 	}
 }
 
+// providerLabel names the model backend in a span; falls back to something
+// readable when the gateway was built without a provider name.
+func providerLabel(deps Deps) string {
+	if deps.ProviderName != "" {
+		return deps.ProviderName
+	}
+	return "model"
+}
+
 func handleStatus(deps Deps) (json.RawMessage, error) {
 	sessions := deps.Sessions.List()
 	result := StatusResult{
@@ -343,6 +352,22 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 		stopPartial := sync.OnceFunc(func() { close(partialDone) })
 		defer stopPartial()
 
+		// Trace this command. This is the path the dashboard chat box, the
+		// `bomclaw send` CLI and a peer agent all take, so it is the one the
+		// admin page most needs to explain.
+		span := deps.Trace.StartTrace("gateway.send", coord.RunTypeChain, trace.Meta{
+			SessionID: sessionID,
+			Model:     modelID,
+			Provider:  deps.ProviderName,
+		})
+		span.SetInputs(p.Message)
+
+		// Tool callbacks carry only the tool name, so pair call with result
+		// FIFO per name — the agent loop executes tools in order.
+		var spanMu sync.Mutex
+		var llmSpan *trace.Span
+		openTools := map[string][]*trace.Span{}
+
 		result, err := agent.RunAgent(agentCtx, agent.RunParams{
 			Provider:     deps.Provider,
 			ToolExecutor: deps.ToolExecutor,
@@ -358,9 +383,46 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 				streamMu.Unlock()
 				emit(StreamEvent{Type: "stream", Event: "text", Data: text})
 			},
+			OnIteration: func(iteration int) func(string, *agent.Usage, error) {
+				spanMu.Lock()
+				llmSpan = span.Child(fmt.Sprintf("%s #%d", providerLabel(deps), iteration+1), coord.RunTypeLLM)
+				call := llmSpan
+				spanMu.Unlock()
+				return func(text string, u *agent.Usage, err error) {
+					in, out := 0, 0
+					if u != nil {
+						in, out = u.InputTokens, u.OutputTokens
+					}
+					call.EndWithTokens(text, err, in, out)
+				}
+			},
 			OnToolCall: func(name, input string) {
 				summary := toolSummary(name, input)
 				emit(StreamEvent{Type: "stream", Event: "tool", Data: summary})
+
+				spanMu.Lock()
+				defer spanMu.Unlock()
+				sp := llmSpan.Child(name, coord.RunTypeTool)
+				if sp == nil {
+					return
+				}
+				sp.SetInputs(input)
+				openTools[name] = append(openTools[name], sp)
+			},
+			OnToolResult: func(name, content string, isErr bool) {
+				spanMu.Lock()
+				defer spanMu.Unlock()
+				q := openTools[name]
+				if len(q) == 0 {
+					return
+				}
+				sp := q[0]
+				openTools[name] = q[1:]
+				var toolErr error
+				if isErr {
+					toolErr = fmt.Errorf("%s failed", name)
+				}
+				sp.End(content, toolErr)
 			},
 		})
 
@@ -388,6 +450,11 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			}
 			emit(StreamEvent{Type: "stream", Event: "error", Data: errMsg})
 		}
+
+		// The root carries no tokens of its own: each model call already
+		// recorded its usage, and a trace's totals are the sum over its tree,
+		// so counting them again here would double every number on screen.
+		span.End(responseText, err)
 
 		finalResult, _ := json.Marshal(map[string]any{
 			"text":       responseText,
@@ -569,7 +636,9 @@ func handleSend(ctx context.Context, deps Deps, params json.RawMessage) (json.Ra
 		span.End("", err)
 		return nil, err
 	}
-	span.EndWithTokens(result.Text, nil, result.Usage.InputTokens, result.Usage.OutputTokens)
+	// No tokens on the root — the per-call children already carry them and the
+	// trace rollup sums the whole tree.
+	span.End(result.Text, nil)
 
 	// Persist transcript
 	tw := transcript.NewWriter(filepath.Join(deps.DataDir, "transcripts"))

--- a/internal/gateway/trace_test.go
+++ b/internal/gateway/trace_test.go
@@ -1,0 +1,128 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/agent"
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/models"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/storage"
+	"github.com/ngocp/goterm-control/internal/trace"
+)
+
+// stubProvider answers with one tool call, then a final message — enough to
+// exercise every span kind the handler is supposed to open.
+type stubProvider struct{ calls int }
+
+func (p *stubProvider) Stream(ctx context.Context, params agent.StreamParams) (<-chan agent.StreamEvent, error) {
+	p.calls++
+	ch := make(chan agent.StreamEvent, 4)
+	if p.calls == 1 {
+		ch <- agent.StreamEvent{
+			Type: "tool_use", ToolID: "t1", ToolName: "run_command",
+			ToolInput: json.RawMessage(`{"command":"echo hi"}`),
+		}
+		ch <- agent.StreamEvent{Type: "end", StopReason: "tool_use", Usage: &agent.Usage{InputTokens: 100, OutputTokens: 5}}
+	} else {
+		ch <- agent.StreamEvent{Type: "text", Text: "done"}
+		ch <- agent.StreamEvent{Type: "end", StopReason: "end_turn", Usage: &agent.Usage{InputTokens: 120, OutputTokens: 3}}
+	}
+	close(ch)
+	return ch, nil
+}
+
+type stubExecutor struct{}
+
+func (stubExecutor) Execute(ctx context.Context, name string, input json.RawMessage) agent.ToolResult {
+	return agent.ToolResult{Content: "hi", IsError: false}
+}
+
+// TestStreamingSendIsTraced covers a gap that shipped once: only the Telegram
+// path was traced, while the dashboard chat box, `bomclaw send` and peer agents
+// all go through the STREAMING send handler and left no trace at all.
+func TestStreamingSendIsTraced(t *testing.T) {
+	dir := t.TempDir()
+
+	cdb, err := coord.Open(filepath.Join(dir, "coord.db"))
+	if err != nil {
+		t.Fatalf("coord: %v", err)
+	}
+	defer cdb.Close()
+
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	rec := trace.New(cdb, "a1")
+	deps := Deps{
+		Sessions:     session.NewManager(storage.NewSessionStore(sdb)),
+		Resolver:     models.NewResolver("claude-opus-4-8", nil),
+		Provider:     &stubProvider{},
+		ToolExecutor: stubExecutor{},
+		DataDir:      dir,
+		System:       "you are a test",
+		Coord:        cdb,
+		AgentID:      "a1",
+		ProviderName: "claude",
+		Trace:        rec,
+	}
+
+	params, _ := json.Marshal(SendParams{Message: "run echo", SessionID: "chat_1"})
+	NewStreamSendHandler(deps)(context.Background(),
+		Request{ID: "1", Method: "send", Params: params},
+		func(StreamEvent) {})
+
+	rec.Close() // drain the async writer before asserting
+
+	traces, err := cdb.ListTraces(coord.TraceFilter{})
+	if err != nil {
+		t.Fatalf("list traces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("got %d traces, want exactly 1 for one command", len(traces))
+	}
+
+	root := traces[0]
+	if root.Name != "gateway.send" {
+		t.Errorf("root run = %q, want gateway.send", root.Name)
+	}
+	if root.Inputs != "run echo" {
+		t.Errorf("root inputs = %q, want the user's message", root.Inputs)
+	}
+	if root.Status != coord.StatusSuccess {
+		t.Errorf("root status = %q", root.Status)
+	}
+
+	runs, err := cdb.GetTrace(root.TraceID)
+	if err != nil {
+		t.Fatalf("get trace: %v", err)
+	}
+
+	var llm, tool int
+	for _, r := range runs {
+		switch r.RunType {
+		case coord.RunTypeLLM:
+			llm++
+		case coord.RunTypeTool:
+			tool++
+			if r.Depth != 2 {
+				t.Errorf("tool %q depth = %d, want 2 (root → llm → tool)", r.Name, r.Depth)
+			}
+		}
+	}
+	if llm != 2 {
+		t.Errorf("got %d llm spans, want 2 — the loop makes one model call per tool round trip", llm)
+	}
+	if tool != 1 {
+		t.Errorf("got %d tool spans, want 1", tool)
+	}
+	if root.TotalTokens != 228 {
+		t.Errorf("rolled-up tokens = %d, want 228 (100+5+120+3)", root.TotalTokens)
+	}
+}


### PR DESCRIPTION
Hai bug trong phần vừa ship, đều do một test viết sau mới lộ ra.

## 1. Trace không ghi gì cho lệnh từ web

Ô chat dashboard và `bomclaw send` **không** đi vào `handleSend`. Gateway route chúng sang `NewStreamSendHandler` — một implementation riêng. Nên phần tracing "lệnh từ web" ở PR #67 ghi được **đúng 0 dòng**: lệnh chạy thật, transcript ghi thật, DB dùng chung trống trơn.

Đã gắn trace vào streaming handler theo đúng hình dạng cũ: một root run, một con cho mỗi model call, một con cho mỗi tool.

## 2. Token bị đếm gấp đôi

Root span ghi tổng usage của cả vòng lặp, trong khi mỗi model-call con đã ghi phần của nó. Tổng của một trace là tổng cả cây, nên **mọi con số token trên admin page đều gấp đôi**. Root span giờ không mang token.

## Test

`TestStreamingSendIsTraced` chạy streaming handler với stub provider trả về một tool call rồi một câu trả lời, và assert đúng hình dạng: 1 trace, 2 llm span, 1 tool span ở depth 2, và **228** token rollup thay vì 456.

Đây chính là loại test lẽ ra phải có từ đầu — nó bắt được cả hai bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)