### PR TITLE
feat(models): default the Claude agent to Opus 5

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ telegram:
 
 claude:
   api_key: ""      # set via ANTHROPIC_API_KEY env var
-  model: "claude-opus-4-8"   # default model (can also use models.default)
+  model: "claude-opus-5"     # default model (can also use models.default)
   max_tokens: 8192
   workspace: "~/goterm-workspace"  # working directory for Claude CLI (default: ~/goterm-workspace)
   execution_timeout: 20            # max minutes per request (default: 20)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,7 +210,7 @@ func Load(path string) (*Config, error) {
 		cfg.Telegram.Timeout = 60
 	}
 	if cfg.Claude.Model == "" {
-		cfg.Claude.Model = "claude-opus-4-8"
+		cfg.Claude.Model = "claude-opus-5"
 	}
 	if cfg.Claude.MaxTokens == 0 {
 		cfg.Claude.MaxTokens = 8192

--- a/internal/models/catalog.go
+++ b/internal/models/catalog.go
@@ -45,12 +45,31 @@ type ModelCost struct {
 // These are hardcoded so the bot works with zero config beyond an API key.
 func BuiltinModels() []Model {
 	return []Model{
+		// First entry doubles as the resolver's fallback when a configured
+		// default is unknown, so the newest Opus goes first.
+		//
+		// ContextWindow/MaxTokens are carried over from Opus 4.8 and only drive
+		// the /models display and the standalone `chat` command — they are not
+		// verified for Opus 5. Cost is left zero on purpose: the bot reaches
+		// this model through the Claude CLI's subscription login, which is not
+		// billed per token, so any figure here would be invented.
+		{
+			ID:            "claude-opus-5",
+			Name:          "Claude Opus 5",
+			Provider:      "anthropic",
+			API:           APIClaudeCLI,
+			Aliases:       []string{"opus", "o5", "opus-5"},
+			ContextWindow: 1_000_000,
+			MaxTokens:     32_000,
+			Reasoning:     true,
+			Input:         []InputType{InputText, InputImage, InputDocument},
+		},
 		{
 			ID:            "claude-opus-4-8",
 			Name:          "Claude Opus 4.8",
 			Provider:      "anthropic",
 			API:           APIClaudeCLI,
-			Aliases:       []string{"opus", "o4", "opus-4-8"},
+			Aliases:       []string{"o4", "opus-4-8"},
 			ContextWindow: 1_000_000,
 			MaxTokens:     32_000,
 			Reasoning:     true,

--- a/internal/models/resolver_test.go
+++ b/internal/models/resolver_test.go
@@ -24,7 +24,9 @@ func TestResolverLookupByAlias(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"opus", "claude-opus-4-8"},
+		{"opus", "claude-opus-5"},
+		{"o5", "claude-opus-5"},
+		{"opus-5", "claude-opus-5"},
 		{"o4", "claude-opus-4-8"},
 		{"opus-4-8", "claude-opus-4-8"},
 		{"opus-4-6", "claude-opus-4-6"},
@@ -68,13 +70,13 @@ func TestResolverOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m.ID != "claude-opus-4-8" {
+	if m.ID != "claude-opus-5" {
 		t.Errorf("expected opus, got %s", m.ID)
 	}
 
 	// Resolve should return override
 	m = r.Resolve(chatID)
-	if m.ID != "claude-opus-4-8" {
+	if m.ID != "claude-opus-5" {
 		t.Errorf("expected opus override, got %s", m.ID)
 	}
 
@@ -133,7 +135,7 @@ func TestResolverUnknownDefault(t *testing.T) {
 	if m == nil {
 		t.Fatal("expected fallback to first model")
 	}
-	if m.ID != "claude-opus-4-8" {
+	if m.ID != "claude-opus-5" {
 		t.Errorf("expected opus as fallback, got %s", m.ID)
 	}
 }


### PR DESCRIPTION
Gotermbot (agent 1) đang chạy `claude-opus-4-8`; yêu cầu mặc định **Opus 5**.

- Thêm `claude-opus-5` vào catalog **đứng đầu** — phần tử đầu cũng là fallback của resolver khi default cấu hình không tồn tại, nên Opus mới nhất phải ở đó.
- Alias `opus` chuyển sang Opus 5 (thêm `o5`, `opus-5`); Opus 4.8 giữ `o4`, `opus-4-8`.
- Mặc định trong `config.go` và `config.yaml` mẫu đổi theo.

**Đã kiểm chứng CLI nhận model trước khi đổi**: `claude -p 'Reply with exactly: OK' --model claude-opus-5` → `OK`.

`ContextWindow`/`MaxTokens` kế thừa từ Opus 4.8 — chỉ dùng cho hiển thị `/models` và lệnh `chat` độc lập, **chưa xác minh** cho Opus 5. `Cost` để 0 có chủ ý: bot đi qua login subscription của CLI, không tính tiền theo token — điền số nào cũng là bịa.

Config live của agent 1 (`~/.bomclaw/config.yaml`) đổi lúc deploy; agent 2 không ảnh hưởng (default là model codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)