### PR TITLE
feat(gateway): run dashboard messages through the bot's turn engine (S0)

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -313,6 +313,9 @@ func runGateway(args []string) {
 		NotesFile:    cfg.Coord.NotesFile,
 	}
 	if tgBot != nil {
+		// Dashboard messages run through the bot's turn engine, so both
+		// channels share one execution path: CLI tool loop, memory, trace.
+		deps.Turn = tgBot.Handler()
 		deps.Runs = func() []gateway.RunInfo {
 			var out []gateway.RunInfo
 			for _, s := range tgBot.Sessions().List() {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -38,6 +38,10 @@ type Bot struct {
 	typing    *TypingIndicator
 }
 
+// Handler exposes the turn engine so the gateway can run dashboard messages
+// through the same path as Telegram messages (see Handler.RunTurn).
+func (b *Bot) Handler() *Handler { return b.handler }
+
 // New creates and initialises the bot. db and sessions are shared with the
 // gateway so label renames and turn counters are visible to the dashboard
 // immediately (two managers on one SQLite file would clobber each other).

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -540,13 +540,10 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	// Inject persistent memory (MEMORY.md + recent daily notes) and recent
 	// conversation history when starting a brand-new session (first message
 	// or after a reset) so Claude has durable facts plus short-term context.
-	newSessionContext := ""
-	if sess.GetSessionID() == "" {
-		newSessionContext = h.memory.BuildContext(time.Now()) + h.buildHistoryContext(sess.ID, 8)
-	}
+	newSessionContext := h.NewSessionContext(sess)
 
 	_, err := h.engine.Enqueue(ctx, chatID, func(ctx context.Context) (*execution.RunResult, error) {
-		return h.runClaude(ctx, sess, chatID, modelID, text, newSessionContext, placeholder)
+		return h.runClaude(ctx, sess, chatID, modelID, text, newSessionContext, NewStreamer(h.bot, chatID, placeholder))
 	})
 
 	if err != nil {
@@ -566,8 +563,46 @@ func (h *Handler) executeMessage(chatID int64, text string) {
 	}
 }
 
+// TurnSink is where a turn's output goes as it happens. It is the only part of
+// a turn that knows which channel it is talking to: Telegram edits a message in
+// place, the dashboard pushes WebSocket events. *Streamer satisfies it for
+// Telegram; the gateway supplies its own. Everything else about a turn — trace,
+// transcript, message store, memory, auto-continue — is identical for both, and
+// lives once, in runClaude.
+//
+// Aliased from the neutral chat package on purpose: Go compares method
+// parameter types by identity, not structure, so a locally declared interface
+// here and another in gateway would make RunTurn satisfy neither.
+type TurnSink = chat.TurnSink
+
+// RunTurn runs one user message through the same engine the Telegram bot uses,
+// delivering output to sink. Callers outside this package (the gateway) use it
+// so a message typed on the dashboard is executed, traced and persisted exactly
+// like one typed on Telegram — the same CLI-owned tool loop, the same memory
+// injection, the same messages table. Before this, the dashboard ran through a
+// separate agent loop and the two channels drifted apart feature by feature.
+//
+// The turn is queued on the chat's execution engine, so a web message and a
+// Telegram message for the same chat can never run concurrently.
+func (h *Handler) RunTurn(ctx context.Context, sess *session.Session, chatID int64, modelID, userText string, sink TurnSink) (*execution.RunResult, error) {
+	memoryContext := h.NewSessionContext(sess)
+	return h.engine.Enqueue(ctx, chatID, func(ctx context.Context) (*execution.RunResult, error) {
+		return h.runClaude(ctx, sess, chatID, modelID, userText, memoryContext, sink)
+	})
+}
+
+// NewSessionContext returns the memory and recent-history block injected into
+// a session's FIRST turn, or "" for a session the CLI already knows. A resumed
+// session carries its history itself; injecting again pollutes the context.
+func (h *Handler) NewSessionContext(sess *session.Session) string {
+	if sess.GetSessionID() != "" {
+		return ""
+	}
+	return h.memory.BuildContext(time.Now()) + h.buildHistoryContext(sess.ID, 8)
+}
+
 // runClaude executes a single Claude CLI call with streaming, transcript recording, and memory extraction.
-func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID int64, modelID, userText, memoryContext string, placeholderMsgID int) (*execution.RunResult, error) {
+func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID int64, modelID, userText, memoryContext string, streamer TurnSink) (*execution.RunResult, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -576,8 +611,6 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		StartedAt: time.Now(),
 		Status:    execution.RunSuccess,
 	}
-
-	streamer := NewStreamer(h.bot, chatID, placeholderMsgID)
 
 	// Open the trace for this turn. Every model call and every tool the model
 	// runs hangs off this root, so the admin page can replay the turn as a

--- a/internal/bot/runturn_test.go
+++ b/internal/bot/runturn_test.go
@@ -1,0 +1,248 @@
+package bot
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/agent"
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/config"
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/memory"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/storage"
+	"github.com/ngocp/goterm-control/internal/tools"
+	"github.com/ngocp/goterm-control/internal/trace"
+	"github.com/ngocp/goterm-control/internal/transcript"
+)
+
+// scriptedClient plays one turn the way the real CLI clients do: text, a tool
+// call with its result, more text, and — like claude/codex — it is the client
+// that stamps the session id and bumps the session counters.
+type scriptedClient struct {
+	mu    sync.Mutex
+	turns int
+}
+
+func (c *scriptedClient) Name() string { return "stub" }
+
+func (c *scriptedClient) SendMessage(ctx context.Context, sess *session.Session, modelID,
+	userText, memoryContext string, cb chat.StreamCallbacks) error {
+	c.mu.Lock()
+	c.turns++
+	c.mu.Unlock()
+
+	cb.OnText("Hello ")
+	cb.OnToolCall("Bash", `{"command":"ls"}`)
+	cb.OnToolResult("Bash", tools.ToolResult{Output: "a b"})
+	cb.OnText("done")
+
+	if sess.GetSessionID() == "" {
+		sess.SetSessionID("stub-session-1")
+		sess.SetProvider("stub")
+	}
+	sess.AddTokens(100, 7)
+	sess.IncrementMessages()
+	return nil
+}
+
+// recordingSink is a TurnSink that keeps what it was handed — the dashboard's
+// stand-in, so the test can see the turn from the channel's side.
+type recordingSink struct {
+	mu     sync.Mutex
+	text   strings.Builder
+	tools  []string
+	photos []string
+	done   bool
+}
+
+func (s *recordingSink) Write(chunk string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.text.WriteString(chunk)
+}
+func (s *recordingSink) NoteTool(label string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tools = append(s.tools, label)
+}
+func (s *recordingSink) Flush() {}
+func (s *recordingSink) SendPhoto(path, caption string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.photos = append(s.photos, path)
+}
+func (s *recordingSink) Finalize() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.done = true
+}
+
+// TestRunTurnIsTheTelegramPath is the S0 acceptance test: a message handed to
+// RunTurn by a non-Telegram caller must leave exactly the footprint a Telegram
+// message leaves — rows in the messages table, events in the transcript, the
+// session counted, and a trace with tool spans. Every one of these was missing
+// on the dashboard before it shared the engine.
+func TestRunTurnIsTheTelegramPath(t *testing.T) {
+	dir := t.TempDir()
+
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	cdb, err := coord.Open(filepath.Join(dir, "coord.db"))
+	if err != nil {
+		t.Fatalf("coord: %v", err)
+	}
+	defer cdb.Close()
+
+	rec := trace.New(cdb, "a1")
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+
+	h := &Handler{
+		sessions:   sessions,
+		llm:        &scriptedClient{},
+		cfg:        &config.Config{},
+		engine:     execution.NewEngine(execution.Hooks{}, 3),
+		transcript: transcript.NewWriter(filepath.Join(dir, "transcripts")),
+		messages:   storage.NewMessageStore(sdb),
+		memory:     memory.NewManager(memory.Config{}), // disabled: no files to read
+		trace:      rec,
+		agentID:    "a1",
+	}
+
+	sess := sessions.Get(1) // the dashboard's chat
+	sink := &recordingSink{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := h.RunTurn(ctx, sess, 1, "test-model", "list the files", sink)
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if result == nil || result.Status != execution.RunSuccess {
+		t.Fatalf("result = %+v, want success", result)
+	}
+	rec.Close() // drain the async trace writer before asserting on it
+
+	// --- the channel saw the turn -------------------------------------------
+	if got := sink.text.String(); got != "Hello done" {
+		t.Errorf("sink text = %q, want %q", got, "Hello done")
+	}
+	if len(sink.tools) != 1 || !strings.HasPrefix(sink.tools[0], "Bash") {
+		t.Errorf("sink tools = %v, want one Bash label", sink.tools)
+	}
+
+	// --- the messages table has both sides (the dashboard never wrote it) ---
+	history, err := h.messages.LoadHistory(sess.ID, 10)
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	if len(history) != 2 || history[0].Role != "user" || history[1].Role != "assistant" {
+		t.Fatalf("messages table = %+v, want user then assistant", history)
+	}
+	if history[1].Content != "Hello done" {
+		t.Errorf("assistant row = %q", history[1].Content)
+	}
+
+	// --- the transcript carries the tool call, not just the text -------------
+	raw, err := os.ReadFile(filepath.Join(dir, "transcripts", sess.ID+".jsonl"))
+	if err != nil {
+		t.Fatalf("transcript: %v", err)
+	}
+	for _, want := range []string{`"user_message"`, `"assistant_text"`, `"tool_call"`, `"tool_result"`} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("transcript is missing a %s event", want)
+		}
+	}
+
+	// --- the session was counted and labelled --------------------------------
+	if sess.GetMessageCount() != 1 {
+		t.Errorf("message count = %d, want 1", sess.GetMessageCount())
+	}
+	if in, out := sess.Tokens(); in != 100 || out != 7 {
+		t.Errorf("tokens = %d/%d, want 100/7", in, out)
+	}
+	if sess.GetLabel() != "list the files" {
+		t.Errorf("label = %q, want the opening message", sess.GetLabel())
+	}
+	if sess.GetSessionID() != "stub-session-1" {
+		t.Errorf("provider session id = %q — the CLI's id must be kept for resume", sess.GetSessionID())
+	}
+
+	// --- the trace has the Telegram shape: turn → llm → tool -----------------
+	traces, err := cdb.ListTraces(coord.TraceFilter{})
+	if err != nil {
+		t.Fatalf("list traces: %v", err)
+	}
+	if len(traces) != 1 || traces[0].Name != "turn" {
+		t.Fatalf("traces = %+v, want exactly one root named turn", traces)
+	}
+	runs, _ := cdb.GetTrace(traces[0].TraceID)
+	var llm, tool int
+	for _, r := range runs {
+		switch r.RunType {
+		case coord.RunTypeLLM:
+			llm++
+		case coord.RunTypeTool:
+			tool++
+			if r.Depth != 2 {
+				t.Errorf("tool span depth = %d, want 2 (turn → llm → tool)", r.Depth)
+			}
+			if r.Name != "Bash" {
+				t.Errorf("tool span name = %q, want Bash", r.Name)
+			}
+		}
+	}
+	if llm != 1 || tool != 1 {
+		t.Errorf("spans: llm=%d tool=%d, want 1 and 1", llm, tool)
+	}
+	if traces[0].TotalTokens != 107 {
+		t.Errorf("rolled-up tokens = %d, want 107 (counted once, on the llm span)", traces[0].TotalTokens)
+	}
+}
+
+// TestNewSessionContextOnlyForFreshSessions pins the rule both channels now
+// share: memory and history are injected into a session's first turn only. A
+// resumed session already carries its history in the CLI; injecting again
+// pollutes the context (an old topic overriding the user's current intent).
+func TestNewSessionContextOnlyForFreshSessions(t *testing.T) {
+	dir := t.TempDir()
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	store := storage.NewMessageStore(sdb)
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+	h := &Handler{
+		sessions: sessions,
+		messages: store,
+		memory:   memory.NewManager(memory.Config{}),
+	}
+
+	// Through the manager, not session.New: messages reference sessions by
+	// foreign key, so a session must exist in the store before it can have any.
+	sess := sessions.Get(7)
+	if err := store.Append(sess.ID, agent.Message{Role: "user", Content: "earlier question"}); err != nil {
+		t.Fatalf("seed history: %v", err)
+	}
+
+	if got := h.NewSessionContext(sess); !strings.Contains(got, "earlier question") {
+		t.Errorf("fresh session must receive recent history, got %q", got)
+	}
+
+	sess.SetSessionID("already-known-to-the-cli")
+	if got := h.NewSessionContext(sess); got != "" {
+		t.Errorf("resumed session must receive nothing, got %q", got)
+	}
+}

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -33,6 +33,28 @@ type Client interface {
 	Name() string
 }
 
+// TurnSink is where a turn's output goes as it happens — the one part of a turn
+// that knows which channel it is talking to. Telegram edits a message in place;
+// the dashboard pushes WebSocket events. Everything else about a turn (trace,
+// transcript, message store, memory, auto-continue) is channel-agnostic and
+// lives once, in the bot's turn engine.
+//
+// It is declared here, in the neutral package, rather than in bot or gateway:
+// Go compares method parameter types by identity, so two structurally equal
+// interfaces in two packages would make the engine satisfy neither caller.
+type TurnSink interface {
+	// Write appends a chunk of the assistant's reply.
+	Write(chunk string)
+	// NoteTool reports a tool the model just invoked, as a short label.
+	NoteTool(label string)
+	// Flush forces any buffered output out before something else is sent.
+	Flush()
+	// SendPhoto delivers an image the turn produced (e.g. a screenshot).
+	SendPhoto(path, caption string)
+	// Finalize marks the reply complete.
+	Finalize()
+}
+
 // ExtractScreenshotPath finds the .png/.jpg path in a screencapture command so
 // the bot can send the file as a photo instead of echoing the shell output.
 // Handles quoted paths like screencapture -x "/tmp/foo.png".

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,7 +13,9 @@ import (
 	"time"
 
 	"github.com/ngocp/goterm-control/internal/agent"
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/trace"
@@ -46,6 +49,62 @@ type Deps struct {
 	// NotesFile is the markdown rendering of shared notes, rewritten whenever
 	// a note is added so agents can read it with their file tools.
 	NotesFile string
+
+	// Turn is the bot's turn engine. When set, dashboard messages run through
+	// it and therefore behave exactly like Telegram messages: the CLI owns the
+	// tool loop, memory is injected, the messages table is written, and the
+	// trace has tool spans. Nil only when the Telegram bot failed to start —
+	// the handler then falls back to the standalone agent loop and says so.
+	Turn TurnRunner
+}
+
+// TurnRunner is the slice of *bot.Handler the gateway needs. Declared here so
+// gateway does not have to import bot.
+type TurnRunner interface {
+	RunTurn(ctx context.Context, sess *session.Session, chatID int64, modelID, userText string, sink TurnSink) (*execution.RunResult, error)
+}
+
+// TurnSink is the shared channel-output contract; wsSink implements it over a
+// WebSocket. Must be the same named type bot uses, or *bot.Handler would not
+// satisfy TurnRunner — Go matches method parameter types by identity.
+type TurnSink = chat.TurnSink
+
+// wsSink delivers a turn to a dashboard client as stream events. It is the
+// dashboard's counterpart of the Telegram Streamer: same interface, different
+// wire. It also keeps the assembled reply so the caller can hand it back in
+// the final response frame.
+type wsSink struct {
+	emit func(StreamEvent)
+	mu   sync.Mutex
+	text strings.Builder
+}
+
+func (w *wsSink) Write(chunk string) {
+	w.mu.Lock()
+	w.text.WriteString(chunk)
+	w.mu.Unlock()
+	w.emit(StreamEvent{Type: "stream", Event: "text", Data: chunk})
+}
+
+func (w *wsSink) NoteTool(label string) {
+	w.emit(StreamEvent{Type: "stream", Event: "tool", Data: label})
+}
+
+// Flush and Finalize exist for Telegram, where output is batched into message
+// edits. WebSocket delivery is already immediate.
+func (w *wsSink) Flush()    {}
+func (w *wsSink) Finalize() {}
+
+// SendPhoto has no dashboard equivalent yet; surface the path so the user can
+// open it, instead of silently dropping the screenshot.
+func (w *wsSink) SendPhoto(path, caption string) {
+	w.emit(StreamEvent{Type: "stream", Event: "tool", Data: caption + ": " + path})
+}
+
+func (w *wsSink) Text() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.text.String()
 }
 
 // NewMethodHandler creates a MethodHandler that routes to the appropriate handler.
@@ -290,6 +349,43 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			sess = deps.Sessions.Get(dashboardChatID) // creates it on first use
 		}
 
+		// One execution path for both channels. The turn engine persists the
+		// user message, the reply, the transcript, the session counters and
+		// the trace itself — the same way it does for Telegram — so this
+		// handler only has to move bytes to the socket and send the final
+		// response frame.
+		if deps.Turn != nil && sess != nil {
+			modelID := deps.Resolver.Default()
+			if p.ModelID != "" {
+				if m := deps.Resolver.Lookup(p.ModelID); m != nil {
+					modelID = m.ID
+				}
+			}
+			agentCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+
+			sink := &wsSink{emit: emit}
+			result, err := deps.Turn.RunTurn(agentCtx, sess, sess.ChatID, modelID, p.Message, sink)
+			if err != nil {
+				errMsg := err.Error()
+				if agentCtx.Err() != nil {
+					errMsg = "Request timed out (5 min limit). Partial response saved."
+				}
+				emit(StreamEvent{Type: "stream", Event: "error", Data: errMsg})
+			} else if result != nil && result.Status == execution.RunFailed && result.Error != nil {
+				emit(StreamEvent{Type: "stream", Event: "error", Data: result.Error.Error()})
+			}
+
+			finalResult, _ := json.Marshal(map[string]any{
+				"text":       sink.Text(),
+				"session_id": sess.ID,
+				"iterations": 0,
+			})
+			emit(StreamEvent{Type: "response", Data: string(finalResult)})
+			return
+		}
+		log.Printf("gateway: turn engine unavailable — running dashboard message through the standalone agent loop (no memory, no CLI tool loop)")
+
 		tw := transcript.NewWriter(filepath.Join(deps.DataDir, "transcripts"))
 
 		// Persist user message IMMEDIATELY so it survives reload
@@ -473,8 +569,9 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			})
 		}
 
-		// Record the turn against the session, the same way the Telegram path
-		// does, so the session list reflects what actually happened here.
+		// Fallback path only: the standalone loop does not touch session
+		// counters, so record the turn by hand. On the shared path above the
+		// engine already did this — counting here too would double it.
 		if sess != nil {
 			sess.IncrementMessages()
 			if result != nil {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -70,14 +70,29 @@ func NewManager(store SessionPersister) *Manager {
 
 // Get returns the active session for a chat, creating a new ChatState if needed.
 // This is the hot path — all existing callers continue to work unchanged.
+//
+// A session created here is written to the store BEFORE it is returned. Other
+// tables reference sessions by foreign key, and the first message of a new chat
+// arrives well inside the one-second save debounce — under the debounce alone
+// that message was rejected with "FOREIGN KEY constraint failed" and silently
+// lost. SaveNow runs after the lock is released: it takes the read lock itself.
 func (m *Manager) Get(chatID int64) *Session {
+	s, created := m.getOrCreate(chatID)
+	if created {
+		m.SaveNow()
+	}
+	return s
+}
+
+// getOrCreate does Get's locked work and reports whether it created a session.
+func (m *Manager) getOrCreate(chatID int64) (*Session, bool) {
 	m.mu.RLock()
 	cs, ok := m.chats[chatID]
 	m.mu.RUnlock()
 
 	if ok {
 		if s, exists := cs.Sessions[cs.ActiveSessionID]; exists {
-			return s
+			return s, false
 		}
 	}
 
@@ -86,14 +101,14 @@ func (m *Manager) Get(chatID int64) *Session {
 	// Double-check after acquiring write lock
 	if cs, ok = m.chats[chatID]; ok {
 		if s, exists := cs.Sessions[cs.ActiveSessionID]; exists {
-			return s
+			return s, false
 		}
 		// ChatState exists but ActiveSessionID is stale — recover by picking
 		// the most recently updated session instead of wiping all sessions.
 		if len(cs.Sessions) > 0 {
 			cs.ActiveSessionID = pickMostRecentSession(cs.Sessions)
 			m.scheduleSave()
-			return cs.Sessions[cs.ActiveSessionID]
+			return cs.Sessions[cs.ActiveSessionID], false
 		}
 		// No sessions left in this ChatState — create a new one in place.
 		s := New(chatID)
@@ -102,8 +117,7 @@ func (m *Manager) Get(chatID int64) *Session {
 		if cs.NextSeq < 1 {
 			cs.NextSeq = 1
 		}
-		m.scheduleSave()
-		return s
+		return s, true
 	}
 
 	// Brand new chat — create ChatState with first session.
@@ -113,8 +127,7 @@ func (m *Manager) Get(chatID int64) *Session {
 		NextSeq:         1,
 		Sessions:        map[string]*Session{s.ID: s},
 	}
-	m.scheduleSave()
-	return s
+	return s, true
 }
 
 // pickMostRecentSession returns the ID of the most recently updated session.
@@ -164,7 +177,19 @@ func (m *Manager) ListForChat(chatID int64) []*Session {
 
 // NewSession creates a new session for a chat and makes it active.
 // Returns error if the session limit is exceeded.
+//
+// Like Get, the new session is persisted before it is returned, for the same
+// foreign-key reason — see Get.
 func (m *Manager) NewSession(chatID int64) (*Session, error) {
+	s, err := m.newSession(chatID)
+	if err == nil {
+		m.SaveNow()
+	}
+	return s, err
+}
+
+// newSession does NewSession's locked work.
+func (m *Manager) newSession(chatID int64) (*Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -177,7 +202,6 @@ func (m *Manager) NewSession(chatID int64) (*Session, error) {
 			NextSeq:         1,
 			Sessions:        map[string]*Session{s.ID: s},
 		}
-		m.scheduleSave()
 		return s, nil
 	}
 
@@ -199,7 +223,6 @@ func (m *Manager) NewSession(chatID int64) (*Session, error) {
 	cs.Sessions[s.ID] = s
 	cs.ActiveSessionID = s.ID
 	cs.NextSeq = seq + 1
-	m.scheduleSave()
 	return s, nil
 }
 

--- a/internal/storage/session_persist_test.go
+++ b/internal/storage/session_persist_test.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/agent"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+// TestNewSessionIsPersistedBeforeUse covers a real production loss: the
+// manager used to persist a freshly created session on a one-second debounce,
+// but the first message of a new chat arrives well inside that second. The
+// messages table references sessions by foreign key, so that message was
+// rejected with "FOREIGN KEY constraint failed" and silently dropped (seen in
+// the agent 2 log, 2026-09-04 16:03). Telegram hit it only on a brand-new chat;
+// the dashboard, once on the shared engine, would hit it on the first message
+// of every new session.
+func TestNewSessionIsPersistedBeforeUse(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "goterm.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	mgr := session.NewManager(NewSessionStore(db))
+	msgs := NewMessageStore(db)
+
+	// Brand-new chat via Get — the dashboard's path.
+	got := mgr.Get(42)
+	if err := msgs.Append(got.ID, agent.Message{Role: "user", Content: "first ever message"}); err != nil {
+		t.Fatalf("first message of a new chat was rejected: %v", err)
+	}
+
+	// Explicit /new — the Telegram path — must be just as safe.
+	fresh, err := mgr.NewSession(42)
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	if fresh.ID == got.ID {
+		t.Fatalf("NewSession returned the existing session %s", fresh.ID)
+	}
+	if err := msgs.Append(fresh.ID, agent.Message{Role: "user", Content: "first message after /new"}); err != nil {
+		t.Fatalf("first message after /new was rejected: %v", err)
+	}
+
+	// And the rows are really there, not just accepted by a lenient store.
+	var n int
+	if err := db.Conn().QueryRow(`SELECT count(*) FROM sessions WHERE chat_id = 42`).Scan(&n); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("sessions persisted = %d, want 2 (both created sessions, synchronously)", n)
+	}
+}


### PR DESCRIPTION
**S0 trong `docs/design/sessions-and-workspaces.md`** — bước chặn mọi bước sau của việc đồng bộ web ↔ Telegram.

## Vấn đề

Dashboard và Telegram là **hai hệ thống khác nhau** dùng chung một binary:

| | Telegram | Dashboard (trước) |
|---|---|---|
| Đường thực thi | `chat.Client` — CLI sở hữu tool loop | `agent.RunAgent` — tool loop của ta |
| Memory dài hạn | có | **không** |
| Lịch sử | CLI resume + bảng `messages` | file transcript, **cắt 40 message** |
| Bảng `messages` | ghi | **không ghi** |
| Tool span trong trace | có | **không** |

Mỗi tính năng sau đó phải làm hai lần, hoặc lệch nhau dần.

## Cách làm

Phần **duy nhất** Telegram-specific trong một lượt là *đầu ra đi đâu*. Tách nó thành interface `chat.TurnSink` (`Write/NoteTool/Flush/SendPhoto/Finalize`) — `*Streamer` của Telegram đã thoả sẵn, gateway cung cấp sink WebSocket. `runClaude` nhận sink thay vì tự dựng Streamer; `Handler.RunTurn` phơi nó ra. Streaming send handler của gateway gọi `RunTurn` — **xếp hàng trên execution engine theo chat**, nên một tin web và một tin Telegram của cùng chat không bao giờ chạy đè nhau. Đường `RunAgent` cũ chỉ còn là fallback có log khi bot Telegram không khởi động được.

`TurnSink` nằm ở package trung lập `chat` **có chủ ý**: Go so kiểu tham số theo *identity*, hai interface giống hệt khai báo ở `bot` và `gateway` sẽ làm `RunTurn` không thoả bên nào — compiler bắt đúng chỗ này.

## Bug thật sửa kèm — vì S0 sẽ biến nó thành thường trực

Manager lưu session mới theo debounce **1 giây**, nhưng tin đầu của chat mới đến trong khe đó. `messages.session_id` tham chiếu FK sang `sessions`, nên tin đó bị **từ chối và mất im lặng**. Có bằng chứng trong log agent 2 (2026-09-04 16:03):

```
handler: message store user error: constraint failed: FOREIGN KEY constraint failed (787)
```

Telegram chỉ gặp khi chat hoàn toàn mới. Dashboard qua đường chung sẽ gặp **ở tin đầu của mọi session mới**. `Get`/`NewSession` giờ ghi session xuống DB **đồng bộ**, sau khi thả lock (`SaveNow` tự lấy `RLock` — gọi trong lock là deadlock).

## Test

- `TestRunTurnIsTheTelegramPath` — gọi `RunTurn` từ caller không phải Telegram, khẳng định đủ dấu chân Telegram: dòng `messages`, event transcript kể cả `tool_call`, counter, label, và trace `turn → llm → tool` với token **đếm một lần**.
- `TestNewSessionIsPersistedBeforeUse` — tái hiện mất tin FK cho cả `Get` lẫn `/new`. **Đã kiểm chứng fail trên manager cũ với đúng thông điệp production.**

Full suite xanh. Làm trong worktree riêng vì một phiên khác đang sửa dở `methods.go`/`handler.go` trên checkout chính — edit của họ thuần thêm (transcript stamp), không giao vùng này.

🤖 Generated with [Claude Code](https://claude.com/claude-code)