### PR TITLE
fix(dashboard): push Telegram turns to open dashboards in real time

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -354,6 +354,18 @@ func runGateway(args []string) {
 
 	srv := gateway.NewServer(addr, gateway.NewMethodHandler(deps), gateway.NewStreamSendHandler(deps), resolveDashboardDir(), authMgr)
 
+	if tgBot != nil {
+		// Push conversation changes to open dashboards. A Telegram turn (or a
+		// claimed task) writes the session both channels now share, and nothing
+		// else would tell a browser showing that session to refresh.
+		tgBot.Handler().SetTurnListener(func(ev bot.TurnEvent) {
+			data, _ := json.Marshal(map[string]any{
+				"session_id": ev.SessionID, "chat_id": ev.ChatID, "phase": ev.Phase,
+			})
+			srv.Broadcast(gateway.StreamEvent{Type: "event", Event: "session.turn", Data: string(data)})
+		})
+	}
+
 	// Start Telegram bot polling in background
 	if tgBot != nil {
 		go func() {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -19,6 +19,29 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
   const setActiveSessionId = useStore(s => s.setActiveSessionId)
   const setMessages = useStore(s => s.setMessages)
   const sessions = useStore(s => s.sessions)
+  const externalTurn = useStore(s => s.externalTurn)
+  const sending = useStore(s => s.sending)
+
+  // Another channel wrote to a session — Telegram, or an agent that claimed a
+  // task. Refresh the list (labels, counts), and if that session is the one on
+  // screen and we are not mid-send ourselves, reload its transcript so the web
+  // shows what Telegram shows, the moment it happens. While the other side is
+  // still working ("started" with no "finished" yet) poll every 5s so its
+  // partial snapshots appear too; "finished" cancels the poll and reloads once.
+  useEffect(() => {
+    if (!externalTurn) return
+    call('sessions.list').then((s: any) => setSessions(s || [])).catch(() => {})
+    if (externalTurn.sessionId !== activeSessionId || sending) return
+
+    const reload = () =>
+      call('transcript.get', { session_id: externalTurn.sessionId })
+        .then((events: any) => { if (Array.isArray(events)) setMessages(eventsToMessages(events)) })
+        .catch(() => {})
+    reload()
+    if (externalTurn.phase !== 'started') return
+    const t = setInterval(reload, 5000)
+    return () => clearInterval(t)
+  }, [externalTurn, activeSessionId, sending, call, setSessions, setMessages])
 
   // Sync URL ↔ state: read on load, write on change
   useEffect(() => {

--- a/dashboard/src/hooks/useGateway.ts
+++ b/dashboard/src/hooks/useGateway.ts
@@ -57,6 +57,18 @@ export function useGateway() {
           return
         }
 
+        // Server-initiated events (no request id): a session moved on another
+        // channel. Hand it to the store; App decides whether it is on screen.
+        if (msg.type === 'event') {
+          if (msg.event === 'session.turn') {
+            try {
+              const d = JSON.parse(msg.data)
+              useStore.getState().setExternalTurn({ sessionId: d.session_id, phase: d.phase, at: Date.now() })
+            } catch {}
+          }
+          return
+        }
+
         // Handle normal RPC responses
         const p = pending.current.get(msg.id)
         if (p) {

--- a/dashboard/src/stores/store.ts
+++ b/dashboard/src/stores/store.ts
@@ -68,6 +68,19 @@ interface Store {
   // Status
   status: any
   setStatus: (s: any) => void
+
+  // Activity on a session from another channel — a Telegram turn, a claimed
+  // task. Set by the gateway hook when the server pushes session.turn;
+  // consumed by App to refresh the open chat the moment it happens instead of
+  // waiting for a reload.
+  externalTurn: ExternalTurn | null
+  setExternalTurn: (t: ExternalTurn | null) => void
+}
+
+export type ExternalTurn = {
+  sessionId: string
+  phase: 'started' | 'finished'
+  at: number
 }
 
 export const useStore = create<Store>((set) => ({
@@ -98,4 +111,7 @@ export const useStore = create<Store>((set) => ({
 
   status: null,
   setStatus: (status) => set({ status }),
+
+  externalTurn: null,
+  setExternalTurn: (externalTurn) => set({ externalTurn }),
 }))

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -50,6 +50,11 @@ type Handler struct {
 	trace      *trace.Recorder // run/trace recorder (nil-safe)
 	agentID    string          // identity in the shared coordination database
 
+	// onTurn, when set, is told when any turn on any channel starts and ends.
+	// The gateway uses it to push a refresh to open dashboards; without it a
+	// browser showing the shared session never learns Telegram moved it.
+	onTurn func(TurnEvent)
+
 	// approvalRequests maps callbackData → channel to signal approval/cancel
 	approvalMu       sync.Mutex
 	approvalRequests map[string]chan bool
@@ -601,6 +606,28 @@ func (h *Handler) NewSessionContext(sess *session.Session) string {
 	return h.memory.BuildContext(time.Now()) + h.buildHistoryContext(sess.ID, 8)
 }
 
+// TurnEvent announces that a session's conversation moved. "started" fires once
+// the user's message is persisted, so a reader can already show it; "finished"
+// fires once the reply, transcript and counters are written — on every exit
+// path, including cancellation and timeout.
+type TurnEvent struct {
+	SessionID string
+	ChatID    int64
+	Phase     string // "started" | "finished"
+}
+
+// SetTurnListener registers the single listener for turn events. Delivery is
+// asynchronous: the listener does network writes and must never slow a turn.
+func (h *Handler) SetTurnListener(fn func(TurnEvent)) { h.onTurn = fn }
+
+func (h *Handler) notifyTurn(sess *session.Session, chatID int64, phase string) {
+	if h.onTurn == nil {
+		return
+	}
+	ev := TurnEvent{SessionID: sess.ID, ChatID: chatID, Phase: phase}
+	go h.onTurn(ev)
+}
+
 // runClaude executes a single Claude CLI call with streaming, transcript recording, and memory extraction.
 func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID int64, modelID, userText, memoryContext string, streamer TurnSink) (*execution.RunResult, error) {
 	ctx, cancel := context.WithCancel(ctx)
@@ -651,6 +678,7 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 			log.Printf("handler: message store user error: %v", err)
 		}
 	}
+	h.notifyTurn(sess, chatID, "started")
 
 	// assistantText accumulates ALL turns (for storage); turnText resets per
 	// iteration so the auto-continue heuristic only inspects the latest turn.
@@ -675,6 +703,9 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		out := assistantText.String()
 		textMu.Unlock()
 		turnSpan.End(out, turnErr)
+		// Last, so a listener that reloads on "finished" sees the transcript
+		// flush and label refresh already done on the normal path.
+		h.notifyTurn(sess, chatID, "finished")
 	}()
 
 	// Snapshot the in-progress reply every 10s so a dashboard reload mid-run

--- a/internal/bot/turnevent_test.go
+++ b/internal/bot/turnevent_test.go
@@ -1,0 +1,107 @@
+package bot
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/config"
+	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/memory"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/storage"
+	"github.com/ngocp/goterm-control/internal/transcript"
+)
+
+// TestRunTurnAnnouncesStartAndFinish covers the dashboard staleness bug: with
+// Telegram and the web on one session, a Telegram turn wrote the session and
+// nothing told an open browser. The turn engine now announces every turn's
+// start (user message already persisted) and finish (reply written), in that
+// order, carrying the session it touched.
+func TestRunTurnAnnouncesStartAndFinish(t *testing.T) {
+	dir := t.TempDir()
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+	h := &Handler{
+		sessions:   sessions,
+		llm:        &scriptedClient{},
+		cfg:        &config.Config{},
+		engine:     execution.NewEngine(execution.Hooks{}, 3),
+		transcript: transcript.NewWriter(filepath.Join(dir, "transcripts")),
+		messages:   storage.NewMessageStore(sdb),
+		memory:     memory.NewManager(memory.Config{}),
+	}
+
+	var mu sync.Mutex
+	var got []TurnEvent
+	done := make(chan struct{}, 4)
+	h.SetTurnListener(func(ev TurnEvent) {
+		mu.Lock()
+		got = append(got, ev)
+		mu.Unlock()
+		done <- struct{}{}
+	})
+
+	sess := sessions.Get(42)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := h.RunTurn(ctx, sess, 42, "m", "hello", &recordingSink{}); err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+
+	// Delivery is asynchronous by design; wait for both events.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d turn event(s) arrived", len(got))
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want started + finished: %+v", len(got), got)
+	}
+	// Both are dispatched in goroutines, so their arrival order is not
+	// guaranteed; the contract is one of each, for this session and chat.
+	phases := map[string]bool{}
+	for _, ev := range got {
+		phases[ev.Phase] = true
+		if ev.SessionID != sess.ID || ev.ChatID != 42 {
+			t.Errorf("event %+v is not for session %s / chat 42", ev, sess.ID)
+		}
+	}
+	if !phases["started"] || !phases["finished"] {
+		t.Errorf("phases = %v, want started and finished", phases)
+	}
+}
+
+// A handler with no listener must run turns exactly as before.
+func TestRunTurnWithoutListener(t *testing.T) {
+	dir := t.TempDir()
+	sdb, err := storage.Open(filepath.Join(dir, "goterm.db"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer sdb.Close()
+
+	sessions := session.NewManager(storage.NewSessionStore(sdb))
+	h := &Handler{
+		sessions: sessions,
+		llm:      &scriptedClient{},
+		cfg:      &config.Config{},
+		engine:   execution.NewEngine(execution.Hooks{}, 3),
+		memory:   memory.NewManager(memory.Config{}),
+	}
+	if _, err := h.RunTurn(context.Background(), sessions.Get(7), 7, "m", "hi", &recordingSink{}); err != nil {
+		t.Fatalf("RunTurn without listener: %v", err)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -28,7 +28,10 @@ type Server struct {
 	httpSrv       *http.Server
 	startedAt     time.Time
 	mu            sync.Mutex
-	clients       map[*websocket.Conn]bool
+	// clients maps each open dashboard socket to its write mutex — gorilla
+	// forbids concurrent writes, and Broadcast writes from outside the
+	// connection's own goroutine.
+	clients map[*websocket.Conn]*sync.Mutex
 }
 
 // MethodHandler processes RPC method calls.
@@ -46,7 +49,29 @@ func NewServer(addr string, handler MethodHandler, streamHandler StreamSendHandl
 			// blocks cross-site WebSocket hijacking from arbitrary origins.
 			CheckOrigin: authMgr.CheckOrigin,
 		},
-		clients: make(map[*websocket.Conn]bool),
+		clients: make(map[*websocket.Conn]*sync.Mutex),
+	}
+}
+
+// Broadcast sends one frame to every connected dashboard client.
+//
+// A conversation can move on a channel the browser is not part of — a Telegram
+// turn, a task an agent claimed — and nothing else would tell an open dashboard
+// showing that session to refresh. A client whose write fails is left to its
+// own read loop to notice and drop; a slow or dead socket must not stall the
+// others, so each write holds only that client's mutex.
+func (s *Server) Broadcast(v any) {
+	s.mu.Lock()
+	targets := make(map[*websocket.Conn]*sync.Mutex, len(s.clients))
+	for c, mu := range s.clients {
+		targets[c] = mu
+	}
+	s.mu.Unlock()
+
+	for c, mu := range targets {
+		mu.Lock()
+		_ = c.WriteJSON(v)
+		mu.Unlock()
 	}
 }
 
@@ -133,8 +158,12 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Write mutex — gorilla websocket doesn't allow concurrent writes. Shared
+	// with Broadcast through the clients map.
+	writeMu := &sync.Mutex{}
+
 	s.mu.Lock()
-	s.clients[conn] = true
+	s.clients[conn] = writeMu
 	s.mu.Unlock()
 
 	defer func() {
@@ -146,8 +175,6 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("gateway: client connected from %s", r.RemoteAddr)
 
-	// Write mutex — gorilla websocket doesn't allow concurrent writes
-	var writeMu sync.Mutex
 	writeJSON := func(v any) error {
 		writeMu.Lock()
 		defer writeMu.Unlock()


### PR DESCRIPTION
**Lỗi báo**: thêm một tin trên Telegram chưa phản ánh ngay vào web.

## Nguyên nhân

Sau S1 hai kênh chung một session, nên lượt Telegram ghi **đúng session trình duyệt đang mở** — nhưng không có gì báo cho trình duyệt. Chat chỉ nạp transcript lúc chọn session; poll 10s chỉ làm mới *danh sách* session, không nạp lại hội thoại. Tin Telegram chỉ hiện sau khi reload.

## Cách sửa — push, không poll

- **Turn engine phát sự kiện mỗi lượt, mọi kênh**: `started` khi tin của user đã lưu, `finished` khi reply/transcript/counter đã ghi — bắn từ chính `defer` đóng trace nên phủ cả cancel/timeout. Giao bất đồng bộ: listener làm network I/O không bao giờ làm chậm lượt.
- **Gateway** đăng ký làm listener và `Broadcast` frame `session.turn` tới mọi client dashboard. Map client giờ giữ **write mutex theo từng kết nối** — gorilla cấm ghi đồng thời, còn `Broadcast` ghi từ ngoài goroutine của kết nối. Client chậm chỉ giữ mutex của chính nó.
- **Dashboard**: nhận event → làm mới danh sách session; nếu là session đang mở và mình không đang gửi → nạp lại transcript **ngay**. Phía kia đang chạy dở (`started` chưa `finished`) → poll 5s để partial snapshot cũng hiện; `finished` huỷ poll và nạp một lần.

## Test

`RunTurn` phát đúng `started` + `finished` cho đúng session/chat; handler không có listener chạy y như cũ. Full suite xanh, `tsc` sạch, dashboard build.

Ghi chú: phiên Claude Code thứ hai đang có bản sửa dở cùng hướng (stamp `transcript_size`/`transcript_at` lên `sessions.list` để poll phát hiện thay đổi). Push ở đây thay thế nhu cầu đó cho khung chat; stamp vẫn hữu ích cho danh sách nếu muốn giữ — nhưng phải rebase lên main vì `methods.go` đã đổi ở S0/S1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)