### PR TITLE
fix(browser): route browser work to the user's browser, and land /new's message

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -405,10 +405,15 @@ func (h *Handler) handleRemember(chatID int64, arg string) {
 // willFlush reports whether a memory flush would actually run for this chat,
 // so callers can show a "saving..." notice before a blocking flush.
 func (h *Handler) willFlush(chatID int64) bool {
-	if !h.memory.Enabled() {
+	return h.shouldFlush(h.sessions.Get(chatID))
+}
+
+// shouldFlush reports whether sess has anything worth writing to memory.
+// A session the CLI never saw, or one with no turns, has nothing to say.
+func (h *Handler) shouldFlush(sess *session.Session) bool {
+	if !h.memory.Enabled() || sess == nil {
 		return false
 	}
-	sess := h.sessions.Get(chatID)
 	return sess.GetSessionID() != "" && sess.GetMessageCount() > 0
 }
 
@@ -431,11 +436,15 @@ func (h *Handler) flushMemory(chatID int64, reason string) {
 // flushMemoryWithModel is flushMemory with an explicit model — used by
 // /model, where the flush must resume the old session with its old model.
 func (h *Handler) flushMemoryWithModel(chatID int64, reason, modelID string) {
-	if !h.memory.Enabled() {
-		return
-	}
-	sess := h.sessions.Get(chatID)
-	if sess.GetSessionID() == "" || sess.GetMessageCount() == 0 {
+	h.flushSession(chatID, h.sessions.Get(chatID), reason, modelID)
+}
+
+// flushSession is flushMemoryWithModel against an explicit session rather than
+// whichever one is active. /new needs that: it switches the chat to a fresh
+// session first and flushes the one it retired afterwards, so the flush has to
+// name its subject instead of asking the manager for it.
+func (h *Handler) flushSession(chatID int64, sess *session.Session, reason, modelID string) {
+	if !h.shouldFlush(sess) {
 		return
 	}
 
@@ -1052,15 +1061,27 @@ func (h *Handler) showSessionList(chatID int64) {
 }
 
 func (h *Handler) handleNewSession(chatID int64) {
-	// Flush the outgoing session's memory before switching to a fresh one.
-	if h.willFlush(chatID) {
+	// Switch first, flush second. The flush replays the outgoing session
+	// through the CLI and routinely takes half a minute; while it ran, the
+	// chat's active session was still the old one, so a message sent in that
+	// window was filed against the session the user had just retired — and
+	// the fresh session stayed empty, on Telegram and in the dashboard alike.
+	// Naming the outgoing session here lets the flush still run against it.
+	outgoing := h.sessions.Get(chatID)
+	modelID := h.currentModelID(chatID)
+	flushing := h.shouldFlush(outgoing)
+	if flushing {
 		h.sendText(chatID, "💾 Saving memory...")
 	}
-	h.flushMemory(chatID, "new-session")
+
 	sess, err := h.sessions.NewSession(chatID)
 	if err != nil {
 		h.sendText(chatID, fmt.Sprintf("❌ %v", err))
 		return
+	}
+
+	if flushing {
+		h.flushSession(chatID, outgoing, "new-session", modelID)
 	}
 	h.sendText(chatID, fmt.Sprintf("✨ New session created (Session %d). Send a message to start.", sess.Seq))
 }

--- a/internal/browserbridge/guide.go
+++ b/internal/browserbridge/guide.go
@@ -15,6 +15,20 @@ logged-in sessions — through the ` + "`bomclaw browser`" + ` command. Each com
 prints its result. Exit code 3 means no browser is connected: tell the user to
 open the extension popup and check that this agent shows "connected".
 
+**This is the only browser that is logged in as the user, so it is the one to
+reach for whenever their own account or session matters.** Use it when the
+request involves "my" anything — my browser, my tabs, my feed, my orders, my
+inbox, my dashboard — or names a site that will not show its content to a
+signed-out visitor (x.com, Facebook, Gmail, LinkedIn, a bank, an admin panel).
+
+Do NOT use any other browser for those. The ` + "`browser_*`" + ` tools and any
+headless-browser tooling start signed out of everything: on such a site they
+land on a login wall and you will report the page as inaccessible or
+anonymous-blocked, which tells the user the task is impossible when in fact it
+was the wrong browser. If a page turns out to need a login, that is the signal
+to switch to ` + "`bomclaw browser`" + `, not to give up. Reserve the other browsers
+for public pages where no account is involved.
+
 - ` + "`bomclaw browser status`" + ` — is a browser connected?
 - ` + "`bomclaw browser tabs`" + ` — list open tabs (id, title, url).
   ` + "`tabs open URL`" + `, ` + "`tabs focus ID`" + ` (work in one of the user's own tabs), ` + "`tabs close ID`" + `.

--- a/internal/claude/args_test.go
+++ b/internal/claude/args_test.go
@@ -1,0 +1,49 @@
+package claude
+
+import (
+	"slices"
+	"testing"
+)
+
+// The CLI subprocess must not inherit the operator's own interactive toolkit.
+// ~/.claude/skills is shared with their hand-driven sessions, and some of it
+// competes for this agent's work: a headless-browser skill advertising "open
+// in browser" wins those requests over `bomclaw browser`, so the agent drives
+// a logged-out browser and reports the site as inaccessible.
+func TestBuildArgsIsolatesSkillsAndMCP(t *testing.T) {
+	args := buildArgs("claude-opus-4-8", "sess-1", true, "system")
+
+	for _, want := range []string{"--disable-slash-commands", "--strict-mcp-config"} {
+		if !slices.Contains(args, want) {
+			t.Errorf("%s missing — the subprocess would load the operator's %s", want, want)
+		}
+	}
+}
+
+// Isolation must hold on resumed turns too, not just the first one: every
+// turn spawns a fresh subprocess, so a flag dropped on resume is a flag that
+// only works once.
+func TestBuildArgsIsolationSurvivesResume(t *testing.T) {
+	resumed := buildArgs("claude-opus-4-8", "sess-1", false, "system")
+
+	if !slices.Contains(resumed, "--disable-slash-commands") {
+		t.Error("--disable-slash-commands missing on a resumed turn")
+	}
+	if !slices.Contains(resumed, "--resume") {
+		t.Error("--resume missing on a resumed turn")
+	}
+	if slices.Contains(resumed, "--append-system-prompt") {
+		t.Error("resumed turns must not re-send the system prompt (the CLI already has it)")
+	}
+}
+
+func TestBuildArgsSystemPromptOnFirstTurnOnly(t *testing.T) {
+	first := buildArgs("m", "s", true, "you are a test")
+	i := slices.Index(first, "--append-system-prompt")
+	if i < 0 || first[i+1] != "you are a test" {
+		t.Fatalf("first turn should carry the system prompt, got %v", first)
+	}
+	if slices.Contains(first, "--resume") {
+		t.Error("a new session must not resume")
+	}
+}

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -279,6 +279,14 @@ func buildArgs(model, sessionID string, isNew bool, systemPrompt string) []strin
 		// Disable user MCP servers to prevent Serena/etc. startup browser popups.
 		"--mcp-config", emptyMCPConfig,
 		"--strict-mcp-config",
+		// Same isolation, for skills. The CLI otherwise loads whatever is in
+		// ~/.claude/skills, which is the operator's own interactive toolkit —
+		// and some of it competes for this agent's work. A headless-browser
+		// skill advertising "open in browser" and "take a screenshot" wins
+		// those requests over `bomclaw browser`, so the agent quietly drives
+		// a logged-out browser and reports the site as inaccessible. Scoped to
+		// the subprocess: the operator's own sessions keep every skill.
+		"--disable-slash-commands",
 	}
 
 	if !isNew {


### PR DESCRIPTION
Reported as *"agent 1 vẫn chưa điều khiển được trình duyệt"* — and then *"nó đang dùng browser trong skill gstack, nhưng đó không phải cái tôi muốn"*.

The bridge was never the problem: the extension was paired and healthy throughout (`connected: true`, Chrome 149). Three other things were.

## 1. The agent used someone else's browser

The CLI subprocess loads whatever is in `~/.claude/skills` — the operator's own interactive toolkit. One of those is a **headless** browser skill whose description claims exactly the phrases a user reaches for:

> Use when asked to "open in browser", "test the site", "take a screenshot"

So it won every browser request. The agent drove a signed-out browser at x.com and replied:

> Việc này cần trình duyệt có session đăng nhập của bạn (x.com chặn truy cập ẩn danh)

which reads as *"impossible"* when the capability was sitting right there.

**Fix:** spawn the CLI with `--disable-slash-commands` — the same isolation already applied to MCP one line above, for the same reason. Scoped to the subprocess; the operator's own sessions keep every skill (`/ship`, `/qa`, `/review`, …).

Deleting gstack was considered and rejected: those skills are symlinks into one directory, so removing it would also take out `/ship`, `/review`, `/qa`, `/investigate`, `/retro` from the operator's own Claude Code — a much wider blast radius than the problem.

## 2. Nothing told the agent which browser to prefer

The guide described `bomclaw browser` but never ranked it against the alternatives, so even with no competing skill the `browser_*` tools were an equally plausible pick.

It now leads with the routing rule — anything involving the user's own account, or a site that hides content from signed-out visitors (x.com, Gmail, LinkedIn, a bank, an admin panel) goes to the bridge — and names the failure mode explicitly: **a login wall is the signal to switch browsers, not to give up.**

## 3. `/new`'s next message landed in the retired session

The memory flush replays the outgoing session through the CLI and routinely takes ~30s. The switch happened only *after* it returned, so a message sent in that window was filed against the session the user had just retired.

Verified in the field:

```
14:57:27  /new → created _28   (0 messages, no transcript)
14:57:27  message sent         → went to _27   ← same second
```

This also **hid fix #2**: `_27` predated the deploy, and a resumed session never re-sends the system prompt (`--append-system-prompt` is first-turn only), so the agent could not have known `bomclaw browser` existed.

**Fix:** switch first, flush the *named* outgoing session second. (Recovered from a stash predating #77; only the `/new` hunk was taken — the transcript-stamp polling in that stash is superseded by #77's push sync.)

## Tests

`buildArgs` had none. It does now, including that isolation **survives resume** — every turn spawns a fresh subprocess, so a flag dropped on resume is a flag that works exactly once.

Confirmed the new test fails with the flag removed:

```
--- FAIL: TestBuildArgsIsolationSurvivesResume
    args_test.go:30: --disable-slash-commands missing on a resumed turn
```

`go build ./... && go test ./...` green.

## After deploying

Existing sessions still carry the old system prompt, so `/new` is needed once — and now the message after it actually lands in the new session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)