### PR TITLE
feat(coord): agents claim queued work and share what they learn (P2 + P3)

### DIFF
--- a/cmd/bomclaw/coordcmd.go
+++ b/cmd/bomclaw/coordcmd.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/gateway"
 )
 
 // The task/inbox commands are the surface an agent uses to hand work to its
@@ -73,6 +74,9 @@ func runTask(args []string) {
 			fmt.Fprintf(os.Stderr, "task new: %v\n", err)
 			os.Exit(1)
 		}
+		// Ring the agent that can take it. Failure is fine — its poll finds
+		// the task anyway; this only removes the wait.
+		gateway.NotifyTaskCreated(db, task)
 		fmt.Println(task.ID)
 
 	case "claim":
@@ -219,6 +223,135 @@ func taskUsage() {
   list   [--state S] [--mine] [--limit N]                   see the queue
   show   --id ID                                            one task with its history
 
+Every command accepts --agent (default $BOMCLAW_AGENT_ID) and --db.`)
+}
+
+func runNote(args []string) {
+	if len(args) == 0 {
+		noteUsage()
+		os.Exit(1)
+	}
+	sub, rest := args[0], args[1:]
+
+	switch sub {
+	case "add":
+		fs := flag.NewFlagSet("note add", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		notesFile := fs.String("file", coord.DefaultNotesFile(), "Markdown file to regenerate")
+		title := fs.String("title", "", "One line summary (required)")
+		body := fs.String("body", "", "The detail")
+		kind := fs.String("kind", coord.KindFact, "fact | decision | result | gotcha")
+		tags := fs.String("tags", "", "Comma separated")
+		private := fs.Bool("private", false, "Visible only to this agent")
+		supersedes := fs.String("supersedes", "", "Id of the note this corrects")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+
+		scope := ""
+		if *private {
+			scope = *agent
+		}
+		note, err := db.AddNote(coord.NewNote{
+			Author: *agent, Scope: scope, Kind: *kind, Title: *title,
+			Body: *body, Tags: *tags, Supersedes: *supersedes,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "note add: %v\n", err)
+			os.Exit(1)
+		}
+		if err := db.WriteNotesFile(*notesFile); err != nil {
+			// The note is safely stored; only the readable copy failed.
+			fmt.Fprintf(os.Stderr, "note add: saved, but could not rewrite %s: %v\n", *notesFile, err)
+		}
+		fmt.Println(note.ID)
+
+	case "search":
+		fs := flag.NewFlagSet("note search", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		limit := fs.Int("limit", 20, "Max rows")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+
+		notes, err := db.SearchNotes(strings.Join(fs.Args(), " "), *agent, *limit)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "note search: %v\n", err)
+			os.Exit(1)
+		}
+		printNotes(notes)
+
+	case "list":
+		fs := flag.NewFlagSet("note list", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		kind := fs.String("kind", "", "Filter by kind")
+		all := fs.Bool("all", false, "Include superseded notes")
+		limit := fs.Int("limit", 50, "Max rows")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+
+		notes, err := db.ListNotes(coord.NoteFilter{
+			Scope: *agent, Kind: *kind, IncludeReplaced: *all, Limit: *limit,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "note list: %v\n", err)
+			os.Exit(1)
+		}
+		printNotes(notes)
+
+	case "render":
+		fs := flag.NewFlagSet("note render", flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		notesFile := fs.String("file", coord.DefaultNotesFile(), "Markdown file to write")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+
+		if err := db.WriteNotesFile(*notesFile); err != nil {
+			fmt.Fprintf(os.Stderr, "note render: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(*notesFile)
+
+	default:
+		noteUsage()
+		os.Exit(1)
+	}
+}
+
+func printNotes(notes []coord.Note) {
+	if len(notes) == 0 {
+		fmt.Println("no notes")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tKIND\tSCOPE\tAUTHOR\tAGE\tTITLE")
+	for _, n := range notes {
+		title := n.Title
+		if n.SupersededBy != "" {
+			title = "(replaced) " + title
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			n.ID, n.Kind, n.Scope, n.Author, age(n.CreatedAt), truncate(title, 60))
+	}
+	w.Flush()
+}
+
+func noteUsage() {
+	fmt.Fprintln(os.Stderr, `Usage: bomclaw note <command>
+
+  add    --title T [--body B] [--kind fact|decision|result|gotcha]
+         [--tags a,b] [--private] [--supersedes ID]     record what you learned
+  search <words>                                        full-text search
+  list   [--kind K] [--all]                             browse
+  render [--file PATH]                                  regenerate the markdown file
+
+Notes are append-only: correct one with --supersedes, never by editing.
 Every command accepts --agent (default $BOMCLAW_AGENT_ID) and --db.`)
 }
 

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/storage"
+	"github.com/ngocp/goterm-control/internal/taskrunner"
 	"github.com/ngocp/goterm-control/internal/tools"
 	"github.com/ngocp/goterm-control/internal/trace"
 )
@@ -104,6 +105,8 @@ func main() {
 		runStatus(os.Args[2:])
 	case "task":
 		runTask(os.Args[2:])
+	case "note":
+		runNote(os.Args[2:])
 	case "inbox":
 		runInbox(os.Args[2:])
 	case "msg":
@@ -143,6 +146,7 @@ Commands:
   chat               Interactive CLI chat with the agent (no gateway needed)
   agents             List agents registered in the shared database
   task               Create, claim and finish work shared between agents
+  note               Record and search what the agents have learned
   inbox              Read messages other agents sent to this one
   msg                Send a message to another agent
   passwd             Set the dashboard password (creates the account if none)
@@ -270,6 +274,22 @@ func runGateway(args []string) {
 		}
 	}
 
+	// Task runner — claims work a peer queued and executes it with the same
+	// backend that answers chat. Off unless the config asks for it: a claimed
+	// task runs with full machine access and nobody is watching.
+	var runner *taskrunner.Runner
+	if coordDB != nil && cfg.Tasks.AutoClaim {
+		runner = taskrunner.New(coordDB, bot.NewChatClient(cfg, nil), gwTrace, taskrunner.Config{
+			AgentID:  cfg.Agent.ID,
+			Model:    resolver.Default(),
+			Interval: time.Duration(cfg.Tasks.PollIntervalSeconds) * time.Second,
+			Timeout:  time.Duration(cfg.Tasks.TimeoutMinutes) * time.Minute,
+		})
+		runner.Start(ctx)
+	} else if coordDB != nil {
+		log.Printf("taskrunner: disabled (tasks.auto_claim=false) — queued work waits for `bomclaw task claim`")
+	}
+
 	deps := gateway.Deps{
 		Sessions:     sessions,
 		Resolver:     resolver,
@@ -281,6 +301,8 @@ func runGateway(args []string) {
 		AgentID:      cfg.Agent.ID,
 		ProviderName: cfg.Provider,
 		Trace:        gwTrace,
+		PokeTasks:    runner.Poke,
+		NotesFile:    cfg.Coord.NotesFile,
 	}
 	if tgBot != nil {
 		deps.Runs = func() []gateway.RunInfo {

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,17 @@ agent:
 coord:
   enabled: true
   path: ""                    # default ~/.goterm-shared/data/coord.db
+  notes_file: ""              # default ~/goterm-shared/NOTES.md
   trace_retention_days: 7     # 0 keeps traces forever
+
+# Whether this agent picks up work its peers queued. OFF by default on purpose:
+# a claimed task is executed with the same machine access the chat backend has,
+# and nobody is watching when it runs. Turn it on only for an agent meant to
+# work unattended.
+tasks:
+  auto_claim: false
+  poll_interval_seconds: 60
+  timeout_minutes: 15
 
 telegram:
   token: ""        # set via TELEGRAM_TOKEN env var
@@ -85,8 +95,33 @@ claude:
 
     You are like Claude Code but running through Telegram. Treat every request as a real engineering task.
 
+    ## Working with the other agents on this machine
+
+    Other agents share a coordination database with you. Use these commands —
+    they write straight to it, so they work even when the other agent is down.
+
+    - `bomclaw agents` — who exists, and who is online right now.
+    - `bomclaw task new --title T [--body B] [--to <agent>]` — hand work over.
+      Omit `--to` and any agent may claim it.
+    - `bomclaw task claim` — take the next task addressed to you. Exit code 2
+      means the queue is empty, which is not an error.
+    - `bomclaw task done --id ID --result R` (or `task fail`) — report back.
+      Your result is what the requesting agent reads.
+    - `bomclaw inbox` / `bomclaw msg --to <agent> <text>` — talk to a peer.
+    - `bomclaw note add --title T [--body B] [--kind fact|decision|result|gotcha]`
+      — record something durable that the other agents should also know.
+      `bomclaw note search <words>` before assuming something is unknown.
+
+    Notes are append-only: correct one with `--supersedes <id>`, never by
+    editing. The readable copy lives at ~/goterm-shared/NOTES.md and is
+    regenerated on every write, so do not edit that file by hand.
+
+    Do not create tasks in a loop. If finishing a task suggests more work, say
+    so in the result and let a person decide.
+
 # Built-in Claude models (opus, sonnet, haiku) are always available.
 # Use models.default to override the default, or models.custom to add more.
+
 models:
   default: ""                # override claude.model (empty = use claude.model)
   # custom:                  # add custom models (e.g. OpenRouter, local Ollama)

--- a/dashboard/src/admin/AdminView.tsx
+++ b/dashboard/src/admin/AdminView.tsx
@@ -4,14 +4,16 @@ import Overview from './Overview'
 import TraceExplorer from './TraceExplorer'
 import TaskBoard from './TaskBoard'
 import MessageStream from './MessageStream'
+import NotesPane from './NotesPane'
 
 type Call = (method: string, params?: any) => Promise<any>
-type Pane = 'overview' | 'traces' | 'tasks' | 'messages'
+type Pane = 'overview' | 'traces' | 'tasks' | 'notes' | 'messages'
 
 const PANES: { key: Pane; label: string }[] = [
   { key: 'overview', label: 'Overview' },
   { key: 'traces', label: 'Traces' },
   { key: 'tasks', label: 'Tasks' },
+  { key: 'notes', label: 'Notes' },
   { key: 'messages', label: 'Messages' },
 ]
 
@@ -86,6 +88,7 @@ export default function AdminView({ call }: { call: Call }) {
         {pane === 'overview' && <Overview data={data} />}
         {pane === 'traces' && <TraceExplorer call={call} agents={agentIDs} />}
         {pane === 'tasks' && <TaskBoard call={call} agents={agentIDs} />}
+        {pane === 'notes' && <NotesPane call={call} />}
         {pane === 'messages' && <MessageStream call={call} agents={agentIDs} selfID={selfID} />}
       </div>
     </div>

--- a/dashboard/src/admin/NotesPane.tsx
+++ b/dashboard/src/admin/NotesPane.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Note } from './types'
+import { ago } from './format'
+
+type Call = (method: string, params?: any) => Promise<any>
+
+const KINDS = ['fact', 'decision', 'result', 'gotcha'] as const
+
+const KIND_STYLE: Record<string, string> = {
+  fact:     'bg-sky-500/15 text-sky-300 ring-sky-500/30',
+  decision: 'bg-violet-500/15 text-violet-300 ring-violet-500/30',
+  result:   'bg-emerald-500/15 text-emerald-300 ring-emerald-500/30',
+  gotcha:   'bg-amber-500/15 text-amber-300 ring-amber-500/30',
+}
+
+function kindStyle(kind: string) {
+  return KIND_STYLE[kind] ?? 'bg-gray-500/15 text-gray-400 ring-gray-500/30'
+}
+
+export default function NotesPane({ call }: { call: Call }) {
+  const [notes, setNotes] = useState<Note[]>([])
+  const [search, setSearch] = useState('')
+  const [kind, setKind] = useState('')
+  const [showReplaced, setShowReplaced] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [newKind, setNewKind] = useState<string>('fact')
+  const [supersedes, setSupersedes] = useState<Note | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      setNotes((await call('notes.list', {
+        search: search || undefined,
+        kind: kind || undefined,
+        include_replaced: showReplaced || undefined,
+        limit: 200,
+      })) || [])
+      setErr(null)
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    }
+  }, [call, search, kind, showReplaced])
+
+  useEffect(() => {
+    load()
+    const id = setInterval(load, 10_000)
+    return () => clearInterval(id)
+  }, [load])
+
+  const add = async () => {
+    if (!title.trim()) return
+    try {
+      await call('notes.add', {
+        title, body, kind: newKind,
+        supersedes: supersedes?.id || undefined,
+      })
+      setTitle(''); setBody(''); setSupersedes(null)
+      load()
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    }
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="p-4 border-b border-gray-800 bg-gray-900/40 space-y-2">
+        {supersedes && (
+          <div className="flex items-center gap-2 text-xs rounded px-2 py-1.5 bg-amber-500/10 ring-1 ring-amber-500/30">
+            <span className="text-amber-300">Correcting:</span>
+            <span className="text-gray-300 truncate">{supersedes.title}</span>
+            <button onClick={() => setSupersedes(null)} className="ml-auto text-gray-500 hover:text-gray-300">✕</button>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <input
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Something worth remembering…"
+            className="flex-1 px-3 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
+          />
+          <select
+            value={newKind}
+            onChange={e => setNewKind(e.target.value)}
+            className="px-2 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 text-gray-300 outline-none"
+          >
+            {KINDS.map(k => <option key={k} value={k}>{k}</option>)}
+          </select>
+          <button
+            onClick={add}
+            disabled={!title.trim()}
+            className="px-4 py-2 text-sm rounded bg-gray-100 text-gray-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {supersedes ? 'Correct' : 'Record'}
+          </button>
+        </div>
+        <textarea
+          value={body}
+          onChange={e => setBody(e.target.value)}
+          placeholder="Detail (optional)"
+          rows={2}
+          className="w-full px-3 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600 resize-none"
+        />
+      </div>
+
+      <div className="px-4 py-2 border-b border-gray-800 flex items-center gap-2">
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search notes…"
+          className="flex-1 px-2.5 py-1.5 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
+        />
+        <select
+          value={kind}
+          onChange={e => setKind(e.target.value)}
+          className="px-2 py-1.5 text-xs bg-gray-950 rounded ring-1 ring-gray-800 text-gray-300 outline-none"
+        >
+          <option value="">all kinds</option>
+          {KINDS.map(k => <option key={k} value={k}>{k}</option>)}
+        </select>
+        <button
+          onClick={() => setShowReplaced(v => !v)}
+          className={`px-2 py-1.5 text-xs rounded ring-1 transition-colors ${
+            showReplaced ? 'ring-gray-600 bg-gray-800 text-gray-200' : 'ring-gray-800 text-gray-500'
+          }`}
+        >
+          history
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        {err && <div className="text-xs text-red-300">{err}</div>}
+        {!err && notes.length === 0 && (
+          <div className="text-sm text-gray-500">
+            Nothing recorded yet. Agents write here with{' '}
+            <code className="font-mono text-gray-400">bomclaw note add --title …</code>, and the
+            markdown copy they read is regenerated on every write.
+          </div>
+        )}
+
+        {notes.map(n => (
+          <div
+            key={n.id}
+            className={`rounded-lg ring-1 p-3 ${
+              n.superseded_by ? 'bg-gray-900/40 ring-gray-800/60 opacity-60' : 'bg-gray-900 ring-gray-800'
+            }`}
+          >
+            <div className="flex items-start gap-2">
+              <span className={`text-[10px] px-1.5 py-0.5 rounded ring-1 shrink-0 ${kindStyle(n.kind)}`}>
+                {n.kind}
+              </span>
+              {n.scope !== 'shared' && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded ring-1 ring-gray-700 text-gray-500 shrink-0">
+                  private
+                </span>
+              )}
+              {n.superseded_by && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded ring-1 ring-gray-700 text-gray-500 shrink-0">
+                  replaced
+                </span>
+              )}
+              <span className="text-sm text-gray-100 leading-snug">{n.title}</span>
+              {!n.superseded_by && (
+                <button
+                  onClick={() => { setSupersedes(n); setTitle(n.title); setBody(n.body ?? ''); setNewKind(n.kind) }}
+                  title="Record a correction that replaces this note"
+                  className="ml-auto shrink-0 text-[11px] text-gray-600 hover:text-gray-300"
+                >
+                  correct
+                </button>
+              )}
+            </div>
+            {n.body && (
+              <p className="mt-1.5 text-xs text-gray-400 whitespace-pre-wrap break-words">{n.body}</p>
+            )}
+            <div className="mt-1.5 flex items-center gap-2 text-[11px] text-gray-600">
+              <span className="font-mono">{n.author}</span>
+              <span>{ago(n.created_at)}</span>
+              {n.tags && <span className="font-mono">{n.tags}</span>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/admin/types.ts
+++ b/dashboard/src/admin/types.ts
@@ -113,3 +113,15 @@ export interface Message {
   read_at?: string
   created_at: string
 }
+
+export interface Note {
+  id: string
+  author: string
+  scope: string
+  kind: string
+  title: string
+  body?: string
+  tags?: string
+  superseded_by?: string
+  created_at: string
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -41,6 +41,23 @@ type Bot struct {
 // New creates and initialises the bot. db and sessions are shared with the
 // gateway so label renames and turn counters are visible to the dashboard
 // immediately (two managers on one SQLite file would clobber each other).
+// NewChatClient builds the CLI chat backend named by cfg.Provider. Both keep
+// their own conversation state (claude session / codex thread); the session row
+// records which one owns the stored id.
+//
+// Exported because the task runner needs its own client: it executes queued
+// work in isolated sessions, alongside whatever the bot is chatting about.
+func NewChatClient(cfg *config.Config, executor *tools.Executor) chat.Client {
+	if cfg.Provider == config.ProviderCodex {
+		c := codex.New(cfg.Claude.SystemPrompt)
+		c.SetWorkspace(cfg.Claude.Workspace)
+		return c
+	}
+	c := claude.New(cfg.Claude.SystemPrompt, executor)
+	c.SetWorkspace(cfg.Claude.Workspace)
+	return c
+}
+
 func New(cfg *config.Config, db *storage.DB, coordDB *coord.DB, sessions *session.Manager) (*Bot, error) {
 	api, err := tgbotapi.NewBotAPI(cfg.Telegram.Token)
 	if err != nil {
@@ -93,19 +110,7 @@ func New(cfg *config.Config, db *storage.DB, coordDB *coord.DB, sessions *sessio
 	// Nil coordDB (coord disabled) yields a nil recorder, which is a no-op.
 	rec := trace.New(coordDB, cfg.Agent.ID)
 
-	// Chat backend — one CLI subprocess family per agent, chosen by config.
-	// Both keep their own conversation state (claude session / codex thread);
-	// the session row records which one owns the stored id.
-	var llm chat.Client
-	if cfg.Provider == config.ProviderCodex {
-		codexClient := codex.New(cfg.Claude.SystemPrompt)
-		codexClient.SetWorkspace(cfg.Claude.Workspace)
-		llm = codexClient
-	} else {
-		claudeClient := claude.New(cfg.Claude.SystemPrompt, executor)
-		claudeClient.SetWorkspace(cfg.Claude.Workspace)
-		llm = claudeClient
-	}
+	llm := NewChatClient(cfg, executor)
 
 	// Message store (SQLite — conversation history)
 	messageStore := storage.NewMessageStore(db)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Coord configures the database shared by every agent on this machine.
 	Coord CoordConfig `yaml:"coord"`
 
+	// Tasks controls whether this agent picks up work its peers queued.
+	Tasks TasksConfig `yaml:"tasks"`
+
 	Telegram TelegramConfig `yaml:"telegram"`
 	Claude   ClaudeConfig   `yaml:"claude"`
 	Models   ModelsConfig   `yaml:"models"`
@@ -50,11 +53,23 @@ type CoordConfig struct {
 	// `enabled: false` still turns it off — a plain bool cannot tell those apart.
 	Enabled            *bool  `yaml:"enabled"`
 	Path               string `yaml:"path"`                 // default ~/.goterm-shared/data/coord.db
+	NotesFile          string `yaml:"notes_file"`           // default ~/goterm-shared/NOTES.md
 	TraceRetentionDays int    `yaml:"trace_retention_days"` // default 7; 0 disables the purge
 }
 
 // IsEnabled reports whether the shared coordination database should be opened.
 func (c CoordConfig) IsEnabled() bool { return c.Enabled == nil || *c.Enabled }
+
+// TasksConfig controls the shared task queue from this agent's side.
+//
+// AutoClaim defaults to OFF and should stay off unless the agent is meant to
+// act unattended: a claimed task is executed with the same machine access the
+// chat backend has, and nobody is watching when it runs.
+type TasksConfig struct {
+	AutoClaim           bool `yaml:"auto_claim"`
+	PollIntervalSeconds int  `yaml:"poll_interval_seconds"` // default 60
+	TimeoutMinutes      int  `yaml:"timeout_minutes"`       // default 15
+}
 
 // GatewayConfig holds gateway HTTP server settings.
 type GatewayConfig struct {
@@ -178,8 +193,18 @@ func Load(path string) (*Config, error) {
 		home, _ := os.UserHomeDir()
 		cfg.Coord.Path = home + cfg.Coord.Path[1:]
 	}
+	if strings.HasPrefix(cfg.Coord.NotesFile, "~/") {
+		home, _ := os.UserHomeDir()
+		cfg.Coord.NotesFile = home + cfg.Coord.NotesFile[1:]
+	}
 	if cfg.Coord.TraceRetentionDays == 0 {
 		cfg.Coord.TraceRetentionDays = 7
+	}
+	if cfg.Tasks.PollIntervalSeconds == 0 {
+		cfg.Tasks.PollIntervalSeconds = 60
+	}
+	if cfg.Tasks.TimeoutMinutes == 0 {
+		cfg.Tasks.TimeoutMinutes = 15
 	}
 	if cfg.Telegram.Timeout == 0 {
 		cfg.Telegram.Timeout = 60

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -25,7 +25,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 1
+const schemaVersion = 2
 
 // DB is the shared coordination database.
 type DB struct {
@@ -167,6 +167,40 @@ var ddl = []string{
 	) STRICT`,
 	`CREATE INDEX IF NOT EXISTS idx_msgs_unread ON agent_messages(to_agent, read_at, created_at)`,
 	`CREATE INDEX IF NOT EXISTS idx_msgs_recent ON agent_messages(created_at DESC)`,
+
+	// --- what the agents know ----------------------------------------------
+	// Append-only: a correction is a NEW row that the old one points at via
+	// superseded_by. Two agents editing one note in place would silently
+	// overwrite each other, and the history would be gone either way.
+	`CREATE TABLE IF NOT EXISTS shared_notes (
+		id            TEXT PRIMARY KEY,
+		author        TEXT NOT NULL,
+		scope         TEXT NOT NULL DEFAULT 'shared',  -- 'shared' or an agent id
+		kind          TEXT NOT NULL,                   -- fact | decision | result | gotcha
+		title         TEXT NOT NULL,
+		body          TEXT NOT NULL DEFAULT '',
+		tags          TEXT NOT NULL DEFAULT '',        -- comma separated
+		superseded_by TEXT NOT NULL DEFAULT '',        -- '' means this is current
+		created_at    TEXT NOT NULL
+	) STRICT`,
+	`CREATE INDEX IF NOT EXISTS idx_notes_live ON shared_notes(scope, superseded_by, created_at DESC)`,
+
+	`CREATE VIRTUAL TABLE IF NOT EXISTS shared_notes_fts USING fts5(
+		title, body, content='shared_notes', content_rowid='rowid'
+	)`,
+	// External-content FTS5 does not track its source table on its own.
+	`CREATE TRIGGER IF NOT EXISTS shared_notes_ai AFTER INSERT ON shared_notes BEGIN
+		INSERT INTO shared_notes_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body);
+	END`,
+	`CREATE TRIGGER IF NOT EXISTS shared_notes_ad AFTER DELETE ON shared_notes BEGIN
+		INSERT INTO shared_notes_fts(shared_notes_fts, rowid, title, body)
+		VALUES ('delete', old.rowid, old.title, old.body);
+	END`,
+	`CREATE TRIGGER IF NOT EXISTS shared_notes_au AFTER UPDATE ON shared_notes BEGIN
+		INSERT INTO shared_notes_fts(shared_notes_fts, rowid, title, body)
+		VALUES ('delete', old.rowid, old.title, old.body);
+		INSERT INTO shared_notes_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body);
+	END`,
 }
 
 func (db *DB) migrate() error {

--- a/internal/coord/notes.go
+++ b/internal/coord/notes.go
@@ -1,0 +1,254 @@
+package coord
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Note kinds. Free-form in the column, but these are what the CLI suggests and
+// what the renderer groups by.
+const (
+	KindFact     = "fact"
+	KindDecision = "decision"
+	KindResult   = "result"
+	KindGotcha   = "gotcha"
+)
+
+// ScopeShared marks a note every agent should see. Any other value scopes the
+// note to the agent whose id it matches.
+const ScopeShared = "shared"
+
+// Note is one durable thing an agent learned.
+type Note struct {
+	ID           string    `json:"id"`
+	Author       string    `json:"author"`
+	Scope        string    `json:"scope"`
+	Kind         string    `json:"kind"`
+	Title        string    `json:"title"`
+	Body         string    `json:"body,omitempty"`
+	Tags         string    `json:"tags,omitempty"`
+	SupersededBy string    `json:"superseded_by,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// NewNote describes a note to record.
+type NewNote struct {
+	Author     string
+	Scope      string // "" means shared
+	Kind       string // "" means fact
+	Title      string
+	Body       string
+	Tags       string
+	Supersedes string // id of the note this replaces
+}
+
+// AddNote records a note. When Supersedes is set the older note is marked
+// replaced rather than edited, so both the correction and what it corrected
+// stay readable.
+func (db *DB) AddNote(n NewNote) (*Note, error) {
+	if strings.TrimSpace(n.Title) == "" {
+		return nil, fmt.Errorf("coord: note title is required")
+	}
+	note := &Note{
+		ID:        "n_" + uuid.NewString(),
+		Author:    n.Author,
+		Scope:     firstNonEmpty(n.Scope, ScopeShared),
+		Kind:      firstNonEmpty(n.Kind, KindFact),
+		Title:     n.Title,
+		Body:      n.Body,
+		Tags:      n.Tags,
+		CreatedAt: time.Now(),
+	}
+
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("add note: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`INSERT INTO shared_notes
+		(id, author, scope, kind, title, body, tags, superseded_by, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, '', ?)`,
+		note.ID, note.Author, note.Scope, note.Kind, note.Title, note.Body,
+		note.Tags, ts(note.CreatedAt)); err != nil {
+		return nil, fmt.Errorf("add note: %w", err)
+	}
+
+	if n.Supersedes != "" {
+		res, err := tx.Exec(`UPDATE shared_notes SET superseded_by = ?
+			WHERE id = ? AND superseded_by = ''`, note.ID, n.Supersedes)
+		if err != nil {
+			return nil, fmt.Errorf("supersede %s: %w", n.Supersedes, err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return nil, fmt.Errorf("coord: note %s is unknown or already superseded", n.Supersedes)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("add note: %w", err)
+	}
+	return note, nil
+}
+
+// NoteFilter narrows a note listing.
+type NoteFilter struct {
+	// Scope "" returns shared notes plus nothing else; set it to an agent id
+	// to get that agent's private notes as well.
+	Scope           string
+	Kind            string
+	IncludeReplaced bool
+	Limit           int
+}
+
+// ListNotes returns notes newest first, current ones only unless asked.
+func (db *DB) ListNotes(f NoteFilter) ([]Note, error) {
+	limit := f.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 200
+	}
+	where := []string{"(scope = ? OR scope = ?)"}
+	args := []any{ScopeShared, firstNonEmpty(f.Scope, ScopeShared)}
+	if !f.IncludeReplaced {
+		where = append(where, "superseded_by = ''")
+	}
+	if f.Kind != "" {
+		where = append(where, "kind = ?")
+		args = append(args, f.Kind)
+	}
+	args = append(args, limit)
+
+	return db.queryNotes(`SELECT id, author, scope, kind, title, body, tags,
+		superseded_by, created_at FROM shared_notes
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY created_at DESC LIMIT ?`, args...)
+}
+
+// SearchNotes runs a full-text search over current notes.
+//
+// The query is passed to FTS5 as a quoted phrase rather than raw: a bare user
+// string can contain FTS operators and would either fail with a syntax error or
+// silently mean something else than the caller typed.
+func (db *DB) SearchNotes(query, scope string, limit int) ([]Note, error) {
+	if strings.TrimSpace(query) == "" {
+		return db.ListNotes(NoteFilter{Scope: scope, Limit: limit})
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	phrase := `"` + strings.ReplaceAll(query, `"`, `""`) + `"`
+
+	return db.queryNotes(`SELECT n.id, n.author, n.scope, n.kind, n.title, n.body,
+		n.tags, n.superseded_by, n.created_at
+		FROM shared_notes_fts
+		JOIN shared_notes n ON n.rowid = shared_notes_fts.rowid
+		WHERE shared_notes_fts MATCH ? AND n.superseded_by = '' AND (n.scope = ? OR n.scope = ?)
+		ORDER BY rank
+		LIMIT ?`, phrase, ScopeShared, firstNonEmpty(scope, ScopeShared), limit)
+}
+
+func (db *DB) queryNotes(q string, args ...any) ([]Note, error) {
+	rows, err := db.conn.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query notes: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Note{}
+	for rows.Next() {
+		var n Note
+		var created string
+		if err := rows.Scan(&n.ID, &n.Author, &n.Scope, &n.Kind, &n.Title,
+			&n.Body, &n.Tags, &n.SupersededBy, &created); err != nil {
+			return nil, fmt.Errorf("scan note: %w", err)
+		}
+		n.CreatedAt = parseTS(created)
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// RenderNotes formats current notes as markdown, grouped by kind. Agents read
+// files far more naturally than they query SQL, so this is written to disk for
+// them; the database stays the source of truth and the file is regenerated.
+func RenderNotes(notes []Note) string {
+	var b strings.Builder
+	b.WriteString("# Shared notes\n\n")
+	b.WriteString("> Generated from the shared coordination database. Do not edit by hand —\n")
+	b.WriteString("> use `bomclaw note add`. Edits here are overwritten on the next write.\n")
+
+	byKind := map[string][]Note{}
+	for _, n := range notes {
+		byKind[n.Kind] = append(byKind[n.Kind], n)
+	}
+	kinds := make([]string, 0, len(byKind))
+	for k := range byKind {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+
+	if len(kinds) == 0 {
+		b.WriteString("\n_No notes recorded yet._\n")
+		return b.String()
+	}
+
+	for _, kind := range kinds {
+		fmt.Fprintf(&b, "\n## %s\n", kind)
+		for _, n := range byKind[kind] {
+			fmt.Fprintf(&b, "\n### %s\n", n.Title)
+			fmt.Fprintf(&b, "\n_%s · %s_", n.Author, n.CreatedAt.Local().Format("2006-01-02"))
+			if n.Tags != "" {
+				fmt.Fprintf(&b, " · `%s`", n.Tags)
+			}
+			b.WriteString("\n")
+			if n.Body != "" {
+				fmt.Fprintf(&b, "\n%s\n", n.Body)
+			}
+		}
+	}
+	return b.String()
+}
+
+// DefaultNotesFile is where the rendered markdown lands when config says
+// nothing. It sits next to the shared git repo the agents already use.
+func DefaultNotesFile() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "goterm-shared", "NOTES.md")
+}
+
+// WriteNotesFile regenerates the markdown view of current shared notes.
+//
+// Written atomically: an agent may be reading the file while another writes it,
+// and a half-written NOTES.md would be worse than a stale one.
+func (db *DB) WriteNotesFile(path string) error {
+	if path == "" {
+		path = DefaultNotesFile()
+	}
+	notes, err := db.ListNotes(NoteFilter{Limit: 500})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("notes file: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(RenderNotes(notes)), 0644); err != nil {
+		return fmt.Errorf("notes file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("notes file: %w", err)
+	}
+	return nil
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/coord/notes_test.go
+++ b/internal/coord/notes_test.go
@@ -1,0 +1,157 @@
+package coord
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAddAndListNotes(t *testing.T) {
+	db := testDB(t)
+
+	if _, err := db.AddNote(NewNote{Author: "a1", Title: "Codex only accepts gpt-6-astra",
+		Kind: KindGotcha, Body: "gpt-5-codex returns 400 on a ChatGPT account", Tags: "codex,auth"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := db.AddNote(NewNote{Author: "a2", Title: "Use WAL for the shared db", Kind: KindDecision}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	notes, err := db.ListNotes(NoteFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(notes) != 2 {
+		t.Fatalf("got %d notes, want 2", len(notes))
+	}
+	if notes[0].Title != "Use WAL for the shared db" {
+		t.Errorf("newest first: got %q", notes[0].Title)
+	}
+	if notes[0].Scope != ScopeShared {
+		t.Errorf("scope defaults to shared, got %q", notes[0].Scope)
+	}
+}
+
+func TestNoteTitleIsRequired(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.AddNote(NewNote{Author: "a1", Body: "orphan body"}); err == nil {
+		t.Error("a note with no title was accepted")
+	}
+}
+
+func TestSupersedeKeepsBothVersions(t *testing.T) {
+	db := testDB(t)
+	old, _ := db.AddNote(NewNote{Author: "a1", Title: "Model is gpt-5-codex"})
+
+	newer, err := db.AddNote(NewNote{Author: "a2", Title: "Model is gpt-6-astra", Supersedes: old.ID})
+	if err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+
+	live, _ := db.ListNotes(NoteFilter{})
+	if len(live) != 1 || live[0].ID != newer.ID {
+		t.Fatalf("current notes = %d, want only the correction", len(live))
+	}
+
+	all, _ := db.ListNotes(NoteFilter{IncludeReplaced: true})
+	if len(all) != 2 {
+		t.Fatalf("history lost: %d rows, want 2", len(all))
+	}
+	for _, n := range all {
+		if n.ID == old.ID && n.SupersededBy != newer.ID {
+			t.Errorf("old note does not point at its replacement: %q", n.SupersededBy)
+		}
+	}
+}
+
+func TestSupersedeRejectsUnknownOrAlreadyReplaced(t *testing.T) {
+	db := testDB(t)
+	old, _ := db.AddNote(NewNote{Author: "a1", Title: "first"})
+	db.AddNote(NewNote{Author: "a1", Title: "second", Supersedes: old.ID})
+
+	if _, err := db.AddNote(NewNote{Author: "a1", Title: "third", Supersedes: old.ID}); err == nil {
+		t.Error("superseding an already-replaced note was accepted — the chain would fork")
+	}
+	if _, err := db.AddNote(NewNote{Author: "a1", Title: "x", Supersedes: "n_nope"}); err == nil {
+		t.Error("superseding an unknown note was accepted")
+	}
+}
+
+func TestSearchFindsBodyAndTitle(t *testing.T) {
+	db := testDB(t)
+	db.AddNote(NewNote{Author: "a1", Title: "Codex auth", Body: "refresh token reused after relogin"})
+	db.AddNote(NewNote{Author: "a1", Title: "Telegram conflict", Body: "orphaned claude subprocess holds getUpdates"})
+
+	hits, err := db.SearchNotes("refresh token", "", 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Title != "Codex auth" {
+		t.Fatalf("search matched %d notes, want the codex one", len(hits))
+	}
+
+	hits, _ = db.SearchNotes("getUpdates", "", 0)
+	if len(hits) != 1 || hits[0].Title != "Telegram conflict" {
+		t.Errorf("body search failed: %d hits", len(hits))
+	}
+}
+
+// A raw user string can contain FTS5 operators; unquoted it either errors or
+// quietly means something else than what was typed.
+func TestSearchToleratesOperatorCharacters(t *testing.T) {
+	db := testDB(t)
+	db.AddNote(NewNote{Author: "a1", Title: "quoted", Body: `he said "hello" loudly`})
+
+	for _, q := range []string{`"hello"`, "AND OR NOT", "foo*", "a(b)c", "-x"} {
+		if _, err := db.SearchNotes(q, "", 0); err != nil {
+			t.Errorf("search(%q) errored: %v", q, err)
+		}
+	}
+}
+
+func TestSearchSkipsSupersededNotes(t *testing.T) {
+	db := testDB(t)
+	old, _ := db.AddNote(NewNote{Author: "a1", Title: "old", Body: "elephant"})
+	db.AddNote(NewNote{Author: "a1", Title: "new", Body: "elephant corrected", Supersedes: old.ID})
+
+	hits, _ := db.SearchNotes("elephant", "", 0)
+	if len(hits) != 1 || hits[0].Title != "new" {
+		t.Errorf("search returned %d hits, want only the current note", len(hits))
+	}
+}
+
+func TestPrivateScopeIsNotVisibleToOtherAgents(t *testing.T) {
+	db := testDB(t)
+	db.AddNote(NewNote{Author: "a1", Scope: "a1", Title: "a1 private"})
+	db.AddNote(NewNote{Author: "a1", Title: "everyone"})
+
+	mine, _ := db.ListNotes(NoteFilter{Scope: "a1"})
+	if len(mine) != 2 {
+		t.Errorf("a1 sees %d notes, want its own plus shared", len(mine))
+	}
+	theirs, _ := db.ListNotes(NoteFilter{Scope: "a2"})
+	if len(theirs) != 1 || theirs[0].Title != "everyone" {
+		t.Errorf("a2 sees %d notes, want only the shared one", len(theirs))
+	}
+}
+
+func TestRenderNotesGroupsByKind(t *testing.T) {
+	out := RenderNotes([]Note{
+		{Title: "T1", Kind: KindGotcha, Author: "a1", Body: "watch out"},
+		{Title: "T2", Kind: KindFact, Author: "a2"},
+	})
+	if !strings.Contains(out, "## fact") || !strings.Contains(out, "## gotcha") {
+		t.Errorf("missing kind headings:\n%s", out)
+	}
+	if strings.Index(out, "## fact") > strings.Index(out, "## gotcha") {
+		t.Error("kinds must be in a stable order so the file does not churn")
+	}
+	if !strings.Contains(out, "Do not edit by hand") {
+		t.Error("rendered file must warn that it is generated")
+	}
+}
+
+func TestRenderNotesHandlesEmpty(t *testing.T) {
+	if out := RenderNotes(nil); !strings.Contains(out, "No notes recorded yet") {
+		t.Errorf("empty render is unhelpful:\n%s", out)
+	}
+}

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/ngocp/goterm-control/internal/coord"
 )
@@ -177,6 +178,9 @@ func handleTaskCreate(deps Deps, params json.RawMessage) (json.RawMessage, error
 	if err != nil {
 		return nil, err
 	}
+	// Ring whoever can take it so the work starts now rather than at the next
+	// poll. Best effort: the queue is the source of truth.
+	go NotifyTaskCreated(deps.Coord, task)
 	return json.Marshal(task)
 }
 
@@ -192,6 +196,74 @@ func handleTaskCancel(deps Deps, params json.RawMessage) (json.RawMessage, error
 		return nil, err
 	}
 	return json.Marshal(map[string]bool{"canceled": true})
+}
+
+// --- shared notes ----------------------------------------------------------
+
+type notesListParams struct {
+	Search          string `json:"search,omitempty"`
+	Kind            string `json:"kind,omitempty"`
+	IncludeReplaced bool   `json:"include_replaced,omitempty"`
+	Limit           int    `json:"limit,omitempty"`
+}
+
+func handleNotesList(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p notesListParams
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	var (
+		notes []coord.Note
+		err   error
+	)
+	if p.Search != "" {
+		notes, err = deps.Coord.SearchNotes(p.Search, deps.AgentID, p.Limit)
+	} else {
+		notes, err = deps.Coord.ListNotes(coord.NoteFilter{
+			Scope: deps.AgentID, Kind: p.Kind,
+			IncludeReplaced: p.IncludeReplaced, Limit: p.Limit,
+		})
+	}
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(notes)
+}
+
+type noteAddParams struct {
+	Title      string `json:"title"`
+	Body       string `json:"body,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Tags       string `json:"tags,omitempty"`
+	Supersedes string `json:"supersedes,omitempty"`
+}
+
+func handleNoteAdd(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p noteAddParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	note, err := deps.Coord.AddNote(coord.NewNote{
+		Author: deps.AgentID, Kind: p.Kind, Title: p.Title,
+		Body: p.Body, Tags: p.Tags, Supersedes: p.Supersedes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Keep the markdown copy agents read in step with the database. The note
+	// is already committed, so a render failure is reported, not fatal.
+	if err := deps.Coord.WriteNotesFile(deps.NotesFile); err != nil {
+		log.Printf("gateway: note saved but NOTES.md not rewritten: %v", err)
+	}
+	return json.Marshal(note)
 }
 
 // --- inter-agent messages --------------------------------------------------

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -38,6 +38,14 @@ type Deps struct {
 	AgentID      string
 	ProviderName string          // "claude" | "codex", for trace metadata
 	Trace        *trace.Recorder // nil-safe: nil disables tracing on this path
+
+	// PokeTasks asks the local task runner to check the queue immediately.
+	// Nil when this agent does not claim tasks.
+	PokeTasks func()
+
+	// NotesFile is the markdown rendering of shared notes, rewritten whenever
+	// a note is added so agents can read it with their file tools.
+	NotesFile string
 }
 
 // NewMethodHandler creates a MethodHandler that routes to the appropriate handler.
@@ -80,6 +88,15 @@ func NewMethodHandler(deps Deps) MethodHandler {
 			return handleMessagesList(deps, params)
 		case "messages.send":
 			return handleMessageSend(deps, params)
+		case "notes.list":
+			return handleNotesList(deps, params)
+		case "notes.add":
+			return handleNoteAdd(deps, params)
+		case "tasks.poke":
+			if deps.PokeTasks != nil {
+				deps.PokeTasks()
+			}
+			return pokeResult, nil
 		default:
 			return nil, fmt.Errorf("unknown method: %s", method)
 		}

--- a/internal/gateway/notify.go
+++ b/internal/gateway/notify.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// PokeAgent tells the gateway at wsAddr to check the shared task queue now
+// instead of waiting out its poll interval.
+//
+// This is a doorbell, not a delivery: the task itself is already committed to
+// the shared database. A failure here — peer down, or its dashboard auth
+// refusing an unauthenticated socket — costs latency and nothing else, because
+// the peer's own poll will find the work anyway. Callers should log it at most.
+func PokeAgent(wsAddr string) error {
+	if wsAddr == "" {
+		return fmt.Errorf("no address")
+	}
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	ws, _, err := dialer.Dial(wsAddr, nil)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", wsAddr, err)
+	}
+	defer ws.Close()
+
+	req := Request{ID: "poke", Method: "tasks.poke"}
+	if err := ws.WriteJSON(req); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	// Read the ack so the peer has actually processed it before we hang up;
+	// without this the close can race the server's read.
+	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp Response
+	if err := ws.ReadJSON(&resp); err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("peer: %s", resp.Error.Message)
+	}
+	return nil
+}
+
+// NotifyTaskCreated rings whoever could pick a new task up. A task addressed to
+// one agent rings only that agent; an unassigned task rings every other online
+// agent, since any of them may claim it.
+//
+// Best effort by design — see PokeAgent. The peer's poll is what guarantees
+// delivery; this only shortens the wait.
+func NotifyTaskCreated(cdb *coord.DB, task *coord.Task) {
+	if cdb == nil || task == nil {
+		return
+	}
+	agents, err := cdb.ListAgents()
+	if err != nil {
+		return
+	}
+	for _, a := range agents {
+		if !a.Online || a.ID == task.CreatedBy {
+			continue
+		}
+		if task.AssignedTo != "" && a.ID != task.AssignedTo {
+			continue
+		}
+		if err := PokeAgent(a.WSAddr); err != nil {
+			log.Printf("gateway: could not ring %s about %s (%v) — its poll will pick the task up",
+				a.ID, task.ID, err)
+		}
+	}
+}
+
+// pokeResult is the ack sent back to a doorbell.
+var pokeResult, _ = json.Marshal(map[string]bool{"poked": true})

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -1,0 +1,232 @@
+// Package taskrunner lets an agent pick up work its peer left in the shared
+// queue and execute it with the same model backend that answers chat.
+//
+// The loop is deliberately dumb: poll, claim, run, report. The database is the
+// source of truth — a missed doorbell only costs latency, never the task. That
+// is why the poll exists at all rather than relying on the peer to notify.
+package taskrunner
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/trace"
+)
+
+// renewEvery must be comfortably shorter than coord.DefaultLease so a task
+// that is genuinely still running is never handed to another agent.
+const renewEvery = 2 * time.Minute
+
+// taskChatID namespaces task sessions away from real Telegram chats.
+const taskChatID = -1
+
+// Config configures a Runner.
+type Config struct {
+	AgentID  string
+	Model    string
+	Interval time.Duration // how often to look for work; 0 disables polling
+	Timeout  time.Duration // hard cap on one task's execution
+}
+
+// Runner claims and executes tasks for one agent.
+type Runner struct {
+	db     *coord.DB
+	llm    chat.Client
+	rec    *trace.Recorder
+	cfg    Config
+	poke   chan struct{}
+	closed sync.Once
+	done   chan struct{}
+}
+
+// New builds a Runner. A nil db or llm returns nil, which is a working no-op —
+// callers do not have to branch on whether coordination is enabled.
+func New(db *coord.DB, llm chat.Client, rec *trace.Recorder, cfg Config) *Runner {
+	if db == nil || llm == nil || cfg.Interval <= 0 {
+		return nil
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 15 * time.Minute
+	}
+	return &Runner{
+		db: db, llm: llm, rec: rec, cfg: cfg,
+		poke: make(chan struct{}, 1),
+		done: make(chan struct{}),
+	}
+}
+
+// Poke asks the runner to look for work right now instead of waiting out the
+// interval. Non-blocking and coalescing: several pokes collapse into one pass.
+func (r *Runner) Poke() {
+	if r == nil {
+		return
+	}
+	select {
+	case r.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Start runs the claim loop until ctx is canceled.
+func (r *Runner) Start(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	log.Printf("taskrunner: claiming tasks for %s every %s", r.cfg.AgentID, r.cfg.Interval)
+	go func() {
+		defer close(r.done)
+		ticker := time.NewTicker(r.cfg.Interval)
+		defer ticker.Stop()
+		for {
+			// Drain the queue before sleeping again: a peer may have left
+			// several tasks at once.
+			for r.claimAndRun(ctx) {
+				if ctx.Err() != nil {
+					return
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			case <-r.poke:
+			}
+		}
+	}()
+}
+
+// Wait blocks until the loop has stopped. Used by tests.
+func (r *Runner) Wait() {
+	if r == nil {
+		return
+	}
+	<-r.done
+}
+
+// claimAndRun takes one task and executes it. It reports whether it found work,
+// so the caller can keep draining.
+func (r *Runner) claimAndRun(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	task, err := r.db.ClaimTask(r.cfg.AgentID)
+	if err == coord.ErrNoTask {
+		return false
+	}
+	if err != nil {
+		log.Printf("taskrunner: claim: %v", err)
+		return false
+	}
+
+	log.Printf("taskrunner: claimed %s (attempt %d): %s", task.ID, task.Attempts, task.Title)
+	r.execute(ctx, task)
+	return true
+}
+
+func (r *Runner) execute(ctx context.Context, task *coord.Task) {
+	runCtx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
+	defer cancel()
+
+	// Keep the lease alive for as long as the work actually takes.
+	stopRenew := r.renewLease(runCtx, task.ID)
+	defer stopRenew()
+
+	span := r.rec.StartTrace("task", coord.RunTypeTask, trace.Meta{
+		SessionID: "task_" + task.ID,
+		Model:     r.cfg.Model,
+		Provider:  r.llm.Name(),
+	})
+	span.SetInputs(taskPrompt(task))
+	if tid := span.TraceID(); tid != "" {
+		if err := r.db.AttachTrace(task.ID, tid); err != nil {
+			log.Printf("taskrunner: attach trace: %v", err)
+		}
+	}
+
+	// A fresh, unregistered session per task: the peer's instruction must not
+	// inherit — or pollute — whatever the agent was chatting about.
+	sess := session.New(taskChatID)
+	sess.ID = "task_" + task.ID
+
+	var reply strings.Builder
+	call := span.Child(r.llm.Name(), coord.RunTypeLLM)
+	err := r.llm.SendMessage(runCtx, sess, r.cfg.Model, taskPrompt(task), "", chat.StreamCallbacks{
+		OnText: func(chunk string) { reply.WriteString(chunk) },
+		OnToolCall: func(name, input string) {
+			sp := call.Child(name, coord.RunTypeTool)
+			sp.SetInputs(input)
+			// Tool results are not paired here: the CLI backends report a
+			// result callback per call, and the span closes on the next line.
+			sp.End("", nil)
+		},
+	})
+	in, out := sess.Tokens()
+	call.EndWithTokens(reply.String(), err, in, out)
+
+	state, result := coord.TaskCompleted, reply.String()
+	if err != nil {
+		state = coord.TaskFailed
+		result = fmt.Sprintf("%s\n\nerror: %v", reply.String(), err)
+	}
+	span.End(result, err)
+
+	if finishErr := r.db.FinishTask(task.ID, r.cfg.AgentID, state, result, task.Attempts); finishErr != nil {
+		// ErrLostLease means another agent took over and already answered;
+		// discarding this result is the correct outcome, not a failure.
+		log.Printf("taskrunner: finish %s: %v", task.ID, finishErr)
+		return
+	}
+	log.Printf("taskrunner: %s → %s", task.ID, state)
+}
+
+// renewLease keeps the claim alive while the task runs, and returns a stop
+// function. If the lease is lost the renewal simply stops: FinishTask's fencing
+// check is what actually protects the other agent's result.
+func (r *Runner) renewLease(ctx context.Context, taskID string) func() {
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(renewEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := r.db.RenewLease(taskID, r.cfg.AgentID); err != nil {
+					log.Printf("taskrunner: lease on %s: %v", taskID, err)
+					return
+				}
+			}
+		}
+	}()
+	return sync.OnceFunc(func() { close(stop) })
+}
+
+// taskPrompt turns a queued task into an instruction. The framing matters: the
+// agent must understand this came from a peer, not from the user it chats with,
+// and that its reply is the deliverable rather than conversation.
+func taskPrompt(t *coord.Task) string {
+	var b strings.Builder
+	b.WriteString("You have picked up a task from the shared queue.\n\n")
+	fmt.Fprintf(&b, "Task id: %s\nRequested by: %s\n\n", t.ID, t.CreatedBy)
+	fmt.Fprintf(&b, "## %s\n", t.Title)
+	if t.Body != "" {
+		b.WriteString("\n")
+		b.WriteString(t.Body)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nDo the work, then reply with the outcome. Your reply is recorded " +
+		"as the task result and is what the requesting agent will read, so state what " +
+		"you did and what you found — do not ask follow-up questions, there is nobody " +
+		"waiting to answer them.")
+	return b.String()
+}

--- a/internal/taskrunner/runner_test.go
+++ b/internal/taskrunner/runner_test.go
@@ -1,0 +1,232 @@
+package taskrunner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+// stubLLM records what it was asked and replies with a canned answer.
+type stubLLM struct {
+	mu      sync.Mutex
+	prompts []string
+	reply   string
+	err     error
+	delay   time.Duration
+}
+
+func (s *stubLLM) Name() string { return "stub" }
+
+func (s *stubLLM) SendMessage(ctx context.Context, sess *session.Session, model,
+	userText, memory string, cb chat.StreamCallbacks) error {
+	s.mu.Lock()
+	s.prompts = append(s.prompts, userText)
+	reply, err, delay := s.reply, s.err, s.delay
+	s.mu.Unlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if cb.OnText != nil && reply != "" {
+		cb.OnText(reply)
+	}
+	sess.SetSessionID("stub-session")
+	sess.AddTokens(50, 7)
+	return err
+}
+
+func (s *stubLLM) seen() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.prompts...)
+}
+
+func testDB(t *testing.T) *coord.DB {
+	t.Helper()
+	db, err := coord.Open(filepath.Join(t.TempDir(), "coord.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func newRunner(db *coord.DB, llm chat.Client) *Runner {
+	return New(db, llm, nil, Config{
+		AgentID:  "a2",
+		Model:    "m",
+		Interval: 10 * time.Millisecond,
+		Timeout:  5 * time.Second,
+	})
+}
+
+func TestRunnerClaimsAndCompletes(t *testing.T) {
+	db := testDB(t)
+	created, err := db.CreateTask(coord.NewTask{
+		CreatedBy: "a1", AssignedTo: "a2",
+		Title: "Check the log", Body: "Look for auth errors",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	llm := &stubLLM{reply: "No auth errors in the last hour."}
+	r := newRunner(db, llm)
+	if !r.claimAndRun(context.Background()) {
+		t.Fatal("runner found no work for a task addressed to it")
+	}
+
+	task, err := db.GetTask(created.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if task.State != coord.TaskCompleted {
+		t.Errorf("state = %q, want completed", task.State)
+	}
+	if task.Result != "No auth errors in the last hour." {
+		t.Errorf("result = %q — the model's reply is the deliverable", task.Result)
+	}
+	if task.ClaimedBy != "a2" {
+		t.Errorf("claimed_by = %q", task.ClaimedBy)
+	}
+
+	prompts := llm.seen()
+	if len(prompts) != 1 {
+		t.Fatalf("model called %d times, want 1", len(prompts))
+	}
+	for _, want := range []string{"Check the log", "Look for auth errors", created.ID, "a1"} {
+		if !strings.Contains(prompts[0], want) {
+			t.Errorf("prompt is missing %q:\n%s", want, prompts[0])
+		}
+	}
+	// The agent must know nobody is waiting to answer questions.
+	if !strings.Contains(prompts[0], "do not ask follow-up questions") {
+		t.Error("prompt does not tell the agent there is nobody to answer questions")
+	}
+}
+
+func TestRunnerRecordsFailure(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "Break"})
+
+	llm := &stubLLM{reply: "partial work", err: errors.New("codex error: 400")}
+	newRunner(db, llm).claimAndRun(context.Background())
+
+	task, _ := db.GetTask(created.ID)
+	if task.State != coord.TaskFailed {
+		t.Errorf("state = %q, want failed", task.State)
+	}
+	if !strings.Contains(task.Result, "codex error: 400") {
+		t.Errorf("result must carry the error, got %q", task.Result)
+	}
+	if !strings.Contains(task.Result, "partial work") {
+		t.Errorf("partial output must be kept, got %q", task.Result)
+	}
+}
+
+func TestRunnerIgnoresTasksForOtherAgents(t *testing.T) {
+	db := testDB(t)
+	db.CreateTask(coord.NewTask{CreatedBy: "a1", AssignedTo: "a3", Title: "not yours"})
+
+	llm := &stubLLM{reply: "hi"}
+	if newRunner(db, llm).claimAndRun(context.Background()) {
+		t.Error("runner claimed a task addressed to another agent")
+	}
+	if len(llm.seen()) != 0 {
+		t.Error("model was called for someone else's task")
+	}
+}
+
+func TestRunnerDrainsTheQueue(t *testing.T) {
+	db := testDB(t)
+	for i := 0; i < 3; i++ {
+		db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "job"})
+	}
+
+	llm := &stubLLM{reply: "done"}
+	r := newRunner(db, llm)
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		done, _ := db.ListTasks(coord.TaskFilter{State: coord.TaskCompleted})
+		if len(done) == 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	r.Wait()
+
+	done, _ := db.ListTasks(coord.TaskFilter{State: coord.TaskCompleted})
+	if len(done) != 3 {
+		t.Errorf("completed %d of 3 queued tasks", len(done))
+	}
+}
+
+func TestStaleRunnerDoesNotOverwriteTheNewOwner(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "slow job"})
+
+	// a2 claims and starts working.
+	slow := &stubLLM{reply: "a2 answer", delay: 300 * time.Millisecond}
+	r := newRunner(db, slow)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.claimAndRun(context.Background())
+	}()
+
+	// Meanwhile the lease lapses and a3 takes the work and finishes first.
+	time.Sleep(50 * time.Millisecond)
+	db.Conn().Exec(`UPDATE tasks SET lease_until = ? WHERE id = ?`,
+		time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano), created.ID)
+	fresh, err := db.ClaimTask("a3")
+	if err != nil {
+		t.Fatalf("a3 could not reclaim: %v", err)
+	}
+	if err := db.FinishTask(fresh.ID, "a3", coord.TaskCompleted, "a3 answer", fresh.Attempts); err != nil {
+		t.Fatalf("a3 could not finish: %v", err)
+	}
+
+	wg.Wait()
+
+	task, _ := db.GetTask(created.ID)
+	if task.Result != "a3 answer" {
+		t.Errorf("result = %q — the stale runner overwrote the new owner's work", task.Result)
+	}
+	if task.ClaimedBy != "a3" {
+		t.Errorf("claimed_by = %q, want a3", task.ClaimedBy)
+	}
+}
+
+func TestNilRunnerIsSafe(t *testing.T) {
+	// A disabled runner is expressed as nil; every entry point must tolerate it
+	// so callers do not have to branch.
+	var r *Runner
+	r.Poke()
+	r.Start(context.Background())
+	r.Wait()
+
+	if New(nil, &stubLLM{}, nil, Config{Interval: time.Second}) != nil {
+		t.Error("New must return nil without a database")
+	}
+	if New(testDB(t), &stubLLM{}, nil, Config{Interval: 0}) != nil {
+		t.Error("New must return nil when polling is disabled")
+	}
+}


### PR DESCRIPTION
Hoàn tất **P2** và làm **P3** trong `docs/design/shared-agent-memory.md`.

## P2 — Agent tự nhận việc

`internal/taskrunner` poll hàng đợi chung, claim một task, chạy nó qua đúng CLI backend đang trả lời chat, rồi ghi câu trả lời lại làm result.

**Mặc định TẮT** (`tasks.auto_claim: false`). Đây là lựa chọn có chủ ý: task được claim sẽ chạy với đúng quyền truy cập máy mà backend chat có, và **không ai ngồi xem lúc nó chạy**. Chỉ bật cho agent thực sự cần làm việc không giám sát.

Ba chi tiết đáng nói:

- **Mỗi task chạy trong session riêng, không đăng ký vào manager.** Lệnh của agent kia không được kế thừa — cũng không được làm bẩn — ngữ cảnh hội thoại agent đang có.
- **Lease được gia hạn trong lúc chạy.** Nếu vẫn hết hạn, fencing check của `FinishTask` **vứt kết quả của agent này đi** thay vì ghi đè lên agent đã tiếp quản. Có test đua trực tiếp hai bên.
- **Prompt nói rõ câu trả lời CHÍNH LÀ deliverable** và không có ai chờ để trả lời câu hỏi ngược. Thiếu câu này thì model hỏi lại một câu và task hoàn thành với... một câu hỏi làm kết quả.

**Chuông cửa** (`tasks.poke` RPC, rung khi tạo task từ cả CLI lẫn dashboard) xoá độ trễ poll. Nó thuần tuý là tối ưu: hàng đợi mới là nguồn sự thật, và agent nào có dashboard auth từ chối socket chưa xác thực thì đơn giản là nhận việc ở lần poll kế tiếp.

## P3 — Tri thức chung

`shared_notes` + FTS5, **append-only**. Sửa một note = ghi dòng MỚI, dòng cũ trỏ sang nó qua `superseded_by`. Hai agent sửa đè lên nhau tại chỗ sẽ ghi đè âm thầm, và lịch sử mất sạch trong cả hai trường hợp.

Search **bọc chuỗi người dùng thành FTS phrase**: chuỗi trần có thể chứa toán tử FTS, hoặc lỗi cú pháp hoặc lặng lẽ mang nghĩa khác cái người ta gõ. Đã test với `"quoted"`, `AND OR NOT`, `foo*`, `a(b)c`, `-x`.

`NOTES.md` được render lại (ghi nguyên tử) sau mỗi lần ghi — agent đọc file tự nhiên hơn nhiều so với query SQL. DB vẫn là nguồn sự thật.

CLI: `bomclaw note add|search|list|render`. RPC: `notes.list`, `notes.add`. Dashboard: pane **Notes** có lọc theo kind, full-text search, bật/tắt xem lịch sử, và nút *correct* điền sẵn note thay thế.

System prompt mẫu giờ dạy agent các lệnh này, kèm việc note là append-only và **không được tạo task thành vòng lặp**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)