### PR TITLE
fix: agent identity in spawned CLIs, and reap codex on every failure path

### DIFF
--- a/cmd/bomclaw/coordcmd.go
+++ b/cmd/bomclaw/coordcmd.go
@@ -30,14 +30,28 @@ func openCoord(dbPath string) *coord.DB {
 	return db
 }
 
-// agentFlag registers the identity flag. An agent running in its own workspace
-// gets this from BOMCLAW_AGENT_ID, set by whoever launched it.
+// agentFlag registers the identity flag. The gateway exports BOMCLAW_AGENT_ID
+// into every CLI subprocess it spawns, so an agent's own shell commands are
+// attributed correctly.
+//
+// There is deliberately NO fallback default. A wrong-but-plausible id is worse
+// than no id: it silently files one agent's tasks, notes and messages under
+// another agent's name, and nothing about the output looks wrong.
 func agentFlag(fs *flag.FlagSet) *string {
-	def := os.Getenv("BOMCLAW_AGENT_ID")
-	if def == "" {
-		def = "bomclaw"
+	return fs.String("agent", os.Getenv("BOMCLAW_AGENT_ID"),
+		"This agent's id (default $BOMCLAW_AGENT_ID)")
+}
+
+// requireAgent exits with a clear message when identity is unknown, rather than
+// writing rows under a guessed name.
+func requireAgent(id string) string {
+	if strings.TrimSpace(id) == "" {
+		fmt.Fprintln(os.Stderr,
+			"error: this agent's id is unknown.\n"+
+				"Pass --agent <id>, or set BOMCLAW_AGENT_ID (the gateway exports it automatically).")
+		os.Exit(1)
 	}
-	return fs.String("agent", def, "This agent's id (default $BOMCLAW_AGENT_ID)")
+	return id
 }
 
 func dbFlag(fs *flag.FlagSet) *string {
@@ -67,7 +81,7 @@ func runTask(args []string) {
 		defer db.Close()
 
 		task, err := db.CreateTask(coord.NewTask{
-			CreatedBy: *agent, AssignedTo: *to, Title: *title, Body: *body,
+			CreatedBy: requireAgent(*agent), AssignedTo: *to, Title: *title, Body: *body,
 			Priority: *priority, Depth: *depth, ContextID: *context,
 		})
 		if err != nil {
@@ -88,7 +102,7 @@ func runTask(args []string) {
 		db := openCoord(*dbPath)
 		defer db.Close()
 
-		task, err := db.ClaimTask(*agent)
+		task, err := db.ClaimTask(requireAgent(*agent))
 		if errors.Is(err, coord.ErrNoTask) {
 			fmt.Fprintln(os.Stderr, "no claimable task")
 			os.Exit(2) // distinct from a real failure so scripts can branch
@@ -130,7 +144,7 @@ func runTask(args []string) {
 			}
 			*attempts = t.Attempts
 		}
-		if err := db.FinishTask(*id, *agent, state, *result, *attempts); err != nil {
+		if err := db.FinishTask(*id, requireAgent(*agent), state, *result, *attempts); err != nil {
 			fmt.Fprintf(os.Stderr, "task %s: %v\n", sub, err)
 			os.Exit(1)
 		}
@@ -254,7 +268,7 @@ func runNote(args []string) {
 			scope = *agent
 		}
 		note, err := db.AddNote(coord.NewNote{
-			Author: *agent, Scope: scope, Kind: *kind, Title: *title,
+			Author: requireAgent(*agent), Scope: scope, Kind: *kind, Title: *title,
 			Body: *body, Tags: *tags, Supersedes: *supersedes,
 		})
 		if err != nil {
@@ -374,7 +388,7 @@ func runInbox(args []string) {
 	if *all {
 		msgs, err = db.RecentMessages(*limit)
 	} else {
-		msgs, err = db.Inbox(*agent, *unread, *limit)
+		msgs, err = db.Inbox(requireAgent(*agent), *unread, *limit)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "inbox: %v\n", err)
@@ -425,7 +439,7 @@ func runMsg(args []string) {
 	db := openCoord(*dbPath)
 	defer db.Close()
 
-	m, err := db.SendMessage(*agent, *to, *taskID, body)
+	m, err := db.SendMessage(requireAgent(*agent), *to, *taskID, body)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "msg: %v\n", err)
 		os.Exit(1)

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -204,6 +204,14 @@ func runGateway(args []string) {
 		cancel()
 	}()
 
+	// Every CLI subprocess this gateway spawns inherits this, so when the agent
+	// runs `bomclaw task`/`note`/`msg` from its shell it is identified as
+	// itself. Without it the CLI fell back to a default and agent 2's work was
+	// silently attributed to agent 1.
+	if err := os.Setenv("BOMCLAW_AGENT_ID", cfg.Agent.ID); err != nil {
+		log.Printf("gateway: could not export BOMCLAW_AGENT_ID: %v", err)
+	}
+
 	// Create model provider: codex CLI, claude CLI (OAuth), or direct API key.
 	provider := buildProvider(cfg)
 

--- a/internal/codex/client.go
+++ b/internal/codex/client.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/session"
@@ -109,6 +110,31 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 		}
 	}()
 
+	// Every exit path must reap the child. Returning on a stream error without
+	// waiting leaves a zombie codex process behind and the stderr goroutine
+	// blocked on a pipe that never closes — one per failed turn, which on a
+	// long-running gateway accumulates until something else breaks.
+	var (
+		waitOnce sync.Once
+		waitErr  error
+	)
+	reap := func() error {
+		waitOnce.Do(func() {
+			waitErr = cmd.Wait()
+			<-stderrDone
+		})
+		return waitErr
+	}
+	// kill first so Wait cannot block on a subprocess still producing output.
+	abort := func(err error) error {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = reap()
+		return err
+	}
+	defer reap()
+
 	// command_execution items arrive as started → completed; keep the command
 	// text so the completion can be reported (and screenshots detected).
 	pending := map[string]string{}
@@ -177,33 +203,33 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 			if ev.Error != nil && ev.Error.Message != "" {
 				msg = ev.Error.Message
 			}
-			return fmt.Errorf("codex error: %s", msg)
+			return abort(fmt.Errorf("codex error: %s", msg))
 
 		case "error":
 			if ev.Message != "" {
-				return fmt.Errorf("codex error: %s", ev.Message)
+				return abort(fmt.Errorf("codex error: %s", ev.Message))
 			}
-			return fmt.Errorf("codex error: unspecified stream error")
+			return abort(fmt.Errorf("codex error: unspecified stream error"))
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan: %w", err)
+		return abort(fmt.Errorf("scan: %w", err))
 	}
 
-	waitErr := cmd.Wait()
-	<-stderrDone
+	err = reap()
 
 	// A non-zero exit with no turn.completed means codex died before doing any
 	// work (bad auth, unknown model). Surface the stderr tail — without it the
-	// user only sees "exit status 1".
-	if waitErr != nil && !sawTurn {
+	// user only sees "exit status 1" — but keep the exit status wrapped so
+	// callers can still inspect it.
+	if err != nil && !sawTurn {
 		if lastErrLine != "" {
-			return fmt.Errorf("codex error: %s", lastErrLine)
+			return fmt.Errorf("codex error: %s (%w)", lastErrLine, err)
 		}
-		return fmt.Errorf("codex: %w", waitErr)
+		return fmt.Errorf("codex: %w", err)
 	}
-	return waitErr
+	return err
 }
 
 // handleCompletedItem maps one finished codex item onto the bot callbacks.

--- a/internal/codex/leak_test.go
+++ b/internal/codex/leak_test.go
@@ -1,0 +1,135 @@
+package codex
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+// fakeCodex installs a stand-in `codex` on PATH that prints the given JSONL
+// lines, then writes its own pid to pidFile and lingers. A leaked child stays
+// alive after SendMessage returns; a reaped one does not.
+func fakeCodex(t *testing.T, jsonl string, linger time.Duration) (pidFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile = filepath.Join(dir, "pid")
+
+	script := fmt.Sprintf(`#!/bin/sh
+cat > /dev/null &
+printf '%%s' $$ > %q
+%s
+sleep %d
+`, pidFile, jsonl, int(linger.Seconds()))
+
+	path := filepath.Join(dir, "codex")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return pidFile
+}
+
+func alive(t *testing.T, pidFile string) bool {
+	t.Helper()
+	raw, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("fake codex never wrote its pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("bad pid %q: %v", raw, err)
+	}
+	// Signal 0 reports whether the process still exists.
+	return syscall.Kill(pid, 0) == nil
+}
+
+// TestTurnFailedReapsTheChild covers a real leak: the stream-error paths used
+// to return before cmd.Wait(), leaving one zombie codex process and one blocked
+// stderr goroutine behind per failed turn.
+func TestTurnFailedReapsTheChild(t *testing.T) {
+	lines := `echo '{"type":"thread.started","thread_id":"t1"}'
+echo '{"type":"turn.failed","error":{"message":"model unavailable"}}'`
+	pidFile := fakeCodex(t, lines, 30*time.Second)
+
+	c := New("test")
+	c.SetWorkspace(t.TempDir())
+	err := c.SendMessage(context.Background(), session.New(1), "", "hi", "", chat.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("turn.failed must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "model unavailable") {
+		t.Errorf("error = %v, want the model's message", err)
+	}
+	if alive(t, pidFile) {
+		t.Error("the codex subprocess outlived the failed turn — it was never reaped")
+	}
+}
+
+func TestStreamErrorReapsTheChild(t *testing.T) {
+	lines := `echo '{"type":"thread.started","thread_id":"t1"}'
+echo '{"type":"error","message":"stream broke"}'`
+	pidFile := fakeCodex(t, lines, 30*time.Second)
+
+	c := New("test")
+	c.SetWorkspace(t.TempDir())
+	if err := c.SendMessage(context.Background(), session.New(1), "", "hi", "", chat.StreamCallbacks{}); err == nil {
+		t.Fatal("a stream error must surface")
+	}
+	if alive(t, pidFile) {
+		t.Error("the codex subprocess outlived the stream error")
+	}
+}
+
+// TestNonZeroExitKeepsTheStatus covers the second half: the stderr tail is the
+// useful message, but dropping the exit status made the failure uninspectable.
+func TestNonZeroExitKeepsTheStatus(t *testing.T) {
+	lines := `echo 'Failed to authenticate: token expired' >&2
+exit 7`
+	fakeCodex(t, lines, 0)
+
+	c := New("test")
+	c.SetWorkspace(t.TempDir())
+	err := c.SendMessage(context.Background(), session.New(1), "", "hi", "", chat.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("a non-zero exit with no turn must be an error")
+	}
+	if !strings.Contains(err.Error(), "token expired") {
+		t.Errorf("error = %v, want the stderr tail (otherwise the user sees only 'exit status 7')", err)
+	}
+	var exitErr *exec.ExitError
+	if !errorsAs(err, &exitErr) {
+		t.Fatalf("error = %v, want the exit status still wrapped", err)
+	}
+	if code := exitErr.ExitCode(); code != 7 {
+		t.Errorf("exit code = %d, want 7", code)
+	}
+}
+
+// errorsAs keeps the import list honest about what this file needs.
+func errorsAs(err error, target any) bool {
+	type unwrapper interface{ Unwrap() error }
+	for err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			if p, ok := target.(**exec.ExitError); ok {
+				*p = e
+				return true
+			}
+		}
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}


### PR DESCRIPTION
Cả hai bug đều lộ ra khi **chạy task runner thật**: agent 2 nhận một task trong hàng đợi, review `internal/codex/client.go`, và bản báo cáo của nó phơi ra một bug — còn *cách* nó báo cáo phơi ra bug thứ hai.

## 1. Sai danh tính agent

Gateway chưa bao giờ export `BOMCLAW_AGENT_ID`, nên `bomclaw task`/`note`/`msg` chạy từ shell của agent rơi về giá trị mặc định cứng `"bomclaw"`.

Kết quả thật quan sát được:

```
• 09-05 11:45  bomclaw → bomclaw
  Review t_a4a876da completed, but task done rejected: lease lost...
```

Tin nhắn của **agent 2** bị ghi là từ **agent 1**, gửi cho chính nó. Và lệnh `task done` của nó bị từ chối — **đúng**, bởi fencing check, đó là lý do duy nhất dữ liệu không bị hỏng.

- Gateway giờ export agent id vào mọi CLI subprocess nó spawn.
- CLI **không đoán nữa**: thiếu cả `--agent` lẫn `BOMCLAW_AGENT_ID` thì thoát kèm giải thích. Một id sai-mà-hợp-lý tệ hơn không có id, vì nó lặng lẽ ghi việc của agent này dưới tên agent kia và output nhìn vẫn bình thường.

## 2. Rò tiến trình codex

`turn.failed`, lỗi stream và lỗi scanner đều `return` **trước** `cmd.Wait()`. Mỗi lần để lại một tiến trình codex zombie và một goroutine stderr kẹt trên pipe không bao giờ đóng — mỗi lượt lỗi một cái, tích luỹ dần trên gateway chạy dài ngày.

Mọi đường thoát giờ kill + reap đúng một lần.

Phần stderr tail cũng **thay thế hoàn toàn** exit status, nên caller đọc được thông báo nhưng không đọc được mã lỗi. Giờ nó bọc status lại.

## Test

Dựng một `codex` giả trên PATH, ghi pid của nó rồi nằm chờ; test khẳng định tiến trình đã biến mất sau khi `SendMessage` trả về.

**Đã kiểm chứng cả ba test đều FAIL trên code cũ** — test không fail được thì không chứng minh gì cả.

🤖 Generated with [Claude Code](https://claude.com/claude-code)