### PR TITLE
feat(storage,gateway): one conversation across Telegram and the dashboard (S1)

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -233,6 +233,20 @@ func runGateway(args []string) {
 	// Session manager (SQLite-backed)
 	sessions := session.NewManager(storage.NewSessionStore(db))
 
+	// Channel → conversation bindings. Every Telegram chat the manager knows
+	// binds to itself so the bindings table is a complete picture; the web
+	// account then joins the Telegram conversation when there is exactly one.
+	conversations := storage.NewConversationStore(db)
+	seen := map[int64]bool{}
+	var chatIDs []int64
+	for _, s := range sessions.List() {
+		if !seen[s.ChatID] {
+			seen[s.ChatID] = true
+			chatIDs = append(chatIDs, s.ChatID)
+		}
+	}
+	conversations.EnsureTelegramBindings(chatIDs)
+
 	// Shared coordination database — traces, tasks and inter-agent messages,
 	// written by every agent on this machine into one file. A failure here is
 	// not fatal: the agent still answers, it just becomes invisible to the
@@ -299,18 +313,19 @@ func runGateway(args []string) {
 	}
 
 	deps := gateway.Deps{
-		Sessions:     sessions,
-		Resolver:     resolver,
-		Provider:     provider,
-		System:       cfg.Claude.SystemPrompt,
-		DataDir:      cfg.Session.DataDir,
-		Uptime:       func() time.Duration { return time.Since(startTime) },
-		Coord:        coordDB,
-		AgentID:      cfg.Agent.ID,
-		ProviderName: cfg.Provider,
-		Trace:        gwTrace,
-		PokeTasks:    runner.Poke,
-		NotesFile:    cfg.Coord.NotesFile,
+		Sessions:      sessions,
+		Resolver:      resolver,
+		Provider:      provider,
+		System:        cfg.Claude.SystemPrompt,
+		DataDir:       cfg.Session.DataDir,
+		Uptime:        func() time.Duration { return time.Since(startTime) },
+		Coord:         coordDB,
+		AgentID:       cfg.Agent.ID,
+		ProviderName:  cfg.Provider,
+		Trace:         gwTrace,
+		PokeTasks:     runner.Poke,
+		NotesFile:     cfg.Coord.NotesFile,
+		Conversations: conversations,
 	}
 	if tgBot != nil {
 		// Dashboard messages run through the bot's turn engine, so both

--- a/docs/design/sessions-and-workspaces.md
+++ b/docs/design/sessions-and-workspaces.md
@@ -316,8 +316,8 @@ submitted → working → in_review → completed
 
 | Giai đoạn | Nội dung | Điều kiện hoàn thành |
 |---|---|---|
-| **S0 — Hợp nhất đường thực thi** | Dashboard dùng `chat.Client` thay `agent.RunAgent` | Cùng một câu hỏi từ web và Telegram sinh ra trace cùng hình dạng (có tool span), web có memory |
-| **S1 — Conversation** | Bảng `conversations` + `channel_bindings`; `sessions.conversation_id`; migrate `chat_id` hiện có | Nhắn Telegram, mở web thấy đúng hội thoại đó và ngược lại |
+| ~~**S0 — Hợp nhất đường thực thi**~~ ✅ | Dashboard dùng `chat.Client` thay `agent.RunAgent` | **Xong (PR #75).** Gateway gọi `bot.Handler.RunTurn` qua `chat.TurnSink`; đo thật trên dashboard: `turn → codex → Bash`, có dòng `messages`, có `tool_call` trong transcript. Sửa kèm: Manager ghi session mới đồng bộ — trước đó tin đầu của chat mới rơi vào khe debounce 1s và bị FK từ chối |
+| ~~**S1 — Conversation**~~ ✅ | Bảng `conversations` + `channel_bindings`; migrate `chat_id` hiện có | **Xong (PR #76).** *Lệch so với bản thiết kế, có chủ ý*: **không** thêm `sessions.conversation_id` — khoá hội thoại chính là `sessions.chat_id` mà Manager đã dùng; `channel_bindings` ánh xạ `telegram:<id>` và `web:1` vào cùng khoá đó. Đổi ít hơn, không phải đụng Manager. Quy tắc single-user: đúng một chat Telegram → web gộp vào; nhiều hơn → web giữ riêng và log, người quyết định |
 | **S2 — Một nguồn lịch sử** | Cả hai kênh ghi `messages` + transcript; UI đọc `messages` | Bỏ được giới hạn cắt 40 message của đường web |
 | **S3 — Session workspace** | `~/.goterm/sessions/<id>/`, inject vào prompt, chuyển `inputs`/`outputs` lớn ra file | Agent đặt sản phẩm đúng chỗ; bảng `runs` ngừng phình |
 | **S4 — Nối task** | `tasks.session_id`, `sessions.task_id`; taskrunner dùng session thật | Từ admin page bấm task → xem được artifact và trace của nó |

--- a/internal/gateway/conversation_test.go
+++ b/internal/gateway/conversation_test.go
@@ -1,0 +1,115 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/models"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/storage"
+)
+
+// capturingTurn is a TurnRunner that records which session it was handed.
+type capturingTurn struct {
+	sessionID string
+	chatID    int64
+}
+
+func (c *capturingTurn) RunTurn(ctx context.Context, sess *session.Session, chatID int64,
+	modelID, userText string, sink TurnSink) (*execution.RunResult, error) {
+	c.sessionID = sess.ID
+	c.chatID = chatID
+	sink.Write("ok")
+	return &execution.RunResult{SessionID: sess.ID, Status: execution.RunSuccess}, nil
+}
+
+// TestDashboardMessageLandsInTheBoundConversation is S1's acceptance test: a
+// dashboard message with no session named must run on the ACTIVE session of the
+// conversation the web account is bound to — the Telegram one — not on a
+// dashboard-private chat_1.
+func TestDashboardMessageLandsInTheBoundConversation(t *testing.T) {
+	dir := t.TempDir()
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+	// The Telegram side has been talking: chat 555, currently on its 2nd session.
+	sessions.Get(555)
+	telegramActive, err := sessions.NewSession(555)
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+
+	conv := storage.NewConversationStore(sdb)
+	conv.EnsureTelegramBindings([]int64{555})
+
+	turn := &capturingTurn{}
+	deps := Deps{
+		Sessions:      sessions,
+		Resolver:      models.NewResolver("claude-opus-4-8", nil),
+		DataDir:       dir,
+		Conversations: conv,
+		Turn:          turn,
+	}
+
+	params, _ := json.Marshal(SendParams{Message: "hello from the web"})
+	var final string
+	NewStreamSendHandler(deps)(context.Background(),
+		Request{ID: "1", Method: "send", Params: params},
+		func(ev StreamEvent) {
+			if ev.Type == "response" {
+				final = ev.Data
+			}
+		})
+
+	if turn.sessionID != telegramActive.ID {
+		t.Errorf("dashboard message ran on %q, want the Telegram conversation's active session %q",
+			turn.sessionID, telegramActive.ID)
+	}
+	if turn.chatID != 555 {
+		t.Errorf("queued on chat lane %d, want 555 (so web and Telegram never run concurrently)", turn.chatID)
+	}
+	if turn.sessionID == "chat_1" {
+		t.Error("message fell back to the dashboard-private chat")
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(final), &resp); err != nil {
+		t.Fatalf("response frame: %v (%q)", err, final)
+	}
+	if resp["session_id"] != telegramActive.ID {
+		t.Errorf("response session_id = %v, want %q so the UI selects the shared session", resp["session_id"], telegramActive.ID)
+	}
+}
+
+// Without a conversation store the gateway must keep the old behaviour so
+// minimal setups and existing tests are unaffected.
+func TestDashboardFallsBackToFixedChatWithoutBindings(t *testing.T) {
+	dir := t.TempDir()
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	turn := &capturingTurn{}
+	deps := Deps{
+		Sessions: session.NewManager(storage.NewSessionStore(sdb)),
+		Resolver: models.NewResolver("claude-opus-4-8", nil),
+		DataDir:  dir,
+		Turn:     turn,
+	}
+	params, _ := json.Marshal(SendParams{Message: "hi"})
+	NewStreamSendHandler(deps)(context.Background(),
+		Request{ID: "1", Method: "send", Params: params}, func(StreamEvent) {})
+
+	if turn.chatID != dashboardChatID {
+		t.Errorf("chat lane = %d, want the fixed dashboard chat %d", turn.chatID, dashboardChatID)
+	}
+}

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/storage"
 	"github.com/ngocp/goterm-control/internal/trace"
 	"github.com/ngocp/goterm-control/internal/transcript"
 )
@@ -49,6 +50,10 @@ type Deps struct {
 	// NotesFile is the markdown rendering of shared notes, rewritten whenever
 	// a note is added so agents can read it with their file tools.
 	NotesFile string
+
+	// Conversations maps channels to conversation keys. Nil falls back to the
+	// old fixed dashboard chat, so tests and minimal setups keep working.
+	Conversations *storage.ConversationStore
 
 	// Turn is the bot's turn engine. When set, dashboard messages run through
 	// it and therefore behave exactly like Telegram messages: the CLI owns the
@@ -330,23 +335,20 @@ func NewStreamSendHandler(deps Deps) StreamSendHandler {
 			return
 		}
 
-		// Use session_id from client, or create a default
+		// With no session named, the message goes to the ACTIVE session of the
+		// conversation the dashboard is bound to — normally the very session
+		// Telegram is on, which is what makes the two channels one
+		// conversation. A named session is used as-is; one that resolves to
+		// nothing stays unresolved rather than being silently redirected into
+		// the default conversation, so the message lands in the transcript
+		// the caller asked for.
+		var sess *session.Session
 		sessionID := p.SessionID
 		if sessionID == "" {
-			sessionID = fmt.Sprintf("chat_%d", dashboardChatID)
-		}
-
-		// Resolve a real session so the dashboard's own conversation is a
-		// first-class session with turn and token counts. Without this it only
-		// ever existed as a transcript file, and sessions.list synthesised a
-		// stub for it that always read "0 turns · 0 tokens".
-		//
-		// Deliberately does NOT change which transcript is written: a session
-		// id that resolves to nothing stays unresolved rather than silently
-		// redirecting the user's message into the default conversation.
-		sess := deps.Sessions.GetByID(sessionID)
-		if sess == nil && sessionID == fmt.Sprintf("chat_%d", dashboardChatID) {
-			sess = deps.Sessions.Get(dashboardChatID) // creates it on first use
+			sess = deps.Sessions.Get(webConversation(deps))
+			sessionID = sess.ID
+		} else {
+			sess = deps.Sessions.GetByID(sessionID)
 		}
 
 		// One execution path for both channels. The turn engine persists the
@@ -641,7 +643,7 @@ func transcriptToMessages(events []transcript.Event) []agent.Message {
 }
 
 func handleCancel(deps Deps) (json.RawMessage, error) {
-	sess := deps.Sessions.Get(dashboardChatID)
+	sess := deps.Sessions.Get(webConversation(deps))
 	sess.Cancel()
 	return json.Marshal(map[string]string{"status": "cancelled"})
 }
@@ -692,8 +694,19 @@ func labelFromMessage(msg string) string {
 	return label
 }
 
-// dashboardChatID is a fixed chatID for dashboard sessions.
-const dashboardChatID int64 = 1
+// dashboardChatID is the conversation the dashboard falls back to when no
+// conversation store is wired (tests, or a gateway built without one). With a
+// store, webConversation resolves the web account's binding instead — which,
+// for a single user, is the Telegram conversation.
+const dashboardChatID = storage.DashboardConversationID
+
+// webConversation returns the conversation key the dashboard should use.
+func webConversation(deps Deps) int64 {
+	if deps.Conversations != nil {
+		return deps.Conversations.ResolveWeb()
+	}
+	return dashboardChatID
+}
 
 func handleSend(ctx context.Context, deps Deps, params json.RawMessage) (json.RawMessage, error) {
 	var p SendParams

--- a/internal/storage/conversations.go
+++ b/internal/storage/conversations.go
@@ -1,0 +1,166 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+// Channel names for channel_bindings.
+const (
+	ChannelTelegram = "telegram"
+	ChannelWeb      = "web"
+)
+
+// WebAccountID is the external id the single dashboard account binds under.
+// The dashboard has one account (PR #63), so one id is enough; a multi-user
+// dashboard would bind each login separately.
+const WebAccountID = "1"
+
+// DashboardConversationID is the conversation a web login gets when there is
+// no Telegram conversation to join. It matches the old hardcoded dashboard chat
+// id, so a fresh install without Telegram behaves exactly as before.
+const DashboardConversationID int64 = 1
+
+// ConversationStore resolves a channel (Telegram chat, web login) to the
+// conversation it belongs to.
+//
+// A conversation is identified by the same integer key the session manager has
+// always used for a chat — sessions.chat_id. Nothing about sessions changes;
+// the bindings table is what lets two channels share one key. This is the whole
+// mechanism behind "the dashboard shows the Telegram conversation": both
+// channels resolve to the same key, so they get the same active session, the
+// same history and the same execution lane.
+type ConversationStore struct {
+	db *DB
+}
+
+// NewConversationStore creates a store backed by the given database.
+func NewConversationStore(db *DB) *ConversationStore {
+	return &ConversationStore{db: db}
+}
+
+// Resolve returns the conversation bound to (channel, externalID).
+// ok is false when nothing is bound yet.
+func (s *ConversationStore) Resolve(channel, externalID string) (int64, bool) {
+	var id int64
+	err := s.db.conn.QueryRow(`SELECT conversation_id FROM channel_bindings
+		WHERE channel = ? AND external_id = ?`, channel, externalID).Scan(&id)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+// Bind points (channel, externalID) at a conversation, creating the
+// conversation row if needed. Rebinding an existing pair replaces it.
+func (s *ConversationStore) Bind(channel, externalID string, conversationID int64) error {
+	tx, err := s.db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("bind: %w", err)
+	}
+	defer tx.Rollback()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := tx.Exec(`INSERT INTO conversations (id, title, created_at, updated_at)
+		VALUES (?, '', ?, ?) ON CONFLICT(id) DO NOTHING`, conversationID, now, now); err != nil {
+		return fmt.Errorf("bind: ensure conversation %d: %w", conversationID, err)
+	}
+	if _, err := tx.Exec(`INSERT INTO channel_bindings (channel, external_id, conversation_id, created_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(channel, external_id) DO UPDATE SET conversation_id = excluded.conversation_id`,
+		channel, externalID, conversationID, now); err != nil {
+		return fmt.Errorf("bind %s:%s: %w", channel, externalID, err)
+	}
+	return tx.Commit()
+}
+
+// ResolveWeb returns the conversation the dashboard should use, binding one on
+// first use.
+//
+// The default follows the single-user rule: when exactly one Telegram
+// conversation exists, the dashboard joins it — the whole point is that typing
+// on the web and typing on Telegram are the same conversation. With none, the
+// dashboard gets its own (DashboardConversationID). With several, it also gets
+// its own, and the log says a person has to choose; guessing which of several
+// people's chats the dashboard should join is not the code's call to make.
+func (s *ConversationStore) ResolveWeb() int64 {
+	if id, ok := s.Resolve(ChannelWeb, WebAccountID); ok {
+		return id
+	}
+	target := DashboardConversationID
+	telegram, err := s.conversationsFor(ChannelTelegram)
+	switch {
+	case err != nil:
+		log.Printf("conversations: listing telegram bindings: %v — dashboard uses its own conversation", err)
+	case len(telegram) == 1:
+		target = telegram[0]
+		log.Printf("conversations: dashboard joins the Telegram conversation %d", target)
+	case len(telegram) > 1:
+		log.Printf("conversations: %d Telegram conversations exist — dashboard keeps its own (%d); bind it explicitly to join one",
+			len(telegram), target)
+	}
+	if err := s.Bind(ChannelWeb, WebAccountID, target); err != nil {
+		log.Printf("conversations: %v", err)
+	}
+	return target
+}
+
+// EnsureTelegramBindings makes sure every Telegram chat the manager knows has a
+// binding row. Telegram chats map to themselves (conversation id = chat id), so
+// this is bookkeeping — it keeps the bindings table a complete picture of who
+// is talking to the agent, which ResolveWeb's single-user rule relies on.
+func (s *ConversationStore) EnsureTelegramBindings(chatIDs []int64) {
+	for _, id := range chatIDs {
+		if id == DashboardConversationID {
+			continue
+		}
+		if _, ok := s.Resolve(ChannelTelegram, fmt.Sprint(id)); ok {
+			continue
+		}
+		if err := s.Bind(ChannelTelegram, fmt.Sprint(id), id); err != nil {
+			log.Printf("conversations: %v", err)
+		}
+	}
+}
+
+// conversationsFor lists the distinct conversations bound through a channel.
+func (s *ConversationStore) conversationsFor(channel string) ([]int64, error) {
+	rows, err := s.db.conn.Query(`SELECT DISTINCT conversation_id FROM channel_bindings
+		WHERE channel = ? ORDER BY conversation_id`, channel)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// mergeChats moves every session of `from` under `to` and drops `from`'s chat
+// state, so the manager sees one chat with the union of both histories. The
+// active session stays whatever `to` had — a merge must not yank a live
+// Telegram conversation onto the dashboard's last session.
+func mergeChats(tx *sql.Tx, from, to int64) error {
+	if _, err := tx.Exec(`UPDATE sessions SET chat_id = ? WHERE chat_id = ?`, to, from); err != nil {
+		return fmt.Errorf("move sessions %d→%d: %w", from, to, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM chat_state WHERE chat_id = ?`, from); err != nil {
+		return fmt.Errorf("drop chat_state %d: %w", from, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM conversations WHERE id = ?`, from); err != nil {
+		return fmt.Errorf("drop conversation %d: %w", from, err)
+	}
+	return nil
+}
+
+// errNoChats marks a database with no conversations to migrate.
+var errNoChats = errors.New("no chats")

--- a/internal/storage/conversations_test.go
+++ b/internal/storage/conversations_test.go
@@ -1,0 +1,238 @@
+package storage
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// seedV5 builds a v5 database by hand: a dashboard chat (1) with its single
+// session, plus the given Telegram chats, each with two sessions of which the
+// second is active. Returns the path.
+func seedV5(t *testing.T, telegramChats ...int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "v5.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	defer raw.Close()
+
+	stmts := []string{
+		`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		`INSERT INTO meta(key, value) VALUES('schema_version', '5')`,
+		`CREATE TABLE sessions (
+			id                TEXT PRIMARY KEY,
+			chat_id           INTEGER NOT NULL,
+			created_at        TEXT NOT NULL,
+			updated_at        TEXT NOT NULL,
+			claude_session_id TEXT DEFAULT '',
+			message_count     INTEGER DEFAULT 0,
+			input_tokens      INTEGER DEFAULT 0,
+			output_tokens     INTEGER DEFAULT 0,
+			compact_summary   TEXT DEFAULT '',
+			label             TEXT DEFAULT '',
+			seq               INTEGER DEFAULT 0,
+			memory_flushed    INTEGER DEFAULT 0,
+			provider          TEXT DEFAULT 'claude'
+		)`,
+		`CREATE TABLE chat_state (
+			chat_id           INTEGER PRIMARY KEY,
+			active_session_id TEXT NOT NULL,
+			next_seq          INTEGER DEFAULT 1
+		)`,
+		`CREATE TABLE messages (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id   TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+			role         TEXT NOT NULL,
+			content      TEXT NOT NULL,
+			tool_calls   TEXT DEFAULT '',
+			tool_results TEXT DEFAULT '',
+			tokens       INTEGER DEFAULT 0,
+			created_at   TEXT NOT NULL
+		)`,
+		`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL,
+			password_hash TEXT NOT NULL, role TEXT DEFAULT 'admin', created_at TEXT NOT NULL)`,
+		`CREATE TABLE web_sessions (token_hash TEXT PRIMARY KEY, user_id INTEGER NOT NULL,
+			expires_at TEXT NOT NULL, created_at TEXT NOT NULL)`,
+		// the dashboard's lone session, with one message
+		`INSERT INTO sessions (id, chat_id, created_at, updated_at, message_count, label)
+			VALUES ('chat_1', 1, '2026-09-01T10:00:00Z', '2026-09-01T10:00:00Z', 3, 'web chat')`,
+		`INSERT INTO chat_state VALUES (1, 'chat_1', 1)`,
+		`INSERT INTO messages (session_id, role, content, created_at)
+			VALUES ('chat_1', 'user', 'hello from the web', '2026-09-01T10:00:00Z')`,
+	}
+	for _, s := range stmts {
+		if _, err := raw.Exec(s); err != nil {
+			t.Fatalf("seed v5: %v\n%s", err, s)
+		}
+	}
+	for _, chat := range telegramChats {
+		for _, s := range []string{
+			`INSERT INTO sessions (id, chat_id, created_at, updated_at, message_count, seq)
+				VALUES ('chat_%d_1', %d, '2026-09-02T10:00:00Z', '2026-09-02T10:00:00Z', 5, 1)`,
+			`INSERT INTO sessions (id, chat_id, created_at, updated_at, message_count, seq)
+				VALUES ('chat_%d_2', %d, '2026-09-03T10:00:00Z', '2026-09-03T10:00:00Z', 2, 2)`,
+			`INSERT INTO chat_state VALUES (%d, 'chat_%d_2', 3)`,
+		} {
+			if _, err := raw.Exec(sprintf2(s, chat)); err != nil {
+				t.Fatalf("seed telegram %d: %v", chat, err)
+			}
+		}
+	}
+	return path
+}
+
+func sprintf2(format string, n int64) string {
+	// every placeholder in the seed statements is the same chat id
+	out := format
+	for i := 0; i < 4; i++ {
+		out = replaceFirst(out, "%d", itoa(n))
+	}
+	return out
+}
+
+func replaceFirst(s, old, new string) string {
+	for i := 0; i+len(old) <= len(s); i++ {
+		if s[i:i+len(old)] == old {
+			return s[:i] + new + s[i+len(old):]
+		}
+	}
+	return s
+}
+
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func count(t *testing.T, db *DB, q string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.Conn().QueryRow(q, args...).Scan(&n); err != nil {
+		t.Fatalf("%s: %v", q, err)
+	}
+	return n
+}
+
+// TestMigrateV5ToV6MergesDashboardIntoTheOnlyTelegramChat covers the
+// single-user case this whole migration exists for: one person, one Telegram
+// chat, one dashboard — two unrelated histories until now.
+func TestMigrateV5ToV6MergesDashboardIntoTheOnlyTelegramChat(t *testing.T) {
+	db, err := Open(seedV5(t, 555))
+	if err != nil {
+		t.Fatalf("Open (migrate): %v", err)
+	}
+	defer db.Close()
+
+	conv := NewConversationStore(db)
+
+	// Bindings: telegram to itself, the web account into the Telegram chat.
+	if id, ok := conv.Resolve(ChannelTelegram, "555"); !ok || id != 555 {
+		t.Errorf("telegram binding = %d,%v; want 555", id, ok)
+	}
+	if id, ok := conv.Resolve(ChannelWeb, WebAccountID); !ok || id != 555 {
+		t.Errorf("web binding = %d,%v; want 555 (merged)", id, ok)
+	}
+
+	// The dashboard's session moved under the Telegram chat; nothing was lost.
+	if n := count(t, db, `SELECT count(*) FROM sessions WHERE chat_id = 555`); n != 3 {
+		t.Errorf("sessions under 555 = %d, want 3 (two telegram + the moved web one)", n)
+	}
+	if n := count(t, db, `SELECT count(*) FROM sessions WHERE chat_id = 1`); n != 0 {
+		t.Errorf("sessions left under the dashboard chat = %d, want 0", n)
+	}
+	if n := count(t, db, `SELECT count(*) FROM messages WHERE session_id = 'chat_1'`); n != 1 {
+		t.Errorf("the web session's messages = %d, want 1 (moving a session must keep its rows)", n)
+	}
+
+	// The Telegram side stays active — a merge must not yank a live
+	// conversation onto the dashboard's last session.
+	var active string
+	if err := db.Conn().QueryRow(`SELECT active_session_id FROM chat_state WHERE chat_id = 555`).Scan(&active); err != nil {
+		t.Fatalf("chat_state 555: %v", err)
+	}
+	if active != "chat_555_2" {
+		t.Errorf("active session = %q, want chat_555_2", active)
+	}
+	if n := count(t, db, `SELECT count(*) FROM chat_state WHERE chat_id = 1`); n != 0 {
+		t.Errorf("dashboard chat_state survived the merge")
+	}
+	if n := count(t, db, `SELECT count(*) FROM conversations`); n != 1 {
+		t.Errorf("conversations = %d, want just the merged one", n)
+	}
+}
+
+// With several Telegram chats there is no safe default; the dashboard keeps its
+// own conversation and nothing moves. Choosing is a person's job.
+func TestMigrateV5ToV6KeepsDashboardApartWhenSeveralTelegramChats(t *testing.T) {
+	db, err := Open(seedV5(t, 555, 777))
+	if err != nil {
+		t.Fatalf("Open (migrate): %v", err)
+	}
+	defer db.Close()
+
+	conv := NewConversationStore(db)
+	if id, ok := conv.Resolve(ChannelWeb, WebAccountID); !ok || id != DashboardConversationID {
+		t.Errorf("web binding = %d,%v; want its own conversation %d", id, ok, DashboardConversationID)
+	}
+	if n := count(t, db, `SELECT count(*) FROM sessions WHERE chat_id = 1`); n != 1 {
+		t.Errorf("dashboard sessions = %d, want 1 (untouched)", n)
+	}
+	if n := count(t, db, `SELECT count(*) FROM conversations`); n != 3 {
+		t.Errorf("conversations = %d, want 3", n)
+	}
+}
+
+// A fresh install has no Telegram chat yet. The web account gets its own
+// conversation, and when the first Telegram chat appears later it is NOT merged
+// retroactively by ResolveWeb — the binding already exists and is honoured.
+func TestResolveWebBindsOnceAndHonoursIt(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "fresh.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	conv := NewConversationStore(db)
+	if got := conv.ResolveWeb(); got != DashboardConversationID {
+		t.Fatalf("fresh install: web conversation = %d, want %d", got, DashboardConversationID)
+	}
+
+	// A Telegram chat shows up afterwards.
+	conv.EnsureTelegramBindings([]int64{4242})
+	if got := conv.ResolveWeb(); got != DashboardConversationID {
+		t.Errorf("an existing web binding was silently re-pointed to %d", got)
+	}
+
+	// But an explicit rebind is honoured.
+	if err := conv.Bind(ChannelWeb, WebAccountID, 4242); err != nil {
+		t.Fatalf("rebind: %v", err)
+	}
+	if got := conv.ResolveWeb(); got != 4242 {
+		t.Errorf("after explicit bind, web conversation = %d, want 4242", got)
+	}
+}
+
+// The runtime rule mirrors the migration: with exactly one Telegram
+// conversation known, an UNBOUND web account joins it.
+func TestResolveWebJoinsTheOnlyTelegramConversation(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "one.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	conv := NewConversationStore(db)
+	conv.EnsureTelegramBindings([]int64{4242})
+	if got := conv.ResolveWeb(); got != 4242 {
+		t.Errorf("web conversation = %d, want the sole Telegram conversation 4242", got)
+	}
+}

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -1,11 +1,37 @@
 package storage
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"time"
+)
 
-const schemaVersion = 5
+const schemaVersion = 6
+
+// conversationDDL is shared by fresh installs (via ddl) and the v5→v6
+// migration, so the two can never drift apart.
+var conversationDDL = []string{
+	// A conversation is keyed by the same integer the session manager uses for
+	// a chat (sessions.chat_id). Two channels bound to one key share the active
+	// session, the history and the execution lane — that is the whole
+	// mechanism behind "the dashboard shows the Telegram conversation".
+	`CREATE TABLE IF NOT EXISTS conversations (
+		id         INTEGER PRIMARY KEY,
+		title      TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`,
+	`CREATE TABLE IF NOT EXISTS channel_bindings (
+		channel         TEXT NOT NULL,   -- 'telegram' | 'web'
+		external_id     TEXT NOT NULL,   -- telegram chat id, or the web account id
+		conversation_id INTEGER NOT NULL REFERENCES conversations(id),
+		created_at      TEXT NOT NULL,
+		PRIMARY KEY (channel, external_id)
+	)`,
+}
 
 // DDL statements executed in order for fresh installs.
-var ddl = []string{
+var ddl = append([]string{
 	`CREATE TABLE IF NOT EXISTS meta (
 		key   TEXT PRIMARY KEY,
 		value TEXT NOT NULL
@@ -60,7 +86,7 @@ var ddl = []string{
 		expires_at TEXT NOT NULL,
 		created_at TEXT NOT NULL
 	)`,
-}
+}, conversationDDL...)
 
 // migrate creates tables and imports legacy data if needed.
 func (db *DB) migrate() error {
@@ -108,9 +134,103 @@ func (db *DB) migrate() error {
 		if err := db.migrateV4ToV5(); err != nil {
 			return fmt.Errorf("migrate v4→v5: %w", err)
 		}
-		return db.setVersion(5)
+		if err := db.setVersion(5); err != nil {
+			return err
+		}
+		ver = 5
+	}
+	if ver < 6 {
+		if err := db.migrateV5ToV6(); err != nil {
+			return fmt.Errorf("migrate v5→v6: %w", err)
+		}
+		return db.setVersion(6)
 	}
 	return nil
+}
+
+// migrateV5ToV6 introduces conversations and channel bindings, and folds the
+// dashboard's private chat into the Telegram conversation.
+//
+// Until now the dashboard talked to a hardcoded chat (id 1) and Telegram to its
+// own chat id, so the same person had two unrelated histories. Every existing
+// chat becomes a conversation; every non-dashboard chat is a Telegram chat and
+// binds to itself. Then the single-user rule: with exactly one Telegram
+// conversation, the dashboard chat is merged into it — its sessions move over,
+// its chat_state goes, and the Telegram side's active session stays active so
+// a live conversation is not yanked onto the dashboard's last session. With
+// zero or several Telegram conversations the dashboard keeps its own; picking
+// one of several people's chats for it is a decision, not a migration.
+func (db *DB) migrateV5ToV6() error {
+	for _, stmt := range conversationDDL {
+		if _, err := db.conn.Exec(stmt); err != nil {
+			return err
+		}
+	}
+
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.Query(`SELECT DISTINCT chat_id FROM sessions
+		UNION SELECT chat_id FROM chat_state ORDER BY 1`)
+	if err != nil {
+		return fmt.Errorf("list chats: %w", err)
+	}
+	var chats []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		chats = append(chats, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	hasDashboard := false
+	var telegram []int64
+	for _, id := range chats {
+		if _, err := tx.Exec(`INSERT INTO conversations (id, title, created_at, updated_at)
+			VALUES (?, '', ?, ?) ON CONFLICT(id) DO NOTHING`, id, now, now); err != nil {
+			return fmt.Errorf("conversation %d: %w", id, err)
+		}
+		if id == DashboardConversationID {
+			hasDashboard = true
+			continue
+		}
+		telegram = append(telegram, id)
+		if _, err := tx.Exec(`INSERT INTO channel_bindings (channel, external_id, conversation_id, created_at)
+			VALUES (?, ?, ?, ?) ON CONFLICT(channel, external_id) DO NOTHING`,
+			ChannelTelegram, fmt.Sprint(id), id, now); err != nil {
+			return fmt.Errorf("bind telegram %d: %w", id, err)
+		}
+	}
+
+	if hasDashboard {
+		webTarget := DashboardConversationID
+		if len(telegram) == 1 {
+			webTarget = telegram[0]
+			if err := mergeChats(tx, DashboardConversationID, webTarget); err != nil {
+				return err
+			}
+			log.Printf("storage: merged the dashboard chat into Telegram conversation %d", webTarget)
+		} else if len(telegram) > 1 {
+			log.Printf("storage: %d Telegram conversations — dashboard keeps its own chat; bind web:%s to one explicitly to merge",
+				len(telegram), WebAccountID)
+		}
+		if _, err := tx.Exec(`INSERT INTO channel_bindings (channel, external_id, conversation_id, created_at)
+			VALUES (?, ?, ?, ?) ON CONFLICT(channel, external_id) DO NOTHING`,
+			ChannelWeb, WebAccountID, webTarget, now); err != nil {
+			return fmt.Errorf("bind web: %w", err)
+		}
+	}
+	return tx.Commit()
 }
 
 // migrateV4ToV5 adds the provider column. It records which CLI produced


### PR DESCRIPTION
**S1 trong `docs/design/sessions-and-workspaces.md`.** S0 (#75) cho hai kênh chạy **cùng engine**; PR này cho chúng chạy trên **cùng hội thoại**.

## Cơ chế

Một conversation được khoá bằng đúng số nguyên Manager luôn dùng cho một chat (`sessions.chat_id`). **Bảng `sessions` không đổi.** Bảng mới `channel_bindings` ánh xạ danh tính kênh — `telegram:<chat id>`, `web:<account>` — vào khoá đó. Hai kênh trỏ chung một khoá ⇒ chung active session, chung lịch sử, chung execution lane.

*Lệch so với design có chủ ý*: không thêm `sessions.conversation_id`. Dùng lại khoá sẵn có ⇒ không phải viết lại bảng session, không đụng Manager, join là một lookup có index.

## Migration v5 → v6 — gộp theo quy tắc single-user

| Số chat Telegram | Web account | Lý do |
|---|---|---|
| **đúng 1** | **gộp vào** — session của web chuyển sang, `chat_state` cũ xoá, **active session phía Telegram giữ nguyên** | Gộp không được kéo hội thoại đang sống sang session cuối của dashboard |
| 0 | giữ riêng (id 1) | Không có gì để gộp |
| ≥ 2 | giữ riêng + log | Chọn một trong nhiều chat của nhiều người là **quyết định**, không phải migration |

Cùng quy tắc áp cho web account **chưa bind** lúc runtime; binding đã có **luôn được tôn trọng** — `ResolveWeb` không bao giờ lặng lẽ trỏ lại.

## Gateway

Tin nhắn dashboard không nêu session ⇒ chạy trên **active session của conversation đã bind** (chính là session Telegram đang ở), thay vì `chat_1` riêng. Session được nêu tên thì dùng nguyên; không resolve được thì **để nguyên**, không redirect. `handleCancel` và `send` non-streaming cùng cách resolve. Không có store (test, setup tối thiểu) ⇒ rơi về chat cố định như cũ.

## Test

- migrate gộp vào chat Telegram duy nhất, **giữ active session** phía Telegram, **giữ messages** của session chuyển đi
- migrate **giữ riêng** khi có 2 chat Telegram
- `ResolveWeb` bind một lần và tôn trọng rebind tường minh; join khi có đúng 1 Telegram
- tin dashboard rơi đúng active session + đúng chat lane của Telegram; frame response nêu session đó để UI chọn theo

Full suite xanh. Làm trong worktree riêng (phiên khác đang sửa dở `methods.go` trên checkout chính).

🤖 Generated with [Claude Code](https://claude.com/claude-code)