### PR TITLE
docs(deploy): record the CLI symlink and the second agent's layout

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -38,6 +38,11 @@ artifacts into `~/.bomclaw/` and restart.
    cp config.yaml ~/.bomclaw/config.yaml
    cp .env ~/.bomclaw/.env
    rm -rf ~/.bomclaw/dashboard/dist && cp -R dashboard/dist ~/.bomclaw/dashboard/dist
+   # Agents call `bomclaw task/note/msg` from their own shell, and the launchd
+   # PATH does not include ~/.bomclaw. The symlink target is stable, so this
+   # only has to be created once — but check it, a wiped ~/.local/bin breaks
+   # every coordination command the agents run.
+   ln -sf ~/.bomclaw/bomclaw ~/.local/bin/bomclaw
    ```
 
 4. **Stop** the gateway and kill stale processes (orphaned `claude --resume`
@@ -90,6 +95,10 @@ Report:
 - Service label: `com.bomclaw.gateway` (plist: `~/Library/LaunchAgents/com.bomclaw.gateway.plist`)
 - Runtime layout: `~/.bomclaw/{bomclaw,config.yaml,.env,dashboard/dist}`
 - Data/logs stay in `~/.goterm/`; workspace in `~/goterm-workspace` — all outside TCC paths
+- Second agent: label `com.bomclaw2.gateway`, config `~/.bomclaw2/`, data `~/.goterm2/`,
+  port 18790 — **shares the same binary**, so every deploy restarts both
+- Coordination (traces, tasks, notes, messages) is shared at `~/.goterm-shared/data/coord.db`;
+  `agent.id` must differ per gateway or they overwrite each other's registration
 - NEVER point the LaunchAgent at a binary/config inside `~/Documents` — TCC
   blocks launchd reads there (Apple-signed tools get EPERM; ad-hoc binaries
   hang in dyld with zero logs)

--- a/docs/design/agents-as-a-service.md
+++ b/docs/design/agents-as-a-service.md
@@ -2,22 +2,24 @@
 
 > Trạng thái: DRAFT — thiết kế, chưa triển khai.
 > Mô hình tham chiếu: [MyClaw.ai](https://myclaw.ai/) — managed hosting cho OpenClaw/agent cá nhân.
+> ⚠️ Bản này chọn mô hình **"AI included" (bán lượt, không BYOK)** dùng **pool OAuth token xoay vòng**. Đây là quyết định kinh doanh có rủi ro ToS/ban đã biết — xem §12 trước khi triển khai.
 
 ## 1. Tầm nhìn & mô hình kinh doanh
 
-Biến bomclaw từ **bot cá nhân trên 1 máy Mac** thành **dịch vụ cho thuê agent**: mỗi khách hàng có một AI assistant riêng — chat qua Telegram/dashboard, có bộ nhớ dài hạn riêng, chạy 24/7, không phải tự vận hành.
+Biến bomclaw từ **bot cá nhân trên 1 máy Mac** thành **dịch vụ cho thuê agent trọn gói**: mỗi khách hàng có một AI assistant riêng — chat qua Telegram/dashboard, bộ nhớ dài hạn riêng, chạy 24/7. **Khách không cần nhập API key, không cần tài khoản Claude** — cứ mua gói và hỏi.
 
-Học từ MyClaw (đã được thị trường kiểm chứng):
+**Điểm khác biệt cốt lõi so với MyClaw**: MyClaw cố tình **KHÔNG** bao gồm token AI (khách tự trả). Ta chọn hướng **ngược lại — bán lượt hỏi đáp, AI đã bao gồm**. Đây là lợi thế bán hàng (khách lười, không muốn tự lo credential) nhưng cũng chính là rủi ro mà MyClaw đã né (§12).
 
-| Yếu tố | MyClaw | BomClaw AaaS (đề xuất) |
+| Yếu tố | MyClaw | BomClaw AaaS (bản này) |
 |---|---|---|
-| Đơn vị bán | 1 instance OpenClaw / khách | 1 agent instance / tenant |
-| Isolation | VM riêng per khách (2-4 vCPU, 4-8GB RAM, 40-80GB SSD) | Container riêng per tenant (tier cao: VM) |
-| AI tokens | **Không bao gồm** — khách tự trả | **BYOK** — khách nhập API key riêng |
-| Giá | PRO $33.3/th · MAX $66.6/th (annual) | Starter/Pro/Max, xem §10 |
-| Giá trị bán | 24/7, zero-maintenance, auto-update, backup, encryption | Như MyClaw + memory system + Telegram tích hợp sẵn |
+| Đơn vị bán | 1 instance OpenClaw / khách | **Gói lượt hỏi đáp / tháng** + 1 agent instance / tenant |
+| Isolation | VM riêng per khách | Container riêng per tenant |
+| AI credentials | **Không bao gồm** — khách tự trả (BYOK) | **AI included** — operator sở hữu **pool nhiều token Claude OAuth**, xoay vòng |
+| Khách nhập gì | API key của họ | **Không gì cả** — chỉ đăng ký + (tuỳ chọn) dán bot token Telegram |
+| Giá | PRO $33.3/th · MAX $66.6/th | Theo **số lượt/tháng**, xem §10 |
+| Giá trị bán | 24/7, zero-maintenance, backup | Như trên + **không phải lo token/tài khoản AI** + memory system + Telegram |
 
-**Điểm mấu chốt của mô hình**: không bán "token AI" (biên lợi nhuận âm, rủi ro ToS) — bán **hạ tầng + vận hành + trải nghiệm**. Khách mang API key/subscription của họ.
+**Cơ chế then chốt**: tổ chức (operator) nạp **nhiều token Claude OAuth** vào hệ thống. Mỗi lượt hỏi đáp tiêu 1 token slot; hệ thống **xoay vòng token — dùng ~20 lượt trên 1 token rồi chuyển sang token khác** để phân tán tải, tránh dồn hết vào một subscription. Khách chỉ thấy "còn X lượt".
 
 ## 2. Hiện trạng & khoảng cách (gap analysis)
 
@@ -27,20 +29,23 @@ Bomclaw hôm nay là **single-tenant triệt để**:
 |---|---|---|
 | Agent runtime | 1 process gateway spawn `claude` CLI, `--permission-mode bypassPermissions`, **full quyền trên máy host** | Một tenant = chiếm cả máy. KHÔNG THỂ share process |
 | Workspace | 1 thư mục `~/goterm-workspace` chung | Tenant A đọc được file + memory của tenant B |
-| Claude auth | 1 OAuth subscription của chủ máy | Share subscription cho khách = vi phạm ToS Anthropic + đụng rate limit lẫn nhau |
+| Claude auth | 1 OAuth subscription của chủ máy, gắn cứng | Không có khái niệm **pool** hay **xoay vòng**; không đo được lượt/token đã dùng |
 | Session | Keyed theo `chat_id` Telegram, 1 DB chung | Chưa có khái niệm tenant |
 | Users | Bảng `users` (v4) chỉ để login dashboard | Chưa gắn với tenant/data scoping |
 | Telegram | 1 bot token, whitelist user id | Mọi user nói chuyện với cùng 1 agent |
 | Memory | 1 bộ MEMORY.md + memory/ chung | Bộ nhớ trộn lẫn giữa các user |
+| Metering | Không có | Không đếm được lượt để bán / để tính hết gói |
 
-**Kết luận nền tảng**: vì agent có shell access, ranh giới bảo mật duy nhất đáng tin là **ranh giới OS-level (container/VM)**, không phải logic trong ứng dụng. Thiết kế xoay quanh nguyên tắc này.
+**Kết luận nền tảng**: (1) vì agent có shell access, ranh giới bảo mật đáng tin duy nhất là **ranh giới OS-level (container/VM)**; (2) vì bán lượt, phải có **credential broker** để cấp phát + xoay token và **turn metering** để đếm lượt. Hai thành phần này là phần việc mới lớn nhất so với hôm nay.
 
 ## 3. Nguyên tắc thiết kế
 
-1. **Isolation-first**: mỗi tenant một sandbox OS riêng (container/VM) + volume disk riêng. Không có đường code nào cho phép agent của tenant này đọc dữ liệu tenant khác — kể cả khi agent bị prompt-injection.
-2. **BYOK (Bring Your Own Key)**: credentials AI là của tenant, chỉ tồn tại trong sandbox của tenant đó.
-3. **Control plane / Data plane tách biệt**: gateway (điều phối, auth, billing) không bao giờ thực thi lệnh của agent; agent không bao giờ thấy DB điều phối.
-4. **Tái sử dụng tối đa**: `internal/claude`, `internal/session`, `internal/memory`, `internal/bot` hiện tại trở thành **agent runtime** chạy TRONG container. Gateway hiện tại tiến hóa thành control plane.
+1. **Isolation-first**: mỗi tenant một sandbox OS riêng (container) + volume disk riêng. Không đường code nào cho agent tenant này đọc dữ liệu tenant khác — kể cả khi bị prompt-injection.
+2. **Managed credentials (không BYOK)**: credentials AI thuộc **operator**, gom thành **pool** ở control plane, chỉ inject token *đang được cấp* vào container tenant tại đúng thời điểm gọi — không bao giờ để lộ cả pool cho agent.
+3. **Provider-agnostic broker (đường lui bắt buộc)**: broker cấp phát credential qua interface `checkout/checkin` **không phụ thuộc loại token**. `kind = claude_oauth | anthropic_api_key`. → Nếu OAuth bị siết/ban, **swap sang API key thương mại hợp lệ mà không viết lại agent** (xem §12).
+4. **Meter everything**: mỗi lượt hỏi đáp được đếm 2 chiều — trừ số dư lượt của tenant (billing) và cộng usage cho token phục vụ (rotation + rate-limit awareness).
+5. **Control plane / Data plane tách biệt**: gateway (auth, billing, broker) không thực thi lệnh agent; agent không thấy DB điều phối, không thấy pool.
+6. **Tái sử dụng tối đa**: `internal/claude`, `internal/session`, `internal/memory`, `internal/bot` hiện tại trở thành **agent runtime** trong container. Gateway tiến hóa thành control plane + broker.
 
 ## 4. Kiến trúc mục tiêu
 
@@ -50,39 +55,39 @@ Internet ─HTTPS──>  │  bomclaw-gateway                                  
 (Cloudflare Tunnel) │  ├── Auth (users/tenants, session cookie — đã có từ v4)             │
                     │  ├── Provisioner (tạo/stop/xóa agent container, quota)              │
                     │  ├── Router (tenant_id → agent endpoint)                            │
-                    │  ├── Billing (Stripe webhook, tier enforcement)                     │
+                    │  ├── ★ Token Broker (pool OAuth, cấp phát + xoay 20 lượt/token)     │
+                    │  ├── ★ Metering (đếm lượt, trừ số dư tenant, ledger)                │
+                    │  ├── Billing (Stripe webhook, nạp lượt, tier)                       │
                     │  └── Fleet DB (SQLite → Postgres khi scale)                         │
-                    └────────────┬────────────────────────────────────────────────────────┘
-                                 │ mạng nội bộ (docker network, mTLS nội bộ)
-        ┌────────────────────────┼────────────────────────┐
-        ▼                        ▼                        ▼
+                    └────────┬───────────────────────────────────┬───────────────────────┘
+                             │ lease token (mTLS nội bộ)          │ proxy chat (WS/HTTP)
+        ┌────────────────────┼────────────────────────┐          │
+        ▼                    ▼                        ▼           ▼
 ┌─ tenant: alice ──────┐ ┌─ tenant: bob ────────┐ ┌─ tenant: carol ──────┐   DATA PLANE
 │ agentd (bomclaw core)│ │ agentd               │ │ agentd               │
-│ ├─ claude CLI (BYOK) │ │ ├─ claude CLI (BYOK) │ │ ├─ claude CLI (BYOK) │
+│ ├─ claude CLI        │ │ ├─ claude CLI        │ │ ├─ claude CLI        │
+│ │   (token cấp/lượt) │ │ │   (token cấp/lượt) │ │ │   (token cấp/lượt) │
 │ ├─ telegram poller*  │ │ ├─ telegram poller*  │ │ ├─ telegram poller*  │
 │ ├─ memory system     │ │ ├─ memory system     │ │ ├─ memory system     │
 │ └─ /workspace (vol)  │ │ └─ /workspace (vol)  │ │ └─ /workspace (vol)  │
-│ limits: 2cpu/4GB/40GB│ │ limits: 2cpu/4GB/40GB│ │ limits: 4cpu/8GB/80GB│
 └──────────────────────┘ └──────────────────────┘ └──────────────────────┘
-        * mỗi tenant dùng BOT TOKEN TELEGRAM RIÊNG (BYO bot) — xem §9
+        * bot token Telegram vẫn BYO per tenant (xem §9); token AI thì KHÔNG — do broker cấp
 ```
 
-### 4.1 Control plane — `bomclaw-gateway` (tiến hóa từ gateway hiện tại)
+**Khác biệt lớn so với bản BYOK**: token AI **không** nằm cố định trong container tenant nữa. Mỗi lượt, agentd **checkout** token đang-active từ broker → dùng → **checkin**. Broker là thành phần trên hot-path mọi lượt (đánh đổi: xem downgrade isolation ở §11–12).
 
-- **Không spawn claude CLI nữa.** Chỉ điều phối.
-- Expose: dashboard (multi-tenant), API quản trị, provisioning.
-- Route request dashboard của user → agent container của tenant tương ứng (reverse proxy WS/HTTP tới `agentd`).
-- Sở hữu: users, tenants, billing, audit log. **Không** sở hữu nội dung chat (nằm trong container của tenant).
+### 4.1 Control plane — `bomclaw-gateway`
+- **Không spawn claude CLI.** Điều phối + sở hữu pool token + đếm lượt.
+- Sở hữu: users, tenants, billing, **provider_tokens (pool)**, **turn_ledger**, audit. **Không** sở hữu nội dung chat.
+- Route dashboard user → agent container tương ứng; cấp phát token cho mỗi lượt.
 
 ### 4.2 Data plane — `agentd` (bomclaw core đóng gói lại)
+- Giữ toàn bộ code hiện có: claude wrapper, session manager, memory, Telegram, transcript.
+- `--workspace /workspace`, `--data-dir /data` (volume + SQLite riêng của tenant).
+- **Mới**: trước mỗi lượt gọi broker lấy token → ghi vào `~/.claude/.credentials.json` (hoặc env) → spawn `claude -p --resume` → sau khi trả lời, checkin usage.
+- Một tenant ≈ bomclaw single-tenant hôm nay, khác đúng chỗ credential do broker cấp.
 
-Binary bomclaw hiện tại, chạy chế độ "agent" trong container:
-- Toàn bộ code hiện có được giữ: claude CLI wrapper, session manager, memory system (MEMORY.md + daily notes + flush), Telegram bot, transcript.
-- `--workspace /workspace` (volume riêng), `--data-dir /data` (SQLite riêng của tenant).
-- Expose HTTP/WS trên mạng nội bộ để control plane proxy tới (dashboard chat).
-- **Điểm hay**: một tenant của AaaS ≈ chính xác bomclaw single-tenant hôm nay. Không viết lại agent logic.
-
-## 5. Tenant model — schema control plane (v5)
+## 5. Schema control plane (v5)
 
 ```sql
 CREATE TABLE tenants (
@@ -90,12 +95,12 @@ CREATE TABLE tenants (
   display_name TEXT NOT NULL,
   tier         TEXT NOT NULL DEFAULT 'starter',  -- starter|pro|max
   status       TEXT NOT NULL DEFAULT 'active',   -- active|suspended|deleted
+  turn_balance INTEGER NOT NULL DEFAULT 0,       -- ★ số lượt còn lại
   created_at   TEXT NOT NULL
 );
 
 -- users (v4) thêm cột:
 ALTER TABLE users ADD COLUMN tenant_id TEXT REFERENCES tenants(id);
--- role hiện có (admin|viewer) trở thành role TRONG tenant; thêm role hệ thống:
 ALTER TABLE users ADD COLUMN is_operator INTEGER DEFAULT 0;  -- vận hành platform
 
 CREATE TABLE agent_instances (
@@ -107,12 +112,31 @@ CREATE TABLE agent_instances (
   updated_at    TEXT NOT NULL
 );
 
-CREATE TABLE credentials (              -- BYOK, mã hóa envelope
+-- ★ POOL token AI của operator (KHÔNG per-tenant) — mã hóa envelope
+CREATE TABLE provider_tokens (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  label          TEXT,                            -- "acc-01" để operator nhận diện
+  kind           TEXT NOT NULL DEFAULT 'claude_oauth', -- claude_oauth | anthropic_api_key
+  ciphertext     BLOB NOT NULL,                   -- AES-GCM, master key ngoài DB (0600/KMS)
+  status         TEXT NOT NULL DEFAULT 'active',  -- active|cooling|disabled|banned
+  turns_used     INTEGER NOT NULL DEFAULT 0,      -- tổng lượt đời token (audit)
+  window_turns   INTEGER NOT NULL DEFAULT 0,      -- lượt trong cửa sổ rate-limit hiện tại
+  window_start   TEXT,                            -- mốc cửa sổ (Claude giới hạn theo ~5h)
+  dwell_turns    INTEGER NOT NULL DEFAULT 0,      -- ★ lượt liên tiếp trên token này (reset khi xoay)
+  cooldown_until TEXT,                            -- set khi gặp 429/limit
+  last_used_at   TEXT,
+  created_at     TEXT NOT NULL
+);
+
+-- ★ sổ cái lượt: vừa để billing (trừ tenant) vừa để audit (token nào phục vụ)
+CREATE TABLE turn_ledger (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts         TEXT NOT NULL,
   tenant_id  TEXT REFERENCES tenants(id),
-  kind       TEXT NOT NULL,             -- anthropic_api_key | telegram_bot_token
-  ciphertext BLOB NOT NULL,             -- AES-GCM, master key ngoài DB (file 0600/KMS)
-  created_at TEXT NOT NULL,
-  PRIMARY KEY (tenant_id, kind)
+  session_id TEXT,
+  token_id   INTEGER REFERENCES provider_tokens(id),  -- token đã phục vụ lượt này
+  delta      INTEGER NOT NULL,        -- -1 mỗi lượt hỏi đáp, +N khi nạp/refund
+  reason     TEXT NOT NULL            -- qa_turn | topup | refund | adjust
 );
 
 CREATE TABLE audit_log (
@@ -121,82 +145,140 @@ CREATE TABLE audit_log (
 );
 ```
 
-Nội dung chat/session/memory **không nằm ở control plane** — nằm trong SQLite + files của từng container (volume tenant). Control plane chỉ biết metadata.
+Nội dung chat/session/memory **không nằm ở control plane** — nằm trong SQLite + files của từng container (volume tenant). Control plane chỉ biết metadata + đếm lượt.
 
 ## 6. Workspace & disk isolation
 
-- Mỗi tenant 1 volume: `/data/tenants/<tenant_id>/` gồm `workspace/` (agent làm việc + memory) và `data/` (SQLite, transcripts của tenant).
-- Mount vào container tại `/workspace`, `/data`. **Không mount bất kỳ path nào khác của host.**
-- Quota theo tier (40/80/320 GB) — enforce bằng filesystem quota (XFS project quota trên Linux) hoặc volume size limit.
+- Mỗi tenant 1 volume: `/data/tenants/<tenant_id>/` gồm `workspace/` (agent làm việc + memory) và `data/` (SQLite, transcripts).
+- Mount vào container tại `/workspace`, `/data`. **Không mount path nào khác của host.**
+- Quota theo tier — filesystem quota (XFS project quota) hoặc volume size limit.
 - Rootfs container **read-only**; chỉ `/workspace`, `/data`, `/tmp` ghi được.
-- Backup: snapshot volume hằng ngày (restic/borg), retention theo tier — đây là feature bán được (MyClaw: "daily backups").
+- Backup: snapshot volume hằng ngày (restic/borg), retention theo tier.
 - Xóa tenant: stop container → giữ volume 30 ngày (grace) → xóa vĩnh viễn.
 
 ## 7. Sandbox runtime — lựa chọn & khuyến nghị
 
 | Phương án | Isolation | Chi phí/khách | Ghi chú |
 |---|---|---|---|
-| **A. Container (Docker + gVisor/runsc)** ✅ đề xuất mặc định | Tốt (gVisor chặn syscall escape) | Thấp — 1 host Linux chạy được hàng chục tenant | Agent chạy `claude` CLI trong Linux container bình thường |
-| B. microVM (Firecracker/Cloud Hypervisor) | Rất tốt | Trung bình | Cho tier Max hoặc khách enterprise |
-| C. VM đầy đủ / VPS riêng (mô hình MyClaw) | Tốt nhất | Cao | Resale VPS + ansible; ít code nhất nhưng vận hành thủ công hơn |
-| D. macOS sandbox-exec + OS user riêng | Yếu, API deprecated | — | ❌ Loại — Mac không phải nền tảng multi-tenant |
+| **A. Container (Docker + gVisor/runsc)** ✅ đề xuất mặc định | Tốt | Thấp | Agent chạy `claude` CLI trong Linux container |
+| B. microVM (Firecracker) | Rất tốt | Trung bình | Tier Max / enterprise |
+| C. VM đầy đủ / VPS (mô hình MyClaw) | Tốt nhất | Cao | Ít code, vận hành thủ công hơn |
+| D. macOS sandbox-exec | Yếu, deprecated | — | ❌ Loại |
 
-**Khuyến nghị**: dev/beta trên Mac hiện tại bằng OrbStack (đã cài) với Docker container thường (khách beta tin cậy); production thuê 1 server Linux (Hetzner/OVH ~$40-80/th cho 16-32GB RAM) chạy Docker + gVisor. Network của container: **egress-only**, chặn 169.254.0.0/16 (metadata), chặn LAN, chặn mạng nội bộ control plane (chỉ cho phép chiều gateway → agentd).
+**Khuyến nghị**: dev/beta trên Mac hiện tại (OrbStack) với container thường; production thuê 1 server Linux (Hetzner/OVH ~$40–80/th) chạy Docker + gVisor. Network container: **egress-only**, chặn 169.254.0.0/16 (metadata), chặn LAN, chặn mạng control plane (chỉ cho phép chiều gateway↔agentd + agentd→broker).
 
-## 8. BYOK — credentials của khách
+## 8. ★ Token pool & rotation (thành phần cốt lõi mới)
 
-- Onboarding: khách dán `ANTHROPIC_API_KEY` (hoặc chạy `claude setup-token` OAuth của chính họ qua web terminal vào container của họ — hỗ trợ khách dùng subscription Claude Pro/Max cá nhân).
-- Lưu: mã hóa AES-GCM trong bảng `credentials`, master key nằm ngoài DB (file mode 0600 trên host, sau này KMS). Giải mã CHỈ tại thời điểm inject env vào container của đúng tenant.
-- **Tuyệt đối không** dùng chung OAuth token của operator cho khách: vi phạm ToS, chung rate-limit, và một khách prompt-injection có thể đốt quota của tất cả.
-- Nếu muốn bán "AI included" sau này: mua API key doanh nghiệp, meter theo token (bảng usage), margin dương — để phase sau.
+Đây là phần thay thế mục "BYOK" của bản trước, và là phần việc kỹ thuật rủi ro/khó nhất.
+
+### 8.1 Nạp token
+- Operator vào dashboard admin → dán nhiều token Claude OAuth (lấy từ `claude setup-token` trên từng account Pro/Max), đặt `label`. Lưu mã hóa AES-GCM vào `provider_tokens`, master key ngoài DB.
+- Cũng chấp nhận `anthropic_api_key` cùng bảng (`kind` khác) → sẵn sàng cho đường lui §12.
+
+### 8.2 Rotation policy — "20 lượt rồi đổi token"
+Broker giữ con trỏ tới token đang-active. Với mỗi lần `checkout`:
+1. Bỏ qua token `status != active` hoặc `cooldown_until > now`.
+2. Cấp token hiện tại; `dwell_turns++`, `window_turns++`.
+3. Khi `dwell_turns >= 20` → advance con trỏ sang token active kế tiếp (round-robin), reset `dwell_turns = 0`.
+4. Nếu lượt trả về **429/limit** → mark token `cooling`, set `cooldown_until`, advance con trỏ ngay và **retry lượt trên token khác** (không tính là hết dwell).
+5. Cửa sổ rate-limit: nếu `now - window_start > 5h` → reset `window_turns`, `window_start = now`.
+
+> Nâng cấp về sau (ghi chú): thay round-robin cứng bằng **least-loaded theo `window_turns`** để rải đều theo cửa sổ 5h của Claude, và **giới hạn concurrency per-token** (không cấp 1 token cho 2 lượt song song) — giảm áp lực limit và độ "lộ".
+
+### 8.3 Broker API (nội bộ, mTLS)
+- `POST /internal/token/checkout {tenant_id, session_id}` → `{token_id, kind, secret}` — lease token đang-active.
+- `POST /internal/token/checkin {token_id, ok, error?, in_tok?, out_tok?}` → cập nhật counter/cooldown.
+- agentd chỉ nhận **1 token đang dùng**, không bao giờ thấy cả pool.
+
+### 8.4 Flow một lượt hỏi đáp
+```
+user msg → agentd
+  → gateway: turn_balance > 0 ?  (không thì báo "hết lượt, nạp thêm")
+  → broker.checkout() → ghi ~/.claude/.credentials.json (hoặc env) trong container
+  → spawn claude -p --resume <session>
+  → trả lời xong:
+      broker.checkin(token_id, ok)         # token.turns_used++, window_turns++
+      metering: turn_ledger(-1, qa_turn)   # trừ số dư tenant
+      tenants.turn_balance--
+```
+**Định nghĩa 1 lượt** = 1 message user → 1 câu trả lời cuối của assistant (bất kể bao nhiêu tool-call bên trong). Đếm khi hoàn tất.
+
+### 8.5 Cảnh báo kỹ thuật (rủi ro triển khai, cần PoC sớm)
+- **Session continuity khi đổi token giữa chừng**: state `--resume` là local, context gửi lại mỗi lượt → *lý thuyết* xoay token vẫn resume được. **Chưa xác nhận** Anthropic không gắn session/thread với account. → PoC bắt buộc trước khi cam kết.
+- **Prompt cache miss**: cache theo từng account. Đổi token = mất cache → **chậm hơn + đốt token/limit nhiều hơn** (dù OAuth không tính tiền theo token, vẫn ăn vào cửa sổ giới hạn).
+- **Ghi credential đua nhau**: nếu nhiều tiến trình trong 1 container hoặc nhiều container dùng chung file credential → race. Giải: mỗi lượt set qua **env riêng cho tiến trình** thay vì sửa file chung, hoặc credential file per-turn.
 
 ## 9. Channels per tenant
 
-**Telegram — BYO bot token (khuyến nghị)**: mỗi tenant tạo bot riêng qua @BotFather (2 phút), dán token vào dashboard → agentd trong container của họ tự long-poll. Ưu điểm: tách hoàn toàn, không cần routing tập trung, đúng mô hình OpenClaw/MyClaw. (Phương án 1-bot-chung route theo `from.ID` bị loại: mọi tenant chung identity bot, rate limit chung, rủi ro route nhầm.)
+- **Telegram — BYO bot token (giữ nguyên khuyến nghị)**: mỗi tenant tạo bot riêng qua @BotFather, dán token → agentd trong container tự long-poll. Vì dịch vụ nay là managed hoàn toàn, có thể **thêm tuỳ chọn "bot dùng chung của platform"** cho khách ngại tạo bot (route theo `from.ID` → tenant), đánh đổi bằng identity bot chung + rate limit Telegram chung. Mặc định vẫn BYO bot.
+- **Dashboard**: login v4 + tenant scoping; gateway proxy WS `wss://bot.bomclaw.org/t/<tenant>/ws` → agentd. Hiển thị **số lượt còn lại**.
 
-**Dashboard**: login đã có (v4) → thêm tenant scoping: user thấy đúng sessions/agent của tenant mình; gateway proxy WS `wss://bot.bomclaw.org/t/<tenant>/ws` → `agentd` container tương ứng. Cookie/session giữ nguyên cơ chế hiện tại.
-
-## 10. Tiers & billing
+## 10. Tiers & billing (bán theo LƯỢT)
 
 | | Starter | Pro | Max |
 |---|---|---|---|
-| Giá tham khảo | $15/th | $35/th | $69/th |
+| Giá tham khảo | $9/th | $19/th | $39/th |
+| **Lượt / tháng** | 300 | 1.000 | 3.000 (hoặc fair-use) |
 | vCPU / RAM | 1 / 2GB | 2 / 4GB | 4 / 8GB |
 | Disk workspace | 20GB | 40GB | 80GB |
-| Sandbox | container | container (gVisor) | microVM |
 | Backup retention | 7 ngày | 30 ngày | 90 ngày |
 | Kênh | Dashboard + Telegram | + WhatsApp/Discord (sau) | + API access |
 
-- Stripe Checkout + webhook → `tenants.tier`, `tenants.status`.
-- Hết hạn thanh toán: `suspended` → stop container (giữ volume), banner trên dashboard; xóa sau 30 ngày.
-- Metering phase đầu: chỉ đo disk + uptime (đủ cho pricing cố định). Token là việc của khách (BYOK).
+- Stripe Checkout + webhook → set `tenants.tier`, nạp `turn_balance` (topup ledger).
+- Hết lượt: agent trả thông báo "hết lượt", nút nạp nhanh trên dashboard. Hết hạn thanh toán: `suspended` → stop container (giữ volume).
+- **Giá phải phủ chi phí subscription pool**: margin = doanh thu − (chi phí N subscription Claude + hạ tầng). Vì OAuth flat-rate nên **không đo được cost/lượt chính xác** → định giá theo lượt là cách chặn abuse; cần theo dõi tỉ lệ lượt-thực/subscription để không lỗ (xem rủi ro §12).
 
 ## 11. Threat model (tóm tắt)
 
 | Mối đe dọa | Đối sách |
 |---|---|
-| Agent escape container (khách chạy code độc trong sandbox của chính họ) | gVisor/microVM, rootfs read-only, no-new-privileges, seccomp, không privileged, user namespace |
-| Cross-tenant: đọc dữ liệu tenant khác | Volume riêng + docker network riêng per tenant; agentd chỉ nhận kết nối từ gateway |
-| Prompt injection đánh cắp secrets | Secrets chỉ tồn tại trong env container của chính tenant; control plane không bao giờ đưa secrets vào prompt |
-| SSRF từ agent vào control plane / metadata | Egress firewall: chặn RFC1918, 169.254.*, mạng docker của control plane |
-| Chiếm control plane | Auth v4 + operator role riêng, audit_log, rate limit, Cloudflare trước mặt |
-| Khách abuse (crypto mining, spam) | CPU/RAM limit theo tier, egress rate limit, ToS + suspend |
+| Agent escape container | gVisor/microVM, rootfs read-only, no-new-privileges, seccomp, non-privileged, user namespace |
+| Cross-tenant đọc dữ liệu | Volume riêng + docker network riêng per tenant; agentd chỉ nhận kết nối từ gateway |
+| **Prompt injection đánh cắp token đang-active** ⚠️ | Chỉ inject token *đang dùng* (không cả pool); token per-turn, thu hồi/rotate nhanh; nhưng **vẫn có thể mất token active** → xem §12 (downgrade so với BYOK) |
+| SSRF vào control plane / metadata | Egress firewall: chặn RFC1918, 169.254.*, mạng docker control plane; broker chỉ nhận từ agentd qua mTLS |
+| Chiếm control plane (lộ cả pool) | Auth v4 + operator role, audit_log, rate limit, Cloudflare; master key mã hóa ngoài DB |
+| Khách abuse (mining/spam) | CPU/RAM limit theo tier, egress rate limit, **giới hạn lượt**, ToS + suspend |
+| **Tài khoản Claude bị ban hàng loạt** ⚠️⚠️ | Xem §12 — rủi ro nền tảng của mô hình, không có đối sách kỹ thuật đáng tin |
 
-## 12. Lộ trình triển khai
+## 12. ⚠️ Rủi ro & điều kiện (ĐỌC KỸ trước khi triển khai)
 
-- **Phase 0 — hoàn thành ✅**: single-tenant + dashboard auth + tunnel public (nền tảng control plane).
-- **Phase 1 — Tenant hóa control plane** (~1 tuần): schema v5 (tenants, agent_instances, credentials, audit), users gắn tenant, dashboard scoping, CLI `bomclaw tenant add/list/suspend`. Agent vẫn chạy như cũ cho tenant đầu tiên (chính bạn).
-- **Phase 2 — Agent runtime container hóa** (~2 tuần): Dockerfile cho `agentd` (bomclaw + claude CLI + node), volume layout §6, Provisioner (docker API: create/start/stop), gateway proxy `/t/<tenant>/`, BYOK flow + mã hóa credentials. Beta trên OrbStack với 2-3 khách tin cậy.
-- **Phase 3 — Thương mại hóa** (~2 tuần): Stripe billing, tier enforcement (cpu/mem/disk limits), backup tự động, trang landing + onboarding self-service (tạo tenant → dán API key → dán bot token → chat).
-- **Phase 4 — Production scale**: chuyển data plane sang server Linux (gVisor), monitoring (uptime per agent, alert), multi-host scheduler khi >50 tenant, cân nhắc Postgres cho control plane.
+Mô hình "pool OAuth token + xoay vòng để bán lượt" mang lại UX tốt nhất cho khách nhưng đặt cược cả dịch vụ vào các rủi ro sau. Ghi lại rõ để team quyết định có chấp nhận không.
 
-## 13. Rủi ro & câu hỏi mở
+**R1 — Vi phạm ToS Anthropic (rủi ro pháp lý, cao).** Token OAuth sinh từ subscription **Pro/Max cá nhân**. Dùng chúng để phục vụ khách trả tiền = gần như chắc chắn vi phạm Consumer Terms / Usage Policy (cấm chia sẻ tài khoản, resell, sub-license). **Cần review pháp lý**; khả năng cao không hợp lệ. (Ngược lại: API key thương mại được phép build sản phẩm phục vụ end-user.)
 
-1. **Máy Mac M1 hiện tại không phải hạ tầng production** — OK cho beta ≤5 khách qua OrbStack; cần server Linux trước khi bán thật. (Chi phí: ~$50/th server đầu tiên ≈ hòa vốn ở 2-3 khách Pro.)
-2. **Anthropic ToS**: BYOK là an toàn; "AI included" cần API key thương mại + kiểm tra kỹ điều khoản resale.
-3. **Claude CLI trong container**: cần image có node + claude CLI; OAuth flow trong container cần web terminal hoặc `claude setup-token` — cần PoC sớm (rủi ro kỹ thuật lớn nhất của Phase 2).
-4. **Support load**: mỗi khách một agent = mỗi khách một kiểu hỏng. Cần log tập trung (đọc được metadata, không đọc nội dung chat — privacy promise).
-5. Mở: có hỗ trợ khách tự host model local (Ollama) không? Có cho phép custom skills/MCP per tenant không (tăng attack surface)?
+**R2 — Ban hàng loạt (rủi ro tồn vong).** Xoay token theo nhịp cố định để né rate-limit là **dấu hiệu vi phạm rõ**, khó biện minh "dùng cá nhân". Anthropic có thể phát hiện qua nhiều account cùng IP/ASN/hạ tầng, pattern rotation đều, usage bất thường, device fingerprint của Claude CLI. Hậu quả: **ban đồng loạt cả pool** → dịch vụ chết trong 1 đêm + mất tiền subscription đã trả trước. **Không có đối sách kỹ thuật đáng tin** cho rủi ro này — đa dạng hóa IP/hạ tầng chỉ khiến hành vi *giống né tránh hơn*, không an toàn hơn.
+
+**R3 — Không đo được cost thật.** OAuth flat-rate → không có `usage` cost/lượt như API. Khó định giá chính xác, dễ lỗ nếu vài khách dùng nặng. Chỉ đếm được *lượt*, không đếm được *token/tiền thật*.
+
+**R4 — Cache miss khi rotate** → chậm + tốn cửa sổ limit (§8.5).
+
+**R5 — Downgrade isolation.** Token pool chảy vào container tenant mỗi lượt. Agent bị prompt-injection có thể exfil **token đang-active** → account đó bị chiếm. BYOK không có vấn đề này (secret là của chính khách).
+
+### Điều kiện nếu vẫn triển khai
+1. **Giới hạn phạm vi**: chỉ beta nội bộ / nhóm tin cậy, **không mở public** cho tới khi có phương án hợp lệ.
+2. **Đường lui bắt buộc (§3.3)**: broker provider-agnostic ngay từ đầu → **swap sang `anthropic_api_key` thương mại** (metering theo token thật, hợp lệ) chỉ bằng đổi `kind`, **không viết lại agent**. Đây là de-risk quan trọng nhất.
+3. **Giới hạn thiệt hại**: không trả trước quá nhiều subscription cùng lúc; chuẩn bị **kill-switch** tắt pool tức thì; theo dõi email/cảnh báo từ Anthropic.
+4. **Review pháp lý** điều khoản resale/AI-included trước khi tính phí khách thật.
+
+> Khuyến nghị kỹ thuật (không phải khuyến nghị kinh doanh): nếu mục tiêu là "khách không nhập key + bán lượt", **API key thương mại + metering token** đạt đúng mục tiêu đó một cách hợp lệ và **đo cost chính xác hơn**. Bản này giữ kiến trúc sao cho chuyển sang hướng đó là một-dòng-config, không phải một-lần-rewrite.
+
+## 13. Lộ trình triển khai
+
+- **Phase 0 — hoàn thành ✅**: single-tenant + dashboard auth + tunnel public.
+- **Phase 1 — Tenant hóa control plane** (~1 tuần): schema v5 (tenants + turn_balance, agent_instances, provider_tokens, turn_ledger, audit), users gắn tenant, dashboard scoping, CLI `bomclaw tenant add/list/suspend`. Agent chạy như cũ cho tenant đầu tiên.
+- **Phase 1.5 — ★ PoC token rotation** (rủi ro cao nhất, làm SỚM): xác nhận (a) xoay OAuth token giữa các lượt vẫn `--resume` được; (b) cache miss impact; (c) hành vi khi 1 token hit limit. Nếu (a) fail → mô hình phải đổi.
+- **Phase 2 — Broker + Metering + container hóa** (~2–3 tuần): Dockerfile `agentd`, volume layout §6, Provisioner, gateway proxy `/t/<tenant>/`, **Token Broker (§8) + turn metering (§8.4)**, admin UI nạp pool token. Beta OrbStack, 2–3 khách tin cậy.
+- **Phase 3 — Thương mại hóa** (~2 tuần): Stripe bán gói lượt, tier enforcement, backup, landing + onboarding self-service (đăng ký → chọn gói → chat, **không nhập key**).
+- **Phase 4 — Production scale**: data plane sang server Linux (gVisor), monitoring per agent, multi-host scheduler khi >50 tenant, cân nhắc Postgres. **Đồng thời chuẩn bị sẵn nhánh API-key hợp lệ (§12.2) để bật khi cần.**
+
+## 14. Câu hỏi mở
+
+1. **PoC rotation (§1.5)** — câu hỏi sống-còn: OAuth có gắn session với account không? Cần trả lời trước mọi thứ khác.
+2. Ngưỡng "20 lượt" là cố định hay adaptive theo cửa sổ 5h của từng token? (Đề xuất: bắt đầu 20 cứng, chuyển least-loaded sau.)
+3. Concurrency per-token: cho phép 1 token phục vụ nhiều tenant song song không? (Đề xuất: giới hạn để giảm áp lực limit + độ lộ.)
+4. Có mở "bot Telegram dùng chung platform" (§9) không, hay bắt buộc BYO bot?
+5. Support load: mỗi khách một agent = mỗi khách một kiểu hỏng. Cần log tập trung (metadata, không đọc nội dung chat — privacy promise).
+6. Mở: cho phép custom skills/MCP per tenant không (tăng attack surface)?
 
 ---
-*Tài liệu này là bản thiết kế để review trước khi bắt đầu Phase 1. Nguồn tham khảo pricing/mô hình: [MyClaw.ai](https://myclaw.ai/), [myclaw.ai/pricing](https://myclaw.ai/pricing), [myclaw.ai/openclaw](https://myclaw.ai/openclaw).*
+*Tài liệu là bản thiết kế để review trước Phase 1. Bản này chọn mô hình "AI included / bán lượt" với pool OAuth xoay vòng — xem §12 về rủi ro. Nguồn tham khảo: [MyClaw.ai](https://myclaw.ai/) (mô hình BYOK đối chiếu), [myclaw.ai/pricing](https://myclaw.ai/pricing).*

--- a/docs/design/browser-control.md
+++ b/docs/design/browser-control.md
@@ -1,0 +1,356 @@
+# Browser Control — Gap Analysis vs OpenClaw & Thiết kế nâng cấp
+
+**Trạng thái**: DRAFT — design only, chưa implement.
+**Ngày**: 2026-07-18
+**Câu hỏi gốc**: BomClaw đã hỗ trợ control browser giống OpenClaw chưa?
+
+**Trả lời ngắn**: **Đã có, ở mức cơ bản (~60%)**. BomClaw có sẵn 12 tool `browser_*`
+chạy trên native CDP (không Playwright). Thiếu so với OpenClaw: security guard
+(SSRF/navigation policy), quản lý tab/dialog/download, profiles, trusted input
+events, và config. **Bug nghiêm trọng nhất: không chạy được trên macOS** —
+`chromePaths` chỉ có đường dẫn Linux, trong khi gateway đang deploy trên macOS.
+
+---
+
+## 1. Bối cảnh & mục tiêu
+
+BomClaw là gateway bridge chat channel (Telegram, CLI) → agent loop → tool
+executor chạy local. Browser control cho phép agent thao tác web thay user:
+đọc trang JS-heavy, điền form, thao tác trên session đã đăng nhập.
+
+OpenClaw (open-source assistant cùng phân khúc) được lấy làm **kiến trúc tham
+chiếu** vì browser tool của nó trưởng thành nhất trong nhóm: profiles cách ly,
+SSRF policy, tab management, dialog/upload/download, extension relay.
+
+Mục tiêu tài liệu này:
+1. Chốt hiện trạng browser control của BomClaw (có gì, thiếu gì — evidence cụ thể).
+2. Gap analysis so với OpenClaw.
+3. Thiết kế phần cần bổ sung, kèm roadmap — **không implement trong scope này**.
+
+---
+
+## 2. Hiện trạng BomClaw (verified 2026-07-18)
+
+### 2.1 Cấu trúc code
+
+```
+internal/browser/
+├── chrome.go       # Launcher: tìm binary, spawn với --remote-debugging-port=9222,
+│                   #   user-data-dir ~/.goterm/browser/user-data, poll CDP ready
+├── cdp.go          # WithCdpSocket: mở WebSocket tới tab, multiplex request/response
+└── operations.go   # Navigate, CaptureScreenshot, EvalJS, SnapshotDOM (ref n1,n2...),
+                    #   Click/Fill/TypeText/SelectOption (JS-injection), Scroll,
+                    #   GetText, GoBack, WaitFor
+
+internal/tools/browser.go   # BrowserTool: EnsureChrome() lazy-launch, Shutdown()
+cmd/bomclaw/main.go:507-519 # Đăng ký 12 tool defs
+cmd/bomclaw/main.go:861-903 # JSON schema cho từng tool
+```
+
+Dependencies: `chromedp/cdproto` (chỉ dùng type/protocol constants), `gorilla/websocket`.
+**Không dùng Playwright, không dùng MCP** — tool chạy in-process trong executor.
+
+### 2.2 Tool đã có (12)
+
+| Tool | Chức năng | Cơ chế |
+|------|-----------|--------|
+| `browser_navigate` | Mở URL, auto-launch Chrome | CDP `Page.navigate` |
+| `browser_snapshot` | DOM tree + element refs (n1, n2…) | JS injection |
+| `browser_click` | Click theo ref | JS `element.click()` |
+| `browser_fill` | Clear + gõ text vào input | JS value setter |
+| `browser_type` | Append text | JS value setter |
+| `browser_select` | Chọn option dropdown | JS |
+| `browser_scroll` | Cuộn trang | JS |
+| `browser_screenshot` | Chụp trang (PNG) | CDP `Page.captureScreenshot` |
+| `browser_get_text` | Lấy text/HTML/value/title/URL | JS |
+| `browser_eval` | Chạy JavaScript tùy ý | CDP `Runtime.evaluate` |
+| `browser_wait` | Chờ ref/text/timeout | Poll JS |
+| `browser_back` | Back history | JS `history.back()` |
+
+### 2.3 Vấn đề đã xác nhận trong code hiện tại
+
+1. **Không chạy trên macOS** — `chrome.go:27-37` chỉ liệt kê
+   `/usr/bin/google-chrome`, `/snap/bin/chromium`… (Linux). Fallback
+   `exec.LookPath("google-chrome")` cũng không match trên macOS
+   (binary nằm ở `/Applications/Google Chrome.app/Contents/MacOS/`).
+   Gateway hiện deploy bằng launchd trên macOS → **browser tools đang chết
+   trên môi trường production chính**.
+2. **CDP port cố định 9222** (`chrome.go:17`) — xung đột nếu user/tool khác
+   đang chạy Chrome debug; hai instance BomClaw không chạy song song được.
+3. **Không có bất kỳ guard nào** — agent có thể navigate tới
+   `http://169.254.169.254/`, `http://localhost:8443` (dashboard/gateway của
+   chính BomClaw), `file://` path. Kết hợp prompt-injection từ nội dung web
+   → SSRF/local access. Nghiêm trọng vì gateway chạy daemon với
+   `--permission-mode bypassPermissions`.
+4. **Interaction bằng JS injection, không phải trusted events** — `element.click()`
+   và value-setter fail trên site check `isTrusted` (nhiều SPA, anti-bot,
+   payment form). OpenClaw/Playwright dùng input events thật.
+5. **Chrome orphan** — `chrome.go:98` set `Setpgid: true` (Chrome tách process
+   group để sống sót khi gateway crash giữa launch), nhưng khi gateway crash
+   thật thì không ai kill Chrome → orphan giữ port 9222, instance mới launch
+   fail. Cùng class bug với orphan Claude CLI đã ghi trong `CLAUDE.md`.
+6. **Screenshot path cố định** `/tmp/browser-screenshot.png`
+   (`internal/tools/browser.go:13`) — hai session chụp cùng lúc ghi đè nhau.
+7. **Không có config** — không tắt được browser, không đổi được binary path,
+   không có headless mode. Chrome luôn mở cửa sổ trên desktop của máy chạy
+   gateway.
+8. **Chỉ thao tác 1 tab** — `PageWsURL()` lấy tab "page" đầu tiên; popup/tab
+   mới do site mở ra là agent mất kiểm soát.
+
+---
+
+## 3. Kiến trúc tham chiếu: OpenClaw browser control
+
+Tóm tắt (nguồn: deepwiki openclaw/openclaw, wiki §3.4.4):
+
+- **Hybrid CDP + Playwright**: CDP cho screenshot/eval/ARIA snapshot;
+  Playwright (connect qua CDP) cho click/type/drag/download — trusted input.
+- **Profiles**: `openclaw` (managed, cách ly khỏi profile cá nhân — mặc định),
+  `user` (attach Chrome đang chạy qua CDP), `chrome` (extension relay),
+  custom `cdpUrl` (browserless/grid). Config `browser.profiles.<name>`.
+- **Tool actions**: navigate/open/focus/close tab; snapshot (AI/ARIA format,
+  `--urls`); screenshot (`--full-page`, `--ref`, `--labels`); click/type/press/
+  hover/drag/select/fill; upload/download/dialog; evaluate (tắt được bằng
+  `browser.evaluateEnabled`); set cookies/storage/timezone/locale/media/offline;
+  resize viewport.
+- **Security**: SSRF policy trên mọi navigation target + CDP endpoint
+  (`browser.ssrfPolicy`: chặn private network mặc định, `hostnameAllowlist`);
+  `navigation-guard` kiểm cả redirect chain; loopback HTTP API có
+  shared-secret auth; sandbox agent mặc định không được control host browser.
+- **Ops**: `doctor` health check, `tabCleanup` tự dọn tab idle,
+  `browser.headless`, `browser.executablePath`.
+- **Exposure**: tool là bundled plugin trong agent loop + standalone loopback
+  HTTP API (opt-in) cho CLI/service khác gọi.
+
+---
+
+## 4. Gap analysis
+
+| Năng lực | OpenClaw | BomClaw | Gap |
+|----------|----------|---------|-----|
+| Launch managed Chrome, profile cách ly | ✅ | ✅ (`~/.goterm/browser/user-data`) | — |
+| Hỗ trợ macOS | ✅ | ❌ Linux-only paths | **P0** |
+| Navigate / snapshot có ref / click / fill / select / scroll / eval / wait / back | ✅ | ✅ | — |
+| Screenshot full-page | ✅ | ✅ | — |
+| SSRF / navigation guard | ✅ policy + redirect check | ❌ | **P0** |
+| Tắt `eval` qua config | ✅ | ❌ | **P0** |
+| Config (enabled/headless/executable_path/port) | ✅ | ❌ hardcode | **P0** |
+| Chrome lifecycle sạch (không orphan, health check) | ✅ doctor | ⚠️ orphan risk | **P1** |
+| Trusted input events (click/type thật) | ✅ Playwright | ❌ JS injection | **P1** |
+| Tab management (list/open/focus/close) | ✅ | ❌ 1 tab | **P1** |
+| Dialog (alert/confirm/prompt) handling | ✅ | ❌ dialog treo là kẹt | **P1** |
+| Download / upload file | ✅ | ❌ | **P2** |
+| Hover / press key / drag | ✅ | ❌ | **P2** |
+| Attach Chrome đang chạy của user (`cdp_url`) | ✅ | ❌ | **P2** |
+| Named profiles nhiều cấu hình | ✅ | ❌ | **P3** |
+| Set cookies / storage / viewport / timezone | ✅ | ❌ | **P3** |
+| Extension relay | ✅ | ❌ | Không làm |
+| Standalone loopback HTTP API | ✅ | ❌ | Không làm |
+| AI-format snapshot / PDF export | ✅ | ❌ | Không làm |
+
+Kết luận: **nền tảng đã tương đương** (managed Chrome + CDP + ref-based
+snapshot/act — đúng mô hình OpenClaw dùng), khác biệt nằm ở **độ an toàn,
+độ tương thích và độ bền vận hành**, không phải ở kiến trúc.
+
+---
+
+## 5. Nguyên tắc thiết kế
+
+1. **Giữ native CDP, không thêm Playwright** — Playwright kéo theo Node runtime
+   hoặc playwright-go (kém maintain); mọi thứ Playwright làm qua CDP thì
+   BomClaw gọi CDP trực tiếp được (Input domain, Target domain, Page domain).
+   Trade-off chấp nhận: tự viết nhiều hơn, không có auto-wait tinh vi.
+2. **Không mở HTTP API riêng cho browser** — tool chạy in-process trong
+   executor, không có consumer thứ hai. YAGNI. (Khác OpenClaw vì OpenClaw có
+   CLI/plugin ecosystem cần gọi từ ngoài.)
+3. **Security mặc định chặt** — gateway chạy daemon không có người ngồi cạnh
+   approve; nội dung web là input không tin được (prompt injection). Mặc định:
+   chặn private network, tắt được eval, allowlist opt-in.
+4. **Config-driven, zero-config vẫn chạy** — không có section `browser:` trong
+   `config.yaml` thì behavior như hiện tại (trừ guard bật mặc định).
+5. **Từng phase độc lập ship được** — không big-bang.
+
+---
+
+## 6. Thiết kế đề xuất
+
+### 6.1 Config schema (mới — `internal/config/config.go`)
+
+```yaml
+browser:
+  enabled: true                # false = không đăng ký browser_* tools
+  executable_path: ""          # override; rỗng = auto-detect
+  headless: false              # true = --headless=new
+  cdp_port: 0                  # 0 = chọn port ephemeral (fix xung đột 9222)
+  attach_url: ""               # CDP URL có sẵn (browserless/Chrome user) — P2
+  eval_enabled: true           # false = bỏ đăng ký browser_eval
+  guard:
+    allow_private_network: false   # chặn RFC1918, loopback, link-local, file://
+    hostname_allowlist: []         # ["*.internal.corp"] — bypass guard có chủ đích
+    hostname_blocklist: []         # chặn thêm ngoài private network
+```
+
+### 6.2 P0.a — macOS support + port động
+
+`FindChrome()` thêm nhánh theo `runtime.GOOS`:
+
+```go
+// darwin
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+"/Applications/Chromium.app/Contents/MacOS/Chromium",
+```
+
+Port: bind `net.Listen("tcp", "127.0.0.1:0")` lấy port trống → đóng → truyền
+vào `--remote-debugging-port`. Lưu port vào struct `Chrome` (đã có field).
+`config.browser.cdp_port != 0` thì dùng giá trị cố định (debug).
+
+### 6.3 P0.b — Navigation guard (SSRF policy)
+
+Module mới `internal/browser/guard.go`:
+
+```
+CheckURL(rawURL, policy) error
+  ├─ scheme ∉ {http, https}         → deny (chặn file://, chrome://, javascript:)
+  ├─ hostname match allowlist        → allow
+  ├─ hostname match blocklist        → deny
+  ├─ resolve DNS → mọi IP là private/loopback/link-local/metadata
+  │    && !allow_private_network     → deny
+  └─ else                            → allow
+```
+
+Điểm hook:
+1. `Navigate()` — check trước khi gửi `Page.navigate`.
+2. **Redirect + client-side navigation**: sau navigate và trước mỗi
+   snapshot/act, đọc URL hiện tại; nếu vi phạm policy → trả lỗi
+   `navigation blocked by guard: <url>` và tự navigate về `about:blank`.
+   (Đơn giản hơn OpenClaw — không chặn realtime từng redirect hop, nhưng chặn
+   được việc agent *thao tác tiếp* trên trang cấm; DNS-rebinding nâng cao ghi
+   nhận ở §8.)
+3. `browser_eval` bị loại khỏi tool list khi `eval_enabled: false` — vì eval
+   là con đường vòng qua guard (`fetch()` trong page context).
+
+### 6.4 P1.a — Lifecycle: hết orphan + doctor
+
+- Ghi PID + port vào `~/.goterm/browser/chrome.json` khi launch. Khi
+  `EnsureChrome()` chạy mà file tồn tại: probe `/json/version` — sống thì
+  **adopt** (reuse) thay vì launch mới; chết thì xóa file, kill PID nếu còn.
+  → gateway restart không tạo orphan, không chết vì port bận.
+- `Shutdown()` kill cả process group (`syscall.Kill(-pgid, SIGTERM)`) — hiện
+  chỉ signal process chính.
+- Thêm reachability check vào lệnh `bomclaw doctor`/status hiện có (nếu có):
+  binary tìm thấy?, CDP reachable?, guard config hợp lệ?
+
+### 6.5 P1.b — Trusted input qua CDP Input domain
+
+Thay JS injection bằng CDP thật cho các action tương tác:
+
+| Action | Hiện tại | Đề xuất |
+|--------|----------|---------|
+| click | `el.click()` | scrollIntoView → `DOM.getBoxModel` lấy tọa độ → `Input.dispatchMouseEvent` (moved, pressed, released) |
+| fill/type | value setter + event giả | focus element → `Input.insertText` / `Input.dispatchKeyEvent` từng phím |
+| press (mới) | — | `Input.dispatchKeyEvent` (Enter, Tab, Escape…) |
+| hover (mới) | — | `Input.dispatchMouseEvent` type=mouseMoved |
+
+Ref resolution giữ nguyên cơ chế snapshot hiện có (map ref → node), chỉ đổi
+tầng thực thi. JS-injection giữ làm fallback khi `getBoxModel` fail
+(element ẩn/0-size).
+
+### 6.6 P1.c — Tab + dialog
+
+- Tool mới `browser_tabs` `{action: list|open|focus|close, url?, tab_id?}` —
+  dùng CDP `Target.getTargets / createTarget / activateTarget / closeTarget`.
+  `Chrome` struct thêm `activeTargetID`; mọi operation route theo target đang
+  focus thay vì "tab page đầu tiên".
+- Dialog: subscribe `Page.javascriptDialogOpening` trên socket; auto-dismiss
+  mặc định + ghi message vào tool result (`[dialog dismissed: "..."]`).
+  Tool mới `browser_dialog` `{action: accept|dismiss, text?}` cho case agent
+  cần accept có chủ đích. → hết deadlock khi site bật `confirm()`.
+
+### 6.7 P2 — Download/upload, attach existing browser
+
+- Download: `Browser.setDownloadBehavior` → thư mục
+  `~/.goterm/browser/downloads/<session>/`; event `Browser.downloadProgress`
+  → tool `browser_download_wait` trả path file.
+- Upload: `DOM.setFileInputFiles` theo ref → tool `browser_upload {ref, paths}`.
+  Chỉ cho phép path trong workspace của session (tránh exfil file hệ thống).
+- `attach_url` trong config: skip launch, connect thẳng CDP URL — dùng được
+  browserless/container hoặc Chrome thật của user (user tự mở với
+  `--remote-debugging-port`). Guard vẫn áp dụng.
+
+### 6.8 P3 — Nice-to-have (chưa cam kết)
+
+Named profiles, set cookies/storage/viewport/timezone, snapshot kèm URL list.
+Chỉ làm khi có use case thật từ vận hành.
+
+### 6.9 Những gì KHÔNG làm theo OpenClaw (quyết định chủ động)
+
+| Thứ OpenClaw có | Lý do bỏ |
+|-----------------|----------|
+| Playwright layer | §5.1 — CDP thuần đủ, tránh dependency nặng |
+| Standalone loopback HTTP API | Không có consumer ngoài executor |
+| Chrome extension relay | Phức tạp cao, use case (điều khiển browser user đang mở khi vắng máy) chưa cần |
+| AI-format snapshot, PDF export | Snapshot ref hiện tại đủ cho agent loop |
+
+---
+
+## 7. Tác động lên multi-tenant (agents-as-a-service)
+
+Design AaaS (xem `docs/design/agents-as-a-service.md`) đặt agent trong
+container per-tenant. Browser control khi đó **không được** dùng Chrome trên
+host: mỗi container tự chạy Chromium headless, hoặc trỏ `attach_url` tới
+browserless pool. Config `browser.attach_url` ở §6.1 chính là điểm nối cho
+hướng này — thiết kế phase 2 nên làm sớm hơn nếu AaaS đi tiếp. Guard private
+network càng bắt buộc trong môi trường multi-tenant (chặn tenant A scan mạng
+nội bộ qua browser của data plane).
+
+---
+
+## 8. ⚠️ Rủi ro & trade-off
+
+1. **Prompt injection qua nội dung web** — trang web độc có thể chứa chỉ thị
+   khiến agent dùng browser_eval/navigate làm việc ngoài ý muốn. Guard giảm
+   blast radius (không vào private network) nhưng **không chặn được** hành vi
+   trên public internet (đăng nhập, gửi form). Trade-off chấp nhận, giống
+   OpenClaw; giảm nhẹ bằng: eval tắt được, audit log tool call đã có transcript.
+2. **DNS rebinding** — guard resolve DNS lúc check, Chrome resolve lại lúc
+   navigate; attacker đổi record ở giữa. Fix triệt để cần proxy toàn bộ traffic
+   (nặng). Ghi nhận là known limitation, mitigate một phần bằng re-check URL
+   sau navigate (§6.3.2).
+3. **Trusted input phức tạp hơn tưởng** — element trong iframe, shadow DOM,
+   element che khuất → tọa độ sai. Giữ JS fallback nghĩa là hai code path
+   phải maintain.
+4. **Adopt-orphan có thể adopt nhầm** Chrome debug của user nếu user tự chạy
+   9222 — vì vậy §6.2 chuyển sang ephemeral port + PID file là điều kiện tiên
+   quyết của §6.4.
+5. **Headless bị nhiều site chặn** (anti-bot) — mặc định giữ headful trên
+   máy có display; headless chỉ là option.
+
+---
+
+## 9. Roadmap
+
+| Phase | Nội dung | Phụ thuộc | Cỡ |
+|-------|----------|-----------|-----|
+| **P0** | macOS paths + ephemeral port (§6.2); config `browser:` (§6.1); navigation guard + eval toggle (§6.3) | — | S–M |
+| **P1** | Lifecycle/orphan + doctor (§6.4); trusted input (§6.5); tabs + dialog (§6.6) | P0 | M |
+| **P2** | Download/upload; `attach_url` (§6.7) | P1 | M |
+| **P3** | Profiles, state mgmt (§6.8) | có use case | — |
+
+P0 là điều kiện để nói "browser control hoạt động và an toàn trên môi trường
+deploy thật"; hiện tại tính năng chỉ chạy đúng trên Linux dev box.
+
+---
+
+## 10. Open questions
+
+1. Guard mặc định `allow_private_network: false` có phá use case nội bộ nào
+   đang dùng không (dashboard localhost, dev server)? → cần quyết trước P0.
+2. Trusted input (§6.5) làm toàn bộ hay chỉ click/fill trước, type/hover sau?
+3. Chrome nên là **một instance dùng chung** mọi session (hiện tại) hay
+   per-session (cách ly cookie giữa các chat)? Per-session sạch hơn nhưng tốn
+   RAM đáng kể trên máy cá nhân.
+4. Screenshot path per-session (`/tmp/browser-screenshot-<session>.png` hoặc
+   vào data dir) — sửa luôn ở P0 hay để P1?
+5. Có cần `browser_snapshot` format gọn hơn cho model nhỏ (token budget) không?

--- a/docs/design/production-hosting.md
+++ b/docs/design/production-hosting.md
@@ -1,0 +1,116 @@
+# Research: Hosting production cho ZeroClaw AaaS (Docker single-node)
+
+**Trạng thái**: RESEARCH — phục vụ quyết định deploy sau này, chưa cam kết.
+**Ngày**: 2026-07-18 (giá tham khảo 07/2026 — thị trường đang biến động vì "RAM crisis",
+Hetzner đã tăng 30–40% trong 2026, netcup cũng tăng; **kiểm tra lại giá khi mua**).
+**Liên quan**: `zeroclaw-docker-aaas.md` (kiến trúc v3 — doc này chọn chỗ đặt nó).
+
+---
+
+## 1. Yêu cầu rút ra từ thiết kế v3
+
+1. **Một VM Linux có Docker daemon do ta toàn quyền** — panel điều khiển `docker.sock`
+   trực tiếp ⇒ loại các PaaS container (Cloud Run, Railway, Render…) vì không cấp Docker
+   API. Ứng viên hợp lệ: VPS / dedicated server / (ngoại lệ có chủ đích: Fly.io Machines,
+   xem §4).
+2. **RAM là tài nguyên quyết định mật độ** (v3 §9): tenant idle ~100–150Mi, Chrome burst
+   0.5–1Gi. Quy đổi thô: **16GB ≈ 50–80 tenant idle / 6–8 phiên browse; 64GB ≈ 250+ tenant
+   idle / ~25 phiên browse**. ⇒ tối ưu **giá/GB RAM**.
+3. **Ổn định > rẻ nhất**: bot chạy 24/7 (Telegram long-poll), downtime là user thấy ngay.
+4. Egress: LLM API + Telegram — vài trăm GB/tháng là nhiều ⇒ hầu hết provider đều thừa,
+   không phải yếu tố quyết định.
+5. Latency: Telegram và LLM API không nhạy latency; chỉ dashboard web là user VN cảm nhận
+   ⇒ region EU chấp nhận được, SG là điểm cộng không bắt buộc.
+6. Ưu tiên có **snapshot/backup + API hạ tầng** (đường lên multi-node sau này panel tự
+   provision).
+7. Deploy production = **đổi máy Mac thành VM Linux, kiến trúc không đổi** (còn bỏ được
+   lớp VM macOS — Docker chạy thẳng trên Linux host).
+
+## 2. Bảng so sánh (giá 07/2026, làm tròn)
+
+| Provider | Gói tiêu biểu | Giá/tháng | €/GB RAM | Ổn định | Region | Ghi chú |
+|----------|---------------|-----------|----------|---------|--------|---------|
+| **netcup** (DE) | RS 2000 G12 — 8 core dedicated / 16GB / 512GB NVMe | **€16.89** | ~1.06 | Tốt (cộng đồng self-host tin dùng từ 2011) | EU (US ít gói) | Rẻ nhất trong nhóm "ổn định"; billing tháng, API/snapshot yếu hơn Hetzner |
+| **Hetzner Cloud** | CX53 — 32GB / shared vCPU | €29.49 | ~0.92 | Rất tốt (VPSBenchmarks A, ISO 27001) | DE/FI (CX/CAX chỉ EU); có SG nhưng giá cao hơn | API + snapshot + backup + hourly billing tốt nhất nhóm; 20TB egress |
+| **Hetzner Cloud ARM** | CAX41 — 16 core Ampere / 32GB | €40.99 | ~1.28 | Rất tốt | EU | ARM: cần kiểm chứng Chromium/pinchtab arm64 (§5.3) |
+| **Hetzner Auction (dedicated)** | vd AX41 cũ — Ryzen 3600 / 64GB / NVMe | **từ ~€30–45** | **~0.5–0.7** | Rất tốt (hardware refurbished, tự quản RAID) | DE/FI | **Best giá/GB khi scale**; không hourly, có setup fee (chính sách 2026) |
+| **Contabo** | ~8–12GB | ~€5–9 | ~0.6–0.8 | **Kém** — uptime 91.1%/quý (Pingoru, Q2/2026), CPU steal 20–40%, VPSBenchmarks F | EU/US/SG | Chỉ cân nhắc cho dev/staging vứt đi được; **loại khỏi production** |
+| **DigitalOcean** | 16GB memory-optimized | ~$84 | ~4.8 | Tốt | có **SGP1** | Đắt 3–5× EU; chỉ khi bắt buộc SG + cần hệ sinh thái DO |
+| **Vultr** | 16GB regular | ~$80–96 | ~4.5–5.5 | Tốt | có SG | Tương tự DO |
+| **Fly.io Machines** | per-machine, tính giây | shared-1x/1GB ≈ $5.7/máy always-on | — | Khá (từng có nhiều incident, free tier đã bỏ) | có SIN | Không phải VPS — xem §4, là phương án kiến trúc riêng |
+| **Oracle Cloud Free** | A1 ARM 4 OCPU / 24GB | $0 | 0 | Rủi ro reclaim/khoá account nổi tiếng | có | Chỉ dùng staging/thí nghiệm, không đặt production trả phí của khách |
+| Cloud VN (Viettel/FPT/VNG) | 16GB | thường ≥ $60–100 | cao | trung bình, tooling yếu | VN | Chỉ khi cần data residency VN hoặc latency dashboard là ưu tiên số 1 |
+
+## 3. Khuyến nghị theo giai đoạn
+
+```
+PoC/P0-P1     : máy Mac hiện tại (đúng thiết kế v3) — $0
+                (+ tuỳ chọn: Oracle free ARM làm môi trường thử Linux)
+                        │
+Production v1 : netcup RS 2000 G12 (€16.89, 16GB, core dedicated)
+(20–60 tenant)  — rẻ nhất trong nhóm ổn định, đủ chỗ cho giai đoạn dò sản phẩm
+                HOẶC Hetzner CX53 (€29.49, 32GB) nếu muốn API/snapshot/hourly
+                và đường tự động hoá hạ tầng đẹp hơn ngay từ đầu
+                        │
+Scale         : Hetzner Auction dedicated 64GB (~€35–45) — giá/GB tốt nhất,
+(100+ tenant)   1 máy gánh ~250 tenant idle; mua máy thứ 2 = HA/DR thủ công
+                        │
+Vượt 1 máy    : quay lại design k8s v2 (multi-node) hoặc phương án Fly (§4)
+```
+
+Lý do chọn **netcup làm production v1**: đúng tiêu chí "giá rẻ + ổn định" nhất bảng —
+core dedicated (không CPU steal như Contabo), reputation tốt, €1.06/GB. Trade-off so với
+Hetzner: không hourly billing, API/snapshot hệ sinh thái mỏng hơn — chấp nhận được vì
+single-node, backup đã tự lo bằng restic (v3 §9). Nếu dự tính chắc chắn sẽ multi-node
+trong ~1 năm thì chọn Hetzner ngay từ đầu để panel dùng một API hạ tầng xuyên suốt.
+
+## 4. Phương án kiến trúc thay thế: Fly.io Machines (ghi nhận, chưa khuyến nghị)
+
+Fly Machines = microVM có REST API tạo/dừng/xoá — về vai trò **tương đương docker.sock
+as-a-service**. Nếu thay adapter bollard bằng Fly Machines API:
+- ✅ Mỗi tenant một **microVM riêng** (Firecracker) — cách ly mạnh hơn hẳn container
+  chung kernel; xoá luôn rủi ro tồn dư §10.3-4 của v3.
+- ✅ Tính tiền theo giây khi máy chạy → hibernate = stop machine = gần như $0/tenant idle
+  → hợp mô hình nhiều tenant ngủ.
+- ❌ Always-on (Telegram long-poll) 1GB ≈ $5.7/máy/tháng → 50 tenant always-on ≈ $285/th,
+  đắt hơn hẳn 1 VPS 64GB. Chỉ rẻ khi chuyển được sang webhook + wake-on-demand (câu hỏi
+  mở #5 của v3).
+- ❌ PinchTab shared + private network nội bộ phải thiết kế lại trên 6PN/WireGuard của Fly.
+- ❌ Lịch sử ổn định của Fly không bằng Hetzner/netcup.
+
+Kết luận: giữ làm **option P3** khi tỷ lệ hibernate cao và cần isolation mạnh hơn; thiết
+kế panel nên tách `trait ContainerRuntime` (bollard | fly) để cửa này không bị đóng.
+
+## 5. Việc cần làm trước khi chốt (checklist mua máy)
+
+1. **Đo lại footprint thật ở P0** trên Mac (RAM idle/burst per tenant) → quy ra cỡ máy.
+2. Kiểm tra lại giá tại thời điểm mua (biến động RAM crisis; Hetzner đã tăng 4 lần trong 2026).
+3. **Nếu cân nhắc ARM (CAX/Oracle A1)**: kiểm chứng multi-arch của cả ba image —
+   zeroclaw (Rust, khả năng cao có arm64), pinchtab (Go, khả năng cao), và **Chromium
+   linux/arm64** (Google Chrome không có bản Linux ARM chính thức — pinchtab phải trỏ
+   `browser.binary` sang Chromium). Nếu lằng nhằng → chọn x86 cho đỡ rủi ro.
+4. Hardening VM khi lên production (ngoài scope v3 vì trước giờ là máy cá nhân):
+   SSH key-only + fail2ban, ufw chỉ mở 443 (D8), unattended-upgrades, Docker daemon
+   không expose TCP, panel :443 sau Caddy/traefik có TLS.
+5. Backup offsite: restic → object storage rẻ (Hetzner Storage Box ~€4/1TB hoặc
+   Backblaze B2) — bổ sung đích backup cho v3 §9.
+6. DR drill: khôi phục toàn bộ từ backup lên máy trống trong < 1 giờ (compose + volumes
+   restore) — single-node không HA, DR là lưới an toàn duy nhất.
+
+## 6. Câu hỏi mở
+
+1. Ngân sách tháng mục tiêu cho hạ tầng là bao nhiêu? (quyết netcup 16GB vs Hetzner 32GB
+   vs auction 64GB ngay từ đầu)
+2. Dashboard latency với user VN có là tiêu chí không? (nếu có: cân Hetzner SG/Vultr SG,
+   chấp nhận đắt hơn; nếu không: EU)
+3. Có yêu cầu data residency (dữ liệu hội thoại của khách VN phải ở VN)? — ảnh hưởng
+   pháp lý nhiều hơn kỹ thuật.
+4. Khi nào cần máy staging riêng thay vì Mac cá nhân? (đề xuất: khi có tenant trả phí
+   đầu tiên)
+
+---
+
+*Nguồn: Hetzner pricing/press (đợt điều chỉnh 15/06/2026), bitdoze/comparedge/betterstack
+tổng hợp giá Hetzner 2026, netcup.com gói RS G12, VPSBenchmarks (Hetzner A / Contabo F,
+CPU steal), DanubeData/Pingoru (uptime Contabo 91.11% Q2/2026), fly.io/docs/about/pricing,
+DigitalOcean pricing SGP. Chi tiết link trong PR/commit message.*

--- a/docs/design/shared-agent-memory.md
+++ b/docs/design/shared-agent-memory.md
@@ -1,0 +1,462 @@
+# Design: Bộ nhớ & điều phối dùng chung cho nhiều agent
+
+> Trạng thái: DRAFT — thiết kế, chưa triển khai.
+> Phạm vi: agent 1 (`bomclaw`, :18789) và agent 2 (`bomclaw2`, :18790) chạy song song trên cùng một máy Mac, cùng user, cùng binary.
+> Mục tiêu cuối: hai agent **thấy chung một bộ nhớ** và **giao việc được cho nhau**, thay vì hai ốc đảo như hôm nay.
+
+---
+
+## 1. Mục tiêu & phi mục tiêu
+
+**Mục tiêu**
+
+1. Một agent ghi nhận điều gì đó (fact, quyết định, kết quả) → agent kia đọc được, không cần copy tay.
+2. Agent A giao việc cho agent B, theo dõi được trạng thái, nhận lại kết quả — có thể kiểm toán.
+3. Không mất tính riêng tư của từng agent: hội thoại Telegram riêng vẫn phải tách bạch.
+4. Sống được với ràng buộc thật: SQLite, hai **tiến trình OS khác nhau**, không có server điều phối.
+
+**Phi mục tiêu (lần này)**
+
+- Không làm multi-tenant / cho thuê (đã có `docs/design/agents-as-a-service.md`).
+- Không làm agent chạy trên nhiều máy — thiết kế này giả định **một máy, một file DB**.
+- Không thay memory markdown bằng vector DB. Semantic search là issue riêng (#13).
+
+---
+
+## 2. Hiện trạng (đã verify 2026-09-05)
+
+| Thành phần | Agent 1 | Agent 2 | Vấn đề |
+|---|---|---|---|
+| DB | `~/.goterm/data/goterm.db` | `~/.goterm2/data/goterm.db` | **Hai file tách rời**, không có đường nào nhìn thấy nhau |
+| Memory | `~/goterm-workspace/{MEMORY.md, memory/*.md}` | `~/goterm-workspace-2/...` | Markdown, ngoài DB, cũng tách rời |
+| Workspace | `~/goterm-workspace` | `~/goterm-workspace-2` | Tách — đúng, giữ nguyên |
+| Kênh agent↔agent | `bomclaw send -addr ws://127.0.0.1:18790/ws "..."` | ngược lại | Có, nhưng **fire-and-forget**: không trạng thái, không kết quả, không retry |
+| Mailbox file | `~/goterm-shared/{mailbox,tasks}` (git repo) | dùng chung | **Rỗng — chưa bao giờ dùng.** Chỉ tồn tại trong system prompt |
+| Định danh agent | không có | không có | DB key theo `chat_id` Telegram, **không có khái niệm `agent_id`** |
+| Backend model | Claude CLI | Claude CLI *(chuyển được sang Codex CLI từ 2026-09-05)* | Đã tách được auth giữa hai agent; phần bộ nhớ/điều phối vẫn chưa chung |
+
+Chi tiết code liên quan:
+
+- `internal/storage/schema.go:5` — `schemaVersion = 4`; bảng: `meta`, `sessions`, `chat_state`, `messages`, `users`, `web_sessions`.
+- `internal/storage/db.go:27` — `sql.Open("sqlite", path)`, driver `modernc.org/sqlite`.
+- `internal/gateway/methods.go:49` — RPC `send` qua WebSocket; đây là kênh đánh thức agent đã có sẵn.
+- `internal/memory/memory.go` — memory là **file markdown trong workspace**, không nằm trong SQLite.
+
+**Kết luận hiện trạng**: không phải "thiếu tính năng chia sẻ" mà là **thiếu hẳn lớp mô hình dữ liệu chung**. Không có `agent_id`, không có task, không có inbox. Cái đã có (`send`, `~/goterm-shared`) là kênh truyền tin trần, không phải giao thức.
+
+---
+
+## 3. Khảo sát thiết kế tham khảo
+
+### 3.1 Blackboard (bảng đen)
+
+Kho dữ liệu trung tâm; agent đăng kết quả trung gian lên đó, các agent khác quan sát và tự quyết định khi nào đóng góp dựa trên năng lực của mình. Đây là mô hình cổ điển (HEARSAY-II) đang được dùng lại cho LLM agent.
+
+- [`claudioed/agent-blackboard`](https://github.com/claudioed/agent-blackboard) — 9 agent chuyên biệt phối hợp qua blackboard dùng chung. Đáng chú ý: **backend mặc định là SQLite** (`BLACKBOARD_PERSISTENCE=sqlite`, `BLACKBOARD_DB_PATH=./data/blackboard.db`) — đúng bối cảnh của ta. Điểm yếu của repo này: dựa vào một "Coordinator" phân việc, **không mô tả cơ chế claim chống trùng** — phần đó ta phải tự thiết kế (§7).
+- [Exploring Advanced LLM Multi-Agent Systems Based on Blackboard Architecture (arXiv 2507.01701)](https://arxiv.org/pdf/2507.01701).
+
+**Rút ra**: blackboard hợp với ta vì hai agent **ngang hàng**, không có ai là orchestrator. Nhưng blackboard thuần (ai cũng đọc, ai cũng ghi) sẽ đẻ ra làm-trùng-việc nếu không có claim.
+
+### 3.2 A2A (Agent2Agent) — vòng đời task
+
+[Spec A2A](https://a2a-protocol.org/latest/specification/) (Google, 2025, nay thuộc Linux Foundation) định nghĩa 8 trạng thái task:
+
+`submitted` → `working` → `completed` | `failed` | `canceled` | `rejected`, cộng hai trạng thái gián đoạn `input-required` và `auth-required`.
+
+Đối tượng lõi: **Task** (id, contextId, status, artifacts, history), **Message** (role user/agent, parts), **Part** (text/file/data), **Artifact** (kết quả), **AgentCard** (mô tả năng lực + endpoint).
+
+**Rút ra**: lấy nguyên **bộ tên trạng thái** và cặp `Task`/`Artifact`. Không lấy transport (JSON-RPC over HTTP + SSE) — ta đã có WebSocket nội bộ, thêm HTTP server nữa là thừa. `AgentCard` rút gọn thành bảng `agents`.
+
+### 3.3 Letta / MemGPT — shared memory blocks
+
+[Letta](https://github.com/letta-ai/letta) cho phép **gắn một memory block vào nhiều agent**: mọi agent gắn block đó đều đọc/ghi được, tạo thành workspace chung. Hai chi tiết quan trọng:
+
+- Với hệ nhiều agent, **`memory_insert` (append) an toàn hơn `memory_replace`**: nhiều agent chèn đồng thời không đụng nhau, còn replace thì ghi đè lẫn nhau.
+- Letta có sẵn tool giao tiếp: `send_message_to_agent_async` (bắn đi, không chờ) và `send_message_to_agent_and_wait_for_reply` (đồng bộ).
+
+Xem thêm [Shared memory blocks | Letta Docs](https://docs.letta.com/tutorials/shared-memory-blocks/) và issue [GNAP: git-native coordination](https://github.com/letta-ai/letta/issues/3226) — tách bạch **coordination state** (git board dùng chung) khỏi **cognitive state** (memory riêng từng agent). Đây chính là ranh giới ta cần.
+
+**Rút ra**: (1) bộ nhớ chung phải **append-only** ở tầng ghi, việc "gọn hoá" là một bước riêng có chủ đích; (2) tách coordination state khỏi memory.
+
+### 3.4 SQLite làm hàng đợi — claim/lease
+
+- [Building a Durable Message Queue on SQLite for AI Agent Orchestration](https://dev.to/minnzen/building-a-durable-message-queue-on-sqlite-for-ai-agent-orchestration-335m) — schema và câu SQL claim nguyên tử:
+
+  ```sql
+  update sqliteq
+  set timeout = ?, received = received + 1
+  where id = (
+    select id from sqliteq
+    where queue = ? and ? >= timeout and received < ?
+    order by priority desc, created
+    limit 1
+  )
+  returning id, body, received
+  ```
+
+  Ý chính: **`timeout` chính là trạng thái**. Quá khứ = rảnh, tương lai = đang bị giữ. Worker chết → lease hết hạn → job tự quay lại hàng đợi. Cột `received` làm **fencing token**: `DELETE ... WHERE id=? AND received=?` — nếu job đã bị giao lại cho worker khác thì `received` lệch, DELETE trúng 0 dòng.
+
+- [`litements/litequeue`](https://github.com/litements/litequeue), [`bewt85/jobqueue`](https://github.com/bewt85/jobqueue) — cùng họ.
+
+**Rút ra**: lấy nguyên mô hình lease + fencing. Đây là phần blackboard thiếu.
+
+### 3.5 LangGraph — checkpointer vs store
+
+[LangGraph persistence](https://docs.langchain.com/oss/python/langgraph/persistence) tách hai thứ: **checkpointer** giữ state của một thread (ngắn hạn), **store** giữ dữ liệu bền vượt qua mọi thread (dài hạn), tổ chức theo namespace/key.
+
+**Rút ra**: ánh xạ thẳng vào ta — `sessions`/`messages` hiện tại **là** checkpointer (per-chat); cái đang thiếu là **store** dùng chung.
+
+### 3.6 Bảng tổng hợp
+
+| Nguồn | Lấy gì | Bỏ gì |
+|---|---|---|
+| Blackboard | Không gian chung, agent ngang hàng, backend SQLite | Coordinator tập trung |
+| A2A | Tên trạng thái task, cặp Task/Artifact, AgentCard | JSON-RPC/HTTP/SSE transport |
+| Letta | Shared block, ghi append-only, tách coordination/cognitive | Server Letta, mô hình agent |
+| SQLite queue | Claim nguyên tử, lease, fencing token | Dead-letter phức tạp |
+| LangGraph | Tách checkpointer (đã có) / store (cần thêm) | Toàn bộ runtime graph |
+
+---
+
+## 4. Nguyên tắc thiết kế
+
+1. **Một file DB, ba vùng.** Riêng tư (per-agent) / điều phối (tasks, inbox) / tri thức chung (shared notes). Ranh giới bằng `agent_id` + `scope`, không bằng file.
+2. **Append-only ở tầng ghi.** Không agent nào được `UPDATE` đè một fact của agent khác. Sửa = ghi bản mới + đánh dấu bản cũ `superseded_by`.
+3. **Không có orchestrator.** Hai agent ngang hàng. Việc được **claim**, không được **assign cứng** — trừ khi chỉ đích danh.
+4. **Mọi giao việc phải có lease.** Agent chết giữa chừng là chuyện bình thường (launchd restart, OAuth hết hạn, TCC dialog). Việc phải tự quay lại hàng đợi.
+5. **DB là nguồn sự thật, WebSocket chỉ là chuông báo.** Mất gói tin `send` không được làm mất việc — agent phải tìm lại được việc bằng cách quét DB.
+6. **Idempotent.** Lease hết hạn → giao lại → có thể chạy hai lần. Handler phải chịu được.
+
+---
+
+## 5. Kiến trúc đề xuất
+
+```
+                 ┌──────────────────────── goterm.db (MỘT file, WAL) ─────────────────────────┐
+                 │                                                                            │
+  agent 1        │  VÙNG RIÊNG                VÙNG ĐIỀU PHỐI            VÙNG TRI THỨC CHUNG    │        agent 2
+ (:18789)        │  sessions                  agents                    shared_notes           │       (:18790)
+    │            │  chat_state                tasks                     note_links             │           │
+    ├── đọc/ghi ─┤  messages                  task_events                                      ├─ đọc/ghi ─┤
+    │  (agent_id)│  (lọc theo agent_id)       agent_messages                                   │ (agent_id)│
+    │            │                                                                             │           │
+    └────────────┴─────────────────────────────────────────────────────────────────────────────┴───────────┘
+           │                                                                                        │
+           └───────────── chuông báo: RPC `send` qua ws://127.0.0.1:1879x/ws ────────────────────────┘
+                          (chỉ để đánh thức; nội dung thật nằm trong DB)
+```
+
+**Vùng riêng** — `sessions`, `chat_state`, `messages` giữ nguyên schema, chỉ thêm cột `agent_id`. Mỗi agent chỉ query dòng của mình. Đây là "checkpointer" theo cách gọi của LangGraph.
+
+**Vùng điều phối** — task + inbox. Đây là chỗ hai agent giao việc. Tương đương "git board" của GNAP.
+
+**Vùng tri thức chung** — `shared_notes`: fact/quyết định/kết quả mà cả hai cùng đọc. Tương đương shared memory block của Letta, và là "store" của LangGraph. *(Chưa làm — P3.)*
+
+**Vùng quan sát** *(thêm khi triển khai, 2026-09-05)* — bảng `runs`: cây trace theo mô hình LangSmith. Một lượt = root run, mỗi lời gọi model = con, mỗi tool model chạy = con của nó. `dotted_order` mang toàn bộ ancestry nên cả cây lấy về đúng thứ tự lồng bằng một truy vấn có index. Ghi bất đồng bộ, được phép rơi khi queue đầy — tracing không bao giờ được là lý do một lượt chậm đi hay hỏng.
+
+---
+
+## 6. Schema đề xuất (schema v5)
+
+```sql
+-- ── Định danh agent (AgentCard rút gọn) ────────────────────────────────
+CREATE TABLE agents (
+  id           TEXT PRIMARY KEY,          -- 'bomclaw', 'bomclaw2'
+  display_name TEXT NOT NULL,
+  ws_addr      TEXT NOT NULL,             -- ws://127.0.0.1:18789/ws
+  workspace    TEXT NOT NULL,
+  skills       TEXT DEFAULT '',           -- JSON array, để routing sau này
+  last_seen_at TEXT NOT NULL,             -- heartbeat, dùng để phát hiện agent chết
+  created_at   TEXT NOT NULL
+);
+
+-- ── Giao việc ──────────────────────────────────────────────────────────
+CREATE TABLE tasks (
+  id            TEXT PRIMARY KEY,         -- 't_' || hex(randomblob(16))
+  context_id    TEXT NOT NULL,            -- gom nhiều task cùng một luồng việc (A2A contextId)
+  created_by    TEXT NOT NULL REFERENCES agents(id),
+  assigned_to   TEXT REFERENCES agents(id),   -- NULL = ai claim cũng được
+  claimed_by    TEXT REFERENCES agents(id),   -- ai đang thực sự giữ
+  state         TEXT NOT NULL DEFAULT 'submitted',
+                -- submitted|working|completed|failed|canceled|rejected|input-required
+  priority      INTEGER NOT NULL DEFAULT 0,
+  title         TEXT NOT NULL,
+  body          TEXT NOT NULL,            -- mô tả việc, markdown
+  result        TEXT DEFAULT '',          -- artifact: kết quả trả về
+  lease_until   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ')),
+                -- quá khứ = rảnh, tương lai = đang bị giữ
+  attempts      INTEGER NOT NULL DEFAULT 0,   -- fencing token + đếm lần giao
+  max_attempts  INTEGER NOT NULL DEFAULT 3,
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_tasks_claimable ON tasks(state, lease_until, priority DESC, created_at);
+CREATE INDEX idx_tasks_context   ON tasks(context_id);
+
+-- ── Nhật ký task (audit, không bao giờ sửa) ─────────────────────────────
+CREATE TABLE task_events (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id    TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  agent_id   TEXT NOT NULL,
+  from_state TEXT DEFAULT '',
+  to_state   TEXT NOT NULL,
+  note       TEXT DEFAULT '',
+  created_at TEXT NOT NULL
+) STRICT;
+
+-- ── Hòm thư (tin nhắn không phải là việc) ───────────────────────────────
+CREATE TABLE agent_messages (
+  id          TEXT PRIMARY KEY,
+  from_agent  TEXT NOT NULL REFERENCES agents(id),
+  to_agent    TEXT NOT NULL REFERENCES agents(id),
+  task_id     TEXT REFERENCES tasks(id) ON DELETE SET NULL,  -- NULL = chat thuần
+  body        TEXT NOT NULL,
+  read_at     TEXT DEFAULT '',
+  created_at  TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_msgs_unread ON agent_messages(to_agent, read_at, created_at);
+
+-- ── Tri thức dùng chung (append-only) ───────────────────────────────────
+CREATE TABLE shared_notes (
+  id            TEXT PRIMARY KEY,
+  author        TEXT NOT NULL REFERENCES agents(id),
+  scope         TEXT NOT NULL DEFAULT 'shared',   -- 'shared' | agent_id (riêng)
+  kind          TEXT NOT NULL,   -- 'fact' | 'decision' | 'result' | 'gotcha'
+  title         TEXT NOT NULL,
+  body          TEXT NOT NULL,
+  tags          TEXT DEFAULT '',                  -- JSON array
+  superseded_by TEXT REFERENCES shared_notes(id), -- sửa = ghi bản mới, trỏ ngược
+  created_at    TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_notes_live ON shared_notes(scope, superseded_by, created_at DESC);
+CREATE VIRTUAL TABLE shared_notes_fts USING fts5(
+  title, body, content='shared_notes', content_rowid='rowid'
+);
+```
+
+Vùng riêng chỉ cần thêm một cột:
+
+```sql
+ALTER TABLE sessions   ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'bomclaw';
+ALTER TABLE chat_state ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'bomclaw';
+```
+
+> Vì sao `superseded_by` chứ không `UPDATE`: hai agent cùng sửa một note sẽ ghi đè lẫn nhau âm thầm. Append + trỏ ngược giữ được cả lịch sử lẫn khả năng đọc "bản mới nhất" (`WHERE superseded_by IS NULL`). Đúng lý do Letta khuyên `memory_insert` thay vì `memory_replace`.
+
+---
+
+## 7. Giao thức giao việc
+
+### 7.1 Claim nguyên tử
+
+Một câu, không có khoảng hở SELECT-rồi-UPDATE:
+
+```sql
+UPDATE tasks
+SET    state       = 'working',
+       claimed_by  = :me,
+       lease_until = :now_plus_10min,
+       attempts    = attempts + 1,
+       updated_at  = :now
+WHERE  id = (
+         SELECT id FROM tasks
+         WHERE  state IN ('submitted', 'working')
+           AND  :now >= lease_until              -- rảnh, hoặc lease đã chết
+           AND  attempts < max_attempts
+           AND  (assigned_to IS NULL OR assigned_to = :me)
+         ORDER  BY priority DESC, created_at
+         LIMIT  1
+       )
+RETURNING id, title, body, attempts;
+```
+
+Bọc trong `BEGIN IMMEDIATE` để giành write-lock **trước khi** subquery chạy.
+
+### 7.2 Lease và agent chết
+
+- Agent giữ task phải **gia hạn lease** định kỳ (mỗi 2 phút, hạn 10 phút) trong lúc chạy.
+- Agent chết (launchd restart, OAuth hết hạn, TCC dialog treo) → không gia hạn → `lease_until` thành quá khứ → agent kia claim lại được.
+- `attempts` là fencing token. Khi agent xong việc:
+
+  ```sql
+  UPDATE tasks SET state='completed', result=:artifact, updated_at=:now
+  WHERE id=:id AND claimed_by=:me AND attempts=:attempts_luc_claim;
+  ```
+
+  Trúng 0 dòng ⇒ task đã bị giao cho agent khác trong lúc mình chạy ⇒ **vứt kết quả đi, ghi `task_events`**, đừng ghi đè.
+
+- Quá `max_attempts` → để nguyên ở `submitted` nhưng không claim được nữa (dead-letter mềm), hiện lên dashboard cho người xử lý.
+
+### 7.3 Vòng đời
+
+```
+submitted ──claim──> working ──done──> completed
+    ▲                   │
+    │                   ├──error────> failed
+    └──lease hết hạn────┤
+                        ├──cần người─> input-required
+                        └──từ chối───> rejected
+```
+
+`canceled` đến từ người dùng qua dashboard/Telegram, chấp nhận ở mọi trạng thái chưa kết thúc.
+
+---
+
+## 8. Đồng thời trên SQLite đa tiến trình — RỦI RO ĐÃ XÁC MINH
+
+Đây là phần dễ làm hỏng nhất, vì **hai tiến trình OS khác nhau** cùng mở một file. Ba vấn đề, đã kiểm chứng trên chính repo này:
+
+### 8.1 Pragma đang bị áp sai chỗ — phải sửa trước
+
+`internal/storage/db.go:33-42` chạy pragma qua `conn.Exec(...)` trên `*sql.DB`, mà `*sql.DB` là **pool**, không phải một connection:
+
+```go
+conn, err := sql.Open("sqlite", path)
+for _, pragma := range []string{
+    "PRAGMA journal_mode=WAL",
+    "PRAGMA busy_timeout=5000",
+    "PRAGMA foreign_keys=ON",
+    "PRAGMA synchronous=NORMAL",
+} {
+    if _, err := conn.Exec(pragma); err != nil { ... }
+}
+```
+
+`journal_mode=WAL` **ghi vào header file DB** nên bền vững — cái này may mắn đúng. Ba pragma còn lại là **per-connection**: chúng chỉ dính vào đúng connection đầu tiên trong pool. Mọi connection mà `database/sql` mở thêm sau đó sẽ có `busy_timeout = 0` → gặp tranh chấp là trả `SQLITE_BUSY` **ngay lập tức**, không chờ. Với một agent một file thì hiếm khi lộ; với hai agent một file thì đây là lỗi thường trực.
+
+**Sửa**: đưa pragma vào DSN để mọi connection đều nhận:
+
+```go
+dsn := "file:" + path +
+    "?_pragma=busy_timeout(10000)" +
+    "&_pragma=journal_mode(WAL)" +
+    "&_pragma=foreign_keys(1)" +
+    "&_pragma=synchronous(NORMAL)"
+conn, _ := sql.Open("sqlite", dsn)
+```
+
+### 8.2 Chỉ một writer tại một thời điểm
+
+WAL cho phép nhiều reader song song **với** một writer, nhưng vẫn **chỉ một writer**. Hai gateway ghi cùng lúc là chuyện chắc chắn xảy ra. Biện pháp:
+
+- `busy_timeout` đủ dài (10s) — writer thứ hai chờ thay vì lỗi.
+- Transaction ghi phải **ngắn**. Tuyệt đối không giữ transaction mở trong lúc gọi Claude CLI (subprocess sống hàng chục giây).
+- Dùng `BEGIN IMMEDIATE` cho mọi transaction có ghi, để giành lock ngay từ đầu thay vì bị nâng cấp lock giữa chừng rồi deadlock.
+- Cân nhắc `SetMaxOpenConns(1)` cho **connection ghi** (hiện tại chưa set gì cả) và một pool riêng chỉ đọc.
+
+### 8.3 Rủi ro riêng của driver
+
+Repo dùng `modernc.org/sqlite v1.48.2` (pure-Go). Có báo cáo `SQLITE_BUSY` khi SELECT đồng thời ở WAL mode với driver này, trong khi `mattn/go-sqlite3` không gặp — xem [cznic/sqlite issue #115](https://gitlab.com/cznic/sqlite/-/issues/115).
+
+**Việc phải làm trước khi chốt**: viết một test tải hai tiến trình (không phải hai goroutine) cùng ghi `tasks` và `shared_notes` trong 60 giây, đếm `SQLITE_BUSY`. Nếu driver không chịu nổi, hai lối thoát:
+- (a) đổi sang `mattn/go-sqlite3` (kéo theo cgo — cân nhắc với việc code-sign hiện tại);
+- (b) mọi ghi vào vùng chung đi qua **một** tiến trình (agent 1 làm chủ file, agent 2 ghi qua RPC). Mất tính đối xứng nhưng loại bỏ hẳn tranh chấp ghi.
+
+> Đây là câu hỏi mở lớn nhất của thiết kế. Không nên viết code schema trước khi đo xong.
+
+---
+
+## 9. Đánh thức agent
+
+Nguyên tắc §4.5: DB là sự thật, WebSocket chỉ là chuông.
+
+1. Agent A tạo task → commit vào DB.
+2. Agent A gọi RPC `send` tới `ws://127.0.0.1:18790/ws` với nội dung ngắn: *"Có task mới `t_abc`, kiểm tra hàng đợi."* (`internal/gateway/methods.go:49`, đã có sẵn).
+3. Agent B nhận, quét hàng đợi, claim.
+4. **Nếu bước 2 thất bại** (agent B đang tắt, mất gói) — không sao: agent B có **vòng quét định kỳ** (60s) tự tìm task chưa claim.
+
+Vòng quét là thứ làm hệ thống bền, `send` chỉ làm nó nhanh. Không được thiết kế ngược lại.
+
+Heartbeat: mỗi agent cập nhật `agents.last_seen_at` mỗi 30s. Agent quá 5 phút không heartbeat được coi là chết — dashboard hiện đỏ, và task `assigned_to` đích danh nó được nới thành `NULL` để agent kia gánh.
+
+---
+
+## 10. Tool cho agent
+
+Agent chạy qua Claude CLI với `bypassPermissions`, nên cách rẻ nhất và không cần đụng vào tool loop: **thêm subcommand cho `bomclaw`**, rồi dạy agent gọi chúng trong system prompt (giống cách `bomclaw send` đang được dạy hôm nay).
+
+```
+bomclaw task new    --title T --body B [--to bomclaw2] [--priority N]  → in ra task id
+bomclaw task claim  [--id ID]                                          → claim, in ra việc
+bomclaw task done   --id ID --result R
+bomclaw task fail   --id ID --reason R
+bomclaw task list   [--state working] [--mine]
+bomclaw inbox       [--unread]
+bomclaw note add    --kind fact --title T --body B [--tags a,b]
+bomclaw note search "query"                                            → FTS5
+```
+
+Ưu điểm: không phải sửa `internal/agent` tool loop, dùng lại được cho cả provider Claude lẫn Codex sau này, và người dùng cũng gõ tay được để debug.
+
+---
+
+## 11. Bộ nhớ markdown dùng chung
+
+Hôm nay memory là file markdown trong workspace riêng (`internal/memory/memory.go`), không nằm trong DB. Không nên bê hết vào SQLite — markdown đang chạy tốt và Claude đọc file dễ hơn đọc DB.
+
+Đề xuất **hai tầng**:
+
+| Tầng | Nơi ở | Ai ghi | Dùng cho |
+|---|---|---|---|
+| Riêng | `~/goterm-workspace{,-2}/MEMORY.md` + `memory/*.md` | agent sở hữu | Thói quen, ngữ cảnh hội thoại riêng — giữ nguyên như hiện tại |
+| Chung | bảng `shared_notes` + `~/goterm-shared/NOTES.md` (render ra) | cả hai, append-only | Fact, quyết định, kết quả, cạm bẫy đã gặp |
+
+`~/goterm-shared/NOTES.md` là **bản render một chiều** từ `shared_notes` (chạy sau mỗi lần ghi), để agent đọc bằng file tool quen thuộc mà không phải query SQL. Nguồn sự thật vẫn là DB — không bao giờ sửa tay file render.
+
+Việc "gọn hoá" (dồn nhiều note vụn thành một note tốt, đánh `superseded_by`) là một **task định kỳ** trong chính hệ thống task ở trên, không phải một hàm chạy ngầm.
+
+---
+
+## 12. Lộ trình
+
+> **Cập nhật 2026-09-05** — P0, P2, P3 và P4 đã làm (PR #66–#70). **P1 (gộp bảng session vào một DB) vẫn chưa** và có thể không cần nữa: vùng điều phối đã tách sang file riêng `~/.goterm-shared/data/coord.db` và giải quyết được toàn bộ nhu cầu "hai agent thấy chung", mà không phải đụng vào bảng session vốn gánh lượng ghi lớn. Nếu chốt bỏ P1 thì cũng bỏ luôn việc đổi tên `claude_session_id` → `provider_session_id` (§13 Q1) vì lý do duy nhất để đổi là gộp bảng.
+>
+> Chạy thật đã lộ ra hai lỗi mà bản thiết kế không lường: gateway không export `BOMCLAW_AGENT_ID` nên CLI ghi nhầm danh tính agent (fencing token chặn được hỏng dữ liệu — xem §7.2), và binary `bomclaw` không nằm trong PATH của launchd nên agent gọi lệnh không được. Cả hai đã sửa (PR #70) và ghi vào NOTES.md.
+
+| Giai đoạn | Nội dung | Điều kiện hoàn thành |
+|---|---|---|
+| ~~**P0 — Đo trước**~~ ✅ | Test tải hai tiến trình ghi đồng thời; sửa pragma DSN (§8.1) | **Xong.** `TestTwoProcessesShareTheDatabase` re-exec test binary thành tiến trình OS thứ hai cùng ghi một file — **pass**, không có `SQLITE_BUSY`. `modernc.org/sqlite` chịu được, **không cần đổi driver**. Pragma đã chuyển vào DSN |
+| **P1 — Nền** | Gộp về một file DB `~/.goterm/data/goterm.db`; schema v5; thêm `agent_id` vào `sessions`/`chat_state`; migrate DB agent 2 vào | Hai agent chạy chung file, hội thoại vẫn tách bạch, không mất lịch sử |
+| ~~**P2 — Giao việc**~~ ✅ | Bảng `tasks`/`task_events`/`agent_messages`; claim+lease+fencing; `bomclaw task/inbox/msg`; heartbeat; vòng quét 60s + chuông `tasks.poke` | **Xong (PR #69).** `tasks.auto_claim` mặc định TẮT — task được claim chạy với đúng quyền truy cập máy của backend chat, không ai giám sát |
+| ~~**P3 — Tri thức chung**~~ ✅ | `shared_notes` + FTS5; `bomclaw note *`; render `NOTES.md`; đưa vào system prompt | **Xong (PR #69).** Append-only, sửa bằng `--supersedes`. Pane Notes trên dashboard |
+| ~~**P4 — Nhìn thấy**~~ ✅ | Tab Admin: Overview / Traces (waterfall) / Tasks / Messages; trạng thái agent theo heartbeat | **Xong.** Thêm cả tầng trace kiểu LangSmith mà bản thiết kế đầu chưa có |
+
+P1 phụ thuộc P0. Không đảo thứ tự.
+
+---
+
+## 13. Rủi ro & câu hỏi mở
+
+| Rủi ro | Mức | Xử lý |
+|---|---|---|
+| `modernc.org/sqlite` không chịu nổi hai tiến trình ghi | **Cao** | P0 phải đo. Lối thoát: đổi driver, hoặc một-writer qua RPC (§8.3) |
+| Hai agent giao việc qua lại vô hạn (ping-pong) | **Cao** | Giới hạn độ sâu: task có `context_id`, chặn khi một `context_id` sinh quá N task; system prompt cấm tự khởi tạo vòng lặp (đã có sẵn dòng này) |
+| Gộp DB làm lộ hội thoại giữa hai agent | Trung bình | Mọi truy vấn vùng riêng bắt buộc lọc `agent_id`; viết test khẳng định agent 2 không đọc được `messages` của agent 1 |
+| Migrate làm mất lịch sử chat agent 2 | Trung bình | Migrate là copy có kiểm chứng số dòng, giữ file cũ; chỉ xoá sau khi chạy ổn 1 tuần |
+| Task chạy hai lần do lease hết hạn | Thấp | Fencing `attempts` (§7.2) + yêu cầu handler idempotent |
+| `shared_notes` phình to, nhiễu | Thấp | Task gọn hoá định kỳ; `superseded_by` giữ bản mới nhất |
+
+**Câu hỏi mở**
+
+1. ~~**Agent 2 chạy Claude hay Codex?**~~ **Đã chốt (2026-09-05)**: backend chọn bằng `provider: claude|codex` trong config; schema v5 thêm cột `sessions.provider` ghi nhận CLI nào tạo ra session id, nên đổi backend sẽ mở thread mới thay vì resume nhầm. Cột `claude_session_id` **chưa** đổi tên thành `provider_session_id` — nó xuất hiện trong JSON của gateway RPC và trong `dashboard/src/stores/store.ts`, nên việc đổi tên gộp vào đợt migrate P1 cho khỏi phá wire format hai lần. Ràng buộc kèm theo: agent chạy Codex phải trỏ vào model có `api: codex-cli` (hiện chỉ `gpt-6-astra` được tài khoản ChatGPT chấp nhận).
+2. **Có cho agent tự tạo task cho chính mình không?** Tiện cho việc dài hơi, nhưng là mầm của vòng lặp vô hạn. Nghiêng về: có, nhưng chặn độ sâu theo `context_id`.
+3. **Ai sở hữu file DB khi cả hai cùng ghi?** Nếu P0 cho kết quả xấu, phải chọn agent 1 làm chủ — mất tính đối xứng, cần quyết định sớm vì ảnh hưởng toàn bộ tool surface §10.
+4. **`~/goterm-shared` git repo giữ hay bỏ?** Hiện rỗng. Nếu `shared_notes` thay được vai trò của nó thì bỏ để đỡ hai nguồn sự thật; nếu giữ thì chỉ dùng để chứa **code/patch** trao đổi, không chứa tri thức.
+
+---
+
+## Tham khảo
+
+- [Agent2Agent (A2A) Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- [claudioed/agent-blackboard](https://github.com/claudioed/agent-blackboard) — blackboard đa agent, backend SQLite
+- [Exploring Advanced LLM Multi-Agent Systems Based on Blackboard Architecture (arXiv 2507.01701)](https://arxiv.org/pdf/2507.01701)
+- [letta-ai/letta](https://github.com/letta-ai/letta) · [Shared memory blocks](https://docs.letta.com/tutorials/shared-memory-blocks/) · [GNAP: git-native coordination (issue #3226)](https://github.com/letta-ai/letta/issues/3226)
+- [Building a Durable Message Queue on SQLite for AI Agent Orchestration](https://dev.to/minnzen/building-a-durable-message-queue-on-sqlite-for-ai-agent-orchestration-335m)
+- [litements/litequeue](https://github.com/litements/litequeue) · [bewt85/jobqueue](https://github.com/bewt85/jobqueue)
+- [LangGraph Persistence — checkpointer vs store](https://docs.langchain.com/oss/python/langgraph/persistence)
+- [SQLite: Write-Ahead Logging](https://www.sqlite.org/wal.html) · [SQLite concurrent writes and "database is locked" errors](https://tenthousandmeters.com/blog/sqlite-concurrent-writes-and-database-is-locked-errors/)
+- [cznic/sqlite issue #115 — SQLITE_BUSY on concurrent SELECT in WAL](https://gitlab.com/cznic/sqlite/-/issues/115)
+- [sqliteai/sqlite-memory](https://github.com/sqliteai/sqlite-memory) · [akitaonrails/ai-memory](https://github.com/akitaonrails/ai-memory) — memory chia sẻ giữa các CLI agent

--- a/docs/design/zeroclaw-docker-aaas.md
+++ b/docs/design/zeroclaw-docker-aaas.md
@@ -1,0 +1,359 @@
+# Design: ZeroClaw AaaS trên Docker (Mac, single-node) — PinchTab dùng chung, cô lập bằng tầng ứng dụng
+
+**Trạng thái**: DRAFT v3 — design first, chưa implement.
+**Ngày**: 2026-07-18
+**Lịch sử**: v1 = k8s namespace-per-tenant → v2 = k8s 1 namespace → **v3 = bỏ k8s, Docker
+thuần trên Mac** (quyết định của owner: tiết kiệm ~1-1.5GB overhead k8s control plane) và
+**PinchTab dùng chung cho mọi user, cô lập bằng cơ chế profile riêng** (quyết định của
+owner), gia cố bằng broker ở tầng ứng dụng.
+**Liên quan**: `agents-as-a-service.md` (AaaS trên nền bomclaw), `browser-control.md`
+(guard browser cho bomclaw — v3 tái dùng ý tưởng URL guard ở broker).
+
+---
+
+## 1. Tầm nhìn & ràng buộc
+
+Dịch vụ "personal AI agent": mỗi user một instance **ZeroClaw** chạy trong container
+Docker riêng, chat qua Telegram/dashboard, điều khiển browser qua **PinchTab dùng chung**.
+Đội tàu do **control panel Rust (`clawpanel`)** quản lý qua Docker API.
+
+Ràng buộc cứng (đã chốt với owner):
+1. Chạy trên **máy Mac này, thông qua Docker** (Docker Desktop hoặc OrbStack — khuyến nghị
+   OrbStack vì VM nhẹ hơn). Không Kubernetes.
+2. Mỗi user = 1 container ZeroClaw (`ghcr.io/zeroclaw-labs/zeroclaw`).
+3. **Một PinchTab duy nhất dùng chung** cho mọi user; độc lập dữ liệu browser giữa user
+   dựa trên cơ chế **profile** của PinchTab (mỗi profile = user-data-dir Chrome riêng:
+   cookies, login, storage tách nhau).
+4. Panel Rust điều khiển vòng đời container, network, volume.
+5. Cô lập data & security giữa user là bắt buộc, enforce bằng **tầng logic ứng dụng**
+   (panel là single writer, broker chặn trước PinchTab, egress proxy) — vì Docker thuần
+   không có namespace/NetworkPolicy/admission webhook như k8s.
+
+Ngoài phạm vi: billing chi tiết, token pool/rotation (xem `agents-as-a-service.md` §8,
+§12 — mặc định **BYO API key**).
+
+## 2. Thành phần bên thứ ba — đã khảo sát
+
+### 2.1 ZeroClaw
+
+- Runtime AI assistant **Rust**, RAM idle thấp (~vài chục MB) → mật độ cao trên 1 máy.
+- Config **TOML** `~/.zeroclaw/config.toml`; override bằng env `ZEROCLAW_<path>__<key>`.
+- Channels: Telegram (long-poll outbound), CLI, HTTP/WS gateway + dashboard **:42617**.
+- Image: `:latest` (distroless) / `:debian` (bash/git/curl — chọn bản này cho coding
+  agent). State `/zeroclaw-data` (`memory/`, `sessions/`, `state/`, `.secret_key`).
+- MCP client (`mcp.servers`), có tool `http` sẵn — dùng để gọi browser-broker.
+- ⚠️ Đang tái kiến trúc → pin image theo digest.
+
+### 2.2 PinchTab
+
+- Go binary ~12–15MB, tự quản Chrome, HTTP API mặc định `127.0.0.1:9867`.
+- Mô hình tài nguyên: **profiles** (browser state bền) → **instances** (process Chrome
+  per profile, start/stop theo yêu cầu) → **tabs**. Endpoint chính:
+  `POST /profiles`, `POST /instances/start`, `POST /instances/{id}/tabs/open`,
+  `POST /tabs/{tabId}/action` (`{"kind":"click","ref":"e5"}`), `GET /tabs/{tabId}/snapshot`
+  (a11y-tree, ref ổn định, ~800 token/trang).
+- Chrome chỉ chạy khi instance được start → idle gần như miễn phí. Profile data tại `/data`.
+- **Không có authentication, không có khái niệm tenant**: ai gọi được API là thấy được
+  *mọi* profile/instance/tab. → Dùng chung nhiều user **bắt buộc phải có broker** đứng
+  trước làm tenancy layer (§6). Đây là hệ quả thiết kế quan trọng nhất của v3.
+
+## 3. Nguyên tắc thiết kế
+
+1. **Panel là single writer của Docker**: chỉ `clawpanel` được mount `docker.sock`. Mọi
+   container/network/volume đều do panel tạo từ template, gắn label `com.claw.tenant=<id>`,
+   `com.claw.role=<agent|browser|broker|proxy|panel>`. Không ai `docker run` tay.
+2. **Không có admission webhook trong Docker** → bù bằng **audit-reconcile loop**: panel
+   định kỳ liệt kê toàn bộ container/network/volume, đối chiếu với trạng thái mong muốn
+   trong DB; mọi sai khác (mount lạ, network attach lạ, container không label) → alert +
+   tự sửa/cô lập.
+3. **Tenant không bao giờ nói chuyện trực tiếp với PinchTab.** Toàn bộ browser traffic đi
+   qua **browser-broker** (Rust): xác thực token per-tenant, map tenant → profile, chặn
+   cross-tenant, ép quota, URL guard.
+4. **Network cô lập bằng per-tenant internal network + multi-attach**: mỗi tenant một
+   Docker network `internal: true` (không NAT ra ngoài); các service dùng chung (broker,
+   egress-proxy, panel) được attach vào *từng* network tenant. Tenant A và B không chung
+   network nào → không route tới nhau.
+5. **Egress đi qua proxy có allowlist**: container tenant không có đường internet trực
+   tiếp; ra ngoài qua egress-proxy (FQDN allowlist: LLM providers, Telegram). SSRF/scan
+   LAN bị chặn ở đây.
+6. **Tiết kiệm trước**: PinchTab một bản, Chrome on-demand, hibernate = `docker stop`,
+   SQLite thay Postgres. Nhưng các chốt an ninh logic (broker auth, single-writer, audit
+   loop) không được đánh đổi.
+
+## 4. Kiến trúc tổng thể
+
+```
+ Mac ── Docker Desktop / OrbStack (Linux VM)
+┌──────────────────────────────────────────────────────────────────────────┐
+│                                                                          │
+│  [clawpanel]  Rust ──► /var/run/docker.sock (duy nhất)                   │
+│    ├─ REST API + Web UI  ◄──HTTPS── admin & users                        │
+│    ├─ Reverse proxy dashboard: /t/{tenant}/ ─► agent-{tenant}:42617      │
+│    ├─ Reconciler (bollard): DB desired state → docker containers        │
+│    ├─ Audit loop: docker thực tế ⇄ desired state (phát hiện lệch)        │
+│    └─ SQLite (tenants, secrets mã hoá, usage, audit)                     │
+│                                                                          │
+│  [egress-proxy]        FQDN allowlist (anthropic, openrouter, telegram…) │
+│    attach: net-alice, net-bob, …, bridge(ra internet)                    │
+│                                                                          │
+│  [browser-broker] Rust  ──► [pinchtab] :9867 ──► Chrome (per profile)    │
+│    attach: net-alice,        attach: net-browser (chỉ broker+pinchtab)   │
+│            net-bob, …,       volume: pinchtab-data (profile per tenant)  │
+│            net-browser                                                   │
+│    auth: Bearer token/tenant; map tenant→profile; URL guard; quota       │
+│                                                                          │
+│  net-alice (internal)              net-bob (internal)                    │
+│  ┌────────────────────┐            ┌────────────────────┐                │
+│  │ [agent-alice]      │            │ [agent-bob]        │                │
+│  │  zeroclaw :42617   │            │  zeroclaw :42617   │                │
+│  │  volume data-alice │            │  volume data-bob   │                │
+│  └────────────────────┘            └────────────────────┘                │
+│                                                                          │
+│  Đường đi: agent ──net-tenant──► broker ──net-browser──► pinchtab        │
+│            agent ──net-tenant──► egress-proxy ──bridge──► internet       │
+│            agent-A ⇄ agent-B : KHÔNG TỒN TẠI đường route                 │
+└──────────────────────────────────────────────────────────────────────────┘
+   User Telegram ⇄ long-poll outbound (qua egress-proxy), không cần mở port vào
+```
+
+## 5. Data plane — container per tenant
+
+### 5.1 Container spec (panel render từ template)
+
+```
+docker run (tương đương — panel gọi bollard):
+  name: agent-alice
+  image: ghcr.io/zeroclaw-labs/zeroclaw@sha256:<pinned>     # :debian
+  labels: com.claw.tenant=alice, com.claw.role=agent
+  networks: [net-alice]                                     # internal, duy nhất
+  volumes:  data-alice:/zeroclaw-data                       # named volume, duy nhất
+  env:
+    ZEROCLAW_providers__models__anthropic__default__api_key=…   # từ secret store panel
+    ZEROCLAW_channels__telegram__default__token=…
+    HTTP_PROXY=http://egress-proxy:3128                     # ép mọi egress qua proxy
+    HTTPS_PROXY=http://egress-proxy:3128
+    NO_PROXY=browser-broker,egress-proxy
+    CLAW_BROWSER_URL=http://browser-broker:8700             # cho skill/MCP browser
+    CLAW_BROWSER_TOKEN=<token-alice>                        # bearer per tenant
+  security:
+    user: non-root; no-new-privileges; cap-drop ALL
+    read-only rootfs + tmpfs /tmp (image debian cho phép)
+    memory limit 768m, cpus 1.0, pids-limit 256
+  restart: unless-stopped
+```
+
+Điểm chốt:
+- **Không mount docker.sock, không host network, không privileged** — bất biến (D-series §7.2).
+- Docker **không có Secret object** như k8s → secrets (API key, Telegram token, browser
+  token) sống trong **secret store mã hoá của panel** (SQLite + AES-GCM, master key trong
+  file quyền 0600 hoặc macOS Keychain), chỉ giải mã lúc render env khi tạo container.
+  `docker inspect` thấy env — chấp nhận được vì chỉ panel có socket.
+- Naming convention là bất biến: tenant `alice` ⇒ `agent-alice`, `net-alice`, `data-alice`,
+  token browser riêng. Audit loop đối chiếu đúng bộ ba này.
+- Docker address pool cấu hình sẵn (vd `10.200.0.0/16` chia `/28`) để đủ subnet cho
+  hàng trăm network tenant.
+
+### 5.2 Config injection
+
+Panel render `config.toml` (mount read-only từ thư mục config do panel quản) + env
+override `ZEROCLAW_…` (env thắng file). `.secret_key` của zeroclaw sinh lần đầu trên
+volume tenant.
+
+## 6. Browser plane — PinchTab dùng chung + browser-broker
+
+### 6.1 Phân vai
+
+```
+[zeroclaw alice] ──token alice──► [browser-broker] ──► [pinchtab] ──► Chrome(profile alice)
+[zeroclaw bob]   ──token bob────►        │                         └─► Chrome(profile bob)
+                                         │
+                              tenancy layer (Rust):
+                              1. AuthN: Bearer token → tenant
+                              2. Mapping: tenant → profile pinchtab (tạo lần đầu)
+                              3. AuthZ: mọi instanceId/tabId trong request phải
+                                 thuộc profile của tenant đó (broker giữ bảng sở hữu)
+                              4. Quota: ≤1 instance/tenant, ≤K instance toàn máy,
+                                 idle timeout → stop instance
+                              5. URL guard: chặn navigate tới private CIDR,
+                                 metadata, localhost (như browser-control.md §6.3)
+                              6. Audit: log (tenant, action, url) — không log nội dung
+```
+
+- **Cô lập dữ liệu browser** = profile PinchTab (mỗi profile một user-data-dir Chrome:
+  cookie/login/history tách nhau) — đúng cơ chế owner chọn.
+- **Cô lập truy cập API** = broker. Thiếu broker thì mọi tenant thấy tab của nhau vì
+  PinchTab không auth (§2.2). Broker là thành phần *bắt buộc*, không phải tối ưu.
+- PinchTab container chỉ nằm trên `net-browser` cùng broker — không tenant nào route tới
+  :9867 trực tiếp.
+
+### 6.2 API broker (phác thảo — cố ý hẹp hơn PinchTab)
+
+```
+POST /v1/browser/navigate   {url}                → mở/tái dùng instance+tab của tenant
+GET  /v1/browser/snapshot   ?filter=interactive  → a11y snapshot (ref e1,e2…)
+POST /v1/browser/act        {kind, ref, text?}   → click/fill/press…
+GET  /v1/browser/tabs       / POST open / close  → trong phạm vi profile tenant
+GET  /v1/browser/screenshot
+POST /v1/browser/stop                            → trả Chrome về idle
+```
+
+Không expose endpoint quản trị (`/profiles`, `/instances` của PinchTab) cho tenant.
+Giai đoạn 1: zeroclaw gọi broker bằng tool `http` + skill mô tả API. Giai đoạn 2:
+broker expose thêm **MCP transport** để khai vào `mcp.servers` của zeroclaw → tool
+`browser__*` có schema chuẩn (kiểm chứng transport zeroclaw hỗ trợ ở P0 — câu hỏi mở #2).
+
+### 6.3 Giới hạn thẳng thắn của mô hình dùng chung
+
+Profile cô lập **dữ liệu**, không phải **ranh giới an ninh runtime**: mọi Chrome process
+của mọi tenant chạy chung một container PinchTab. Một trang web độc khai thác được lỗ
+hổng Chrome (RCE) trong phiên của tenant A ⇒ code chạy trong container pinchtab ⇒ đọc
+được profile của *mọi* tenant. Giảm nhẹ:
+- Chrome/PinchTab pin bản mới, cập nhật nhanh (Chrome vá RCE liên tục);
+- container pinchtab: non-root, cap-drop, no-new-privileges, chỉ có `net-browser`
+  + egress qua proxy (hạn chế exfil);
+- **escape hatch trong thiết kế**: schema đã có `browser_mode: shared | dedicated` per
+  tenant — tenant nhạy cảm/trả tiền cao cấp được cấp pinchtab container riêng (panel chỉ
+  cần đổi template, broker trỏ endpoint khác). Mặc định: shared (quyết định owner).
+
+Rủi ro tồn dư này được chấp nhận có chủ đích để đổi lấy mật độ (ghi ở §10.3).
+
+## 7. Cô lập & network — bảng bù cho việc không có k8s
+
+### 7.1 Ma trận cô lập
+
+| Tầng | Cơ chế | Chống gì |
+|------|--------|----------|
+| Compute | container riêng per tenant, non-root, cap-drop, pids/mem/cpu limit | noisy neighbor, leo thang trong container |
+| Disk | named volume per tenant, chỉ mount vào container của chính tenant (audit loop kiểm) | user đụng phân vùng nhau |
+| Browser data | profile PinchTab per tenant | lẫn cookie/session giữa user |
+| Browser API | broker: token per tenant + bảng sở hữu instance/tab | tenant A điều khiển browser tenant B |
+| Network | per-tenant internal net; service chung multi-attach; không ICC chéo | lateral movement |
+| Egress | proxy FQDN allowlist; tenant net không NAT trực tiếp | SSRF, scan LAN/metadata, exfil bừa |
+| Docker API | chỉ panel mount docker.sock | tenant thao túng hạ tầng |
+| Secrets | store mã hoá trong panel, giải mã lúc create container | đọc chéo credential |
+| Host Mac | Docker VM boundary (Desktop/OrbStack) | sự cố tồi nhất bị nhốt trong VM |
+
+### 7.2 Bất biến (D1–D8) — panel enforce khi tạo + audit loop kiểm định kỳ
+
+```
+D1. Container role=agent: đúng 1 label tenant, đúng 1 network net-<tenant>,
+    đúng 1 volume data-<tenant>. Không mount gì khác.
+D2. Không container nào ngoài clawpanel được mount docker.sock.
+D3. Không container tenant nào: privileged, host network/pid/ipc, cap-add,
+    mount đường dẫn host.
+D4. pinchtab chỉ attach net-browser; không publish port nào ra host.
+D5. broker là container duy nhất attach đồng thời net-browser + các net tenant.
+D6. Mọi container thuộc hệ thống phải có label com.claw.* ; container lạ trong
+    phạm vi quản lý → alert.
+D7. Image chỉ từ digest allowlist trong DB panel.
+D8. Port publish ra host: duy nhất clawpanel :443 (API/UI/proxy). Không gì khác.
+```
+
+Audit loop chạy mỗi 30–60s: `list containers/networks/volumes` → so khớp desired state
+→ lệch thì sửa (stop/disconnect) + ghi audit + notify. Đây là "webhook thay thế" của v3.
+
+### 7.3 Egress-proxy
+
+- Squid hoặc proxy Rust nhỏ (ưu tiên viết Rust chung repo — CONNECT proxy + allowlist,
+  ~vài trăm dòng, khỏi kéo image lạ).
+- Per-tenant policy: allowlist mặc định (`api.anthropic.com`, `openrouter.ai`,
+  `api.telegram.org`, registry skill…) + tenant mở rộng qua panel (có audit).
+- Chrome trong pinchtab cũng cần đi qua proxy (container pinchtab nằm trên net nội bộ):
+  PinchTab cho đặt Chrome binary/flags hay proxy per-profile → kiểm chứng ở P0; nếu
+  không đặt được `--proxy-server` per instance thì cho pinchtab attach bridge (egress
+  trực tiếp) và dựa vào URL guard của broker + chấp nhận residual DNS-rebinding
+  (câu hỏi mở #3).
+
+## 8. Control panel — `clawpanel` (Rust)
+
+| Lớp | Chọn | Ghi chú |
+|-----|------|---------|
+| Docker API | **bollard** | async, đầy đủ container/network/volume/events |
+| HTTP API + UI + reverse proxy | **axum** + tower | một framework ba vai |
+| DB | **SQLite + sqlx** (WAL) | repo pattern để lên Postgres khi cần |
+| Secret store | AES-GCM trong SQLite, master key file 0600 / macOS Keychain | Docker không có Secret object |
+| AuthN | password/magic-link tenant; 2FA admin | |
+| Observability | `tracing` + file log xoay vòng; metrics endpoint | không bắt buộc Prometheus |
+
+Một binary, các task: API/UI, reverse proxy dashboard, reconciler (desired state trong DB
+→ Docker qua bollard), audit loop (§7.2), capacity ledger.
+
+- **Capacity ledger**: budget máy (CPU/RAM cấp cho Docker VM) − Σ limits đã cấp; vượt →
+  từ chối provision/resume. Cộng thêm semaphore Chrome toàn máy (≤K instance, K≈6–8).
+- **Reverse proxy dashboard**: user → panel (auth session, scope tenant) → attach sẵn vào
+  net tenant → `agent-<tenant>:42617`. Chỉ panel publish port ra host (D8).
+- **API** (rút gọn): `POST/GET/PATCH/DELETE /api/tenants`, `PUT /api/tenants/{id}/secrets/*`
+  (write-only), `/usage`, `/health`, `/restart`, `GET /api/audit`. DB:
+  `tenants/plans/secrets(enc)/usage_daily/audit_log/images_allowlist`.
+- **Flow provision**: INSERT tenant → reconciler: volume → network → (connect broker+proxy
+  vào net mới) → container agent → broker cấp token + tạo profile pinchtab lần đầu dùng
+  → Ready, hướng dẫn nhập Telegram token/API key. Mục tiêu < 30s (image pre-pulled).
+
+## 9. Vòng đời & vận hành
+
+- **Hibernate** = `docker stop agent-<t>` (volume giữ; Telegram offset trong state → wake
+  đọc backlog). Auto-hibernate sau N giờ idle — đòn bẩy mật độ chính. Chrome instance
+  idle do broker tự stop (timeout).
+- **Delete**: soft-delete → 30 ngày → xoá container/network/volume + profile pinchtab
+  (broker gọi xoá profile) theo label selector; orphan-sweep nằm sẵn trong audit loop.
+- **Upgrade zeroclaw/pinchtab**: đổi digest trong allowlist → reconciler recreate theo
+  ring (vài tenant canary trước). PinchTab nâng bản cần đọc changelog phần bind/auth (§10.2).
+- **Backup**: job định kỳ `docker run --rm -v data-<t>:/src -v backup:/dst tar` + restic
+  ra đĩa ngoài; pinchtab-data backup cả cụm (profile theo thư mục).
+- **Sự cố máy Mac ngủ/restart**: Docker Desktop/OrbStack tự khởi động lại, container
+  `restart: unless-stopped`; panel lên trước (depends) rồi audit loop tự đối soát.
+- **Ước tính mật độ** (VM Docker cấp 8 CPU / 12–16Gi):
+  - Hạ tầng thường trực: panel + broker + proxy + pinchtab idle ≈ **300–400Mi** (so với
+    ~1.5Gi nếu còn k8s).
+  - Tenant idle ≈ zeroclaw ~50–128Mi → **70–100 tenant idle** về RAM.
+  - Chrome ~400Mi–1Gi/phiên → **6–8 phiên browse đồng thời** (semaphore K).
+
+## 10. Threat model & rủi ro chính
+
+| # | Mối đe doạ | Kiểm soát | Tồn dư |
+|---|------------|-----------|--------|
+| 1 | Tenant A điều khiển browser/tab của B | broker auth + bảng sở hữu (§6.1); pinchtab không route trực tiếp (D4/D5) | thấp |
+| 2 | Cross-tenant network | per-tenant internal net, không net chung giữa tenant | thấp |
+| 3 | **Chrome RCE trong pinchtab chung** → đọc mọi profile | pin/update nhanh, hardening container, egress proxy chặn exfil; escape hatch `dedicated` | **trung bình — chấp nhận có chủ đích** (quyết định shared của owner) |
+| 4 | SSRF/scan LAN/metadata (prompt injection) | tenant net internal + egress-proxy allowlist; URL guard broker cho Chrome | DNS-rebinding nếu Chrome không qua proxy (mở #3) |
+| 5 | Tenant đụng volume nhau | D1 + audit loop; named volume chỉ mount bởi panel | thấp |
+| 6 | Chiếm panel = chiếm tất cả (docker.sock = root VM) | panel là bề mặt tấn công chính: 2FA admin, secrets mã hoá, audit, cập nhật deps (cargo-audit), chỉ :443 publish | trung bình — SPOF có chủ đích |
+| 7 | Thao tác docker tay phá bất biến | D-series + audit loop tự sửa + alert | thấp |
+| 8 | Noisy neighbor | mem/cpu/pids limit + capacity ledger + Chrome semaphore | thấp |
+| 9 | Supply chain (image) | D7 digest allowlist | thấp |
+| 10 | ZeroClaw upstream gãy API config | pin digest, canary ring | thấp |
+
+So với k8s (v2): mất PSA/webhook/NetworkPolicy chuẩn → thay bằng D-series + audit loop
++ broker, tất cả nằm trong code panel ⇒ **test suite cho D1–D8 và broker AuthZ là
+deliverable bắt buộc của P1**, không phải nice-to-have.
+
+## 11. Lộ trình
+
+| Phase | Nội dung | Nghiệm thu |
+|-------|----------|------------|
+| **P0 — PoC** (tay, docker compose) | 2 tenant: agent+net+volume; pinchtab + broker stub (auth token cứng); egress-proxy; zeroclaw gọi broker qua tool http | A không gọi được B (:42617), không thấy tab của B, không ra được LAN/private; browse OK; đo RAM idle |
+| **P1 — Panel MVP** | clawpanel: bollard reconciler + audit loop D1–D8 + API/UI + secret store + capacity ledger + hibernate; broker hoàn chỉnh (ownership, quota, URL guard) | provision < 30s không docker tay; test suite D-series + broker AuthZ pass |
+| **P2 — Product hoá** | broker MCP transport; reverse-proxy dashboard + auth; metering; backup restic; Chrome semaphore tinh chỉnh; `browser_mode: dedicated` | 20–50 tenant thật trên máy này |
+| **P3 — Mở rộng** | billing; managed-key proxy; đường lên multi-node (Postgres + quay lại k8s design v2 nếu vượt 1 máy) | theo traction |
+
+## 12. Câu hỏi mở
+
+1. OrbStack hay Docker Desktop? (khuyến nghị OrbStack: VM nhẹ, network nhanh hơn trên Mac;
+   Docker Desktop phổ biến hơn). Budget CPU/RAM cấp cho VM là bao nhiêu?
+2. zeroclaw `mcp.servers` hỗ trợ transport nào (stdio only hay có HTTP/streamable)? Quyết
+   cách broker expose MCP ở P2; P0-P1 dùng tool `http` là đủ.
+3. PinchTab có cho đặt Chrome `--proxy-server` (per profile/instance) không? Quyết việc
+   Chrome đi qua egress-proxy hay chỉ dựa URL guard (§7.3).
+4. Giới hạn profile/instance của PinchTab khi ~50-100 profile trong một container? (RAM
+   map profile registry, tốc độ start Chrome) — đo ở P0.
+5. Telegram long-poll (giữ container luôn chạy) vs webhook qua panel (wake-from-hibernate,
+   tăng mật độ) — MVP long-poll; webhook đáng làm ở P2 nếu mật độ hibernate quan trọng.
+6. Panel có cần chế độ read-only cho owner xem hội thoại tenant không? (mặc định thiết kế:
+   KHÔNG — sessions nằm trong volume tenant, panel không đọc; nếu cần support phải có cơ
+   chế consent per tenant.)
+
+---
+
+*Nguồn khảo sát: deepwiki `zeroclaw-labs/zeroclaw`; `github.com/pinchtab/pinchtab` README
++ pinchtab.com/docs (2026-07); các bản thiết kế trước: `agents-as-a-service.md`,
+`browser-control.md`, và v1/v2 của chính file này (lịch sử git).*


### PR DESCRIPTION
Agent gọi `bomclaw task/note/msg` từ shell của chính nó, nhưng PATH của launchd không có `~/.bomclaw` — nên mọi lệnh điều phối agent chạy đều "command not found". Chỉ nhìn thấy được trong kết quả task, không có trong log nào.

Bổ sung luôn những gì một lần deploy thực sự chạm tới bây giờ: hai gateway **dùng chung một binary**, và DB điều phối chung khoá mọi thứ theo `agent.id` riêng của từng gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)