### PR TITLE
fix(dashboard): make the chat tab land somewhere, and count its turns

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -18,6 +18,7 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
   const activeSessionId = useStore(s => s.activeSessionId)
   const setActiveSessionId = useStore(s => s.setActiveSessionId)
   const setMessages = useStore(s => s.setMessages)
+  const sessions = useStore(s => s.sessions)
 
   // Sync URL ↔ state: read on load, write on change
   useEffect(() => {
@@ -28,6 +29,8 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
         setActiveSessionId(id)
         setTab('chat')
       }
+    } else if (path === '/chat') {
+      setTab('chat')
     } else if (path === '/status') {
       setTab('status')
     } else if (path === '/admin') {
@@ -37,8 +40,11 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
 
   // Update URL when session/tab changes
   useEffect(() => {
-    if (tab === 'chat' && activeSessionId && activeSessionId !== 'new') {
-      history.replaceState(null, '', `/chat/${activeSessionId}`)
+    if (tab === 'chat') {
+      // A chat with no session picked still needs its own URL — without this
+      // branch the address bar kept showing the tab you arrived from.
+      const path = activeSessionId && activeSessionId !== 'new' ? `/chat/${activeSessionId}` : '/chat'
+      history.replaceState(null, '', path)
     } else if (tab === 'status') {
       history.replaceState(null, '', '/status')
     } else if (tab === 'admin') {
@@ -84,6 +90,21 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
   useEffect(() => {
     if (activeSessionId) setTab('chat')
   }, [activeSessionId, setTab])
+
+  // Opening Chat with nothing selected used to show an empty conversation even
+  // when one was in progress — the history was only reachable by going through
+  // Sessions first. Land on the most recent session instead; "+ New Chat" is
+  // how you deliberately start a blank one.
+  useEffect(() => {
+    if (tab !== 'chat' || activeSessionId || sessions.length === 0) return
+    const newest = sessions[0]
+    setActiveSessionId(newest.id)
+    call('transcript.get', { session_id: newest.id })
+      .then((events: any) => {
+        if (Array.isArray(events) && events.length > 0) setMessages(eventsToMessages(events))
+      })
+      .catch(() => {})
+  }, [tab, activeSessionId, sessions, setActiveSessionId, setMessages, call])
 
   return (
     <div className="h-full flex flex-col bg-gray-950 text-gray-100">

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -277,6 +277,19 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			sessionID = fmt.Sprintf("chat_%d", dashboardChatID)
 		}
 
+		// Resolve a real session so the dashboard's own conversation is a
+		// first-class session with turn and token counts. Without this it only
+		// ever existed as a transcript file, and sessions.list synthesised a
+		// stub for it that always read "0 turns · 0 tokens".
+		//
+		// Deliberately does NOT change which transcript is written: a session
+		// id that resolves to nothing stays unresolved rather than silently
+		// redirecting the user's message into the default conversation.
+		sess := deps.Sessions.GetByID(sessionID)
+		if sess == nil && sessionID == fmt.Sprintf("chat_%d", dashboardChatID) {
+			sess = deps.Sessions.Get(dashboardChatID) // creates it on first use
+		}
+
 		tw := transcript.NewWriter(filepath.Join(deps.DataDir, "transcripts"))
 
 		// Persist user message IMMEDIATELY so it survives reload
@@ -460,6 +473,19 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			})
 		}
 
+		// Record the turn against the session, the same way the Telegram path
+		// does, so the session list reflects what actually happened here.
+		if sess != nil {
+			sess.IncrementMessages()
+			if result != nil {
+				sess.AddTokens(result.Usage.InputTokens, result.Usage.OutputTokens)
+			}
+			if sess.GetLabel() == "" {
+				sess.SetLabel(labelFromMessage(p.Message))
+			}
+			deps.Sessions.MarkDirty()
+		}
+
 		if err != nil {
 			errMsg := err.Error()
 			if agentCtx.Err() != nil {
@@ -554,6 +580,20 @@ func extractSnippet(name, input string) string {
 }
 
 // --- Send (non-streaming fallback, for CLI) ---
+
+// labelFromMessage names a session after its opening message, so the sessions
+// list shows something readable instead of a bare id.
+func labelFromMessage(msg string) string {
+	const max = 40
+	label := strings.TrimSpace(strings.ReplaceAll(msg, "\n", " "))
+	if label == "" {
+		return ""
+	}
+	if r := []rune(label); len(r) > max {
+		return string(r[:max-1]) + "…"
+	}
+	return label
+}
 
 // dashboardChatID is a fixed chatID for dashboard sessions.
 const dashboardChatID int64 = 1

--- a/internal/gateway/trace_test.go
+++ b/internal/gateway/trace_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -124,5 +125,86 @@ func TestStreamingSendIsTraced(t *testing.T) {
 	}
 	if root.TotalTokens != 228 {
 		t.Errorf("rolled-up tokens = %d, want 228 (100+5+120+3)", root.TotalTokens)
+	}
+}
+
+// TestStreamingSendRecordsTheSession covers a gap the dashboard made visible:
+// the streaming handler wrote transcripts but never touched a session, so the
+// dashboard's own conversation existed only as a file. sessions.list then
+// synthesised a stub for it that always read "0 turns · 0 tokens".
+func TestStreamingSendRecordsTheSession(t *testing.T) {
+	dir := t.TempDir()
+
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+	deps := Deps{
+		Sessions:     sessions,
+		Resolver:     models.NewResolver("claude-opus-4-8", nil),
+		Provider:     &stubProvider{},
+		ToolExecutor: stubExecutor{},
+		DataDir:      dir,
+		System:       "you are a test",
+		AgentID:      "a1",
+		ProviderName: "claude",
+	}
+
+	params, _ := json.Marshal(SendParams{Message: "summarise yesterday's deploy"})
+	NewStreamSendHandler(deps)(context.Background(),
+		Request{ID: "1", Method: "send", Params: params},
+		func(StreamEvent) {})
+
+	sess := sessions.Get(dashboardChatID)
+	if sess == nil {
+		t.Fatal("the dashboard conversation did not become a real session")
+	}
+	if got := sess.GetMessageCount(); got != 1 {
+		t.Errorf("message count = %d, want 1 — the sessions list shows this as turns", got)
+	}
+	in, out := sess.Tokens()
+	if in != 220 || out != 8 {
+		t.Errorf("tokens = %d/%d, want 220/8 summed across both model calls", in, out)
+	}
+	if label := sess.GetLabel(); label != "summarise yesterday's deploy" {
+		t.Errorf("label = %q, want the opening message", label)
+	}
+}
+
+// A session id that resolves to nothing must not be redirected into the default
+// conversation: that would file the user's message under the wrong transcript.
+func TestUnknownSessionIDIsNotRedirected(t *testing.T) {
+	dir := t.TempDir()
+
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+	deps := Deps{
+		Sessions:     sessions,
+		Resolver:     models.NewResolver("claude-opus-4-8", nil),
+		Provider:     &stubProvider{},
+		ToolExecutor: stubExecutor{},
+		DataDir:      dir,
+		AgentID:      "a1",
+	}
+
+	params, _ := json.Marshal(SendParams{Message: "hello", SessionID: "chat_does_not_exist"})
+	NewStreamSendHandler(deps)(context.Background(),
+		Request{ID: "1", Method: "send", Params: params},
+		func(StreamEvent) {})
+
+	// The transcript must carry the id the caller asked for.
+	if _, err := os.Stat(filepath.Join(dir, "transcripts", "chat_does_not_exist.jsonl")); err != nil {
+		t.Errorf("message was not written to the requested transcript: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "transcripts", "chat_1.jsonl")); err == nil {
+		t.Error("message leaked into the default dashboard conversation")
 	}
 }


### PR DESCRIPTION
Báo cáo: *"luồng chat đang không có gì"* — mở tab Chat ra hội thoại rỗng, URL vẫn trỏ về tab trước đó.

Đằng sau là **ba lỗi riêng biệt**.

## 1. Chat mở ra chỗ trống

Chưa chọn session thì tab render một hội thoại rỗng, kể cả khi đang có hội thoại dở — lịch sử chỉ vào được nếu đi vòng qua tab Sessions trước. Giờ nó vào session mới nhất và nạp transcript; **+ New Chat** mới là cách bắt đầu một hội thoại trống có chủ ý.

## 2. URL không cập nhật cho chat chưa có session

Effect ghi URL **không có nhánh** cho `tab === 'chat'` khi chưa chọn session, nên bấm Chat xong thanh địa chỉ vẫn hiện `/admin` hoặc `/status` — đúng như trong ảnh chụp màn hình được báo. `/chat` trần giờ là một route thật.

## 3. Hội thoại của dashboard không phải là session

Streaming send handler ghi transcript nhưng **không hề động vào session store**, nên nó chỉ tồn tại dưới dạng file. `sessions.list` phải dựng stub cho nó, và stub luôn hiện `0 turns · 0 tokens`, không có label:

```
chat_1   0 turns
1h ago · 0 tokens
```

(trong khi transcript có 8 tin nhắn)

Giờ nó được resolve (tạo ở lần dùng đầu), đếm lượt, cộng token và đặt label theo tin nhắn mở đầu — giống hệt đường Telegram.

Một `session_id` không resolve được thì **cố ý để nguyên**, không rơi về hội thoại mặc định: redirect sẽ ghi tin nhắn của người dùng vào nhầm transcript. Có test riêng cho việc này.

## Test

Đã kiểm chứng test FAIL trên code cũ:

```
--- FAIL: TestStreamingSendRecordsTheSession
    message count = 0, want 1 — the sessions list shows this as turns
    tokens = 0/0, want 220/8 summed across both model calls
    label = "", want the opening message
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)