### PR TITLE
fix(browser): say why a page refuses scripting instead of blaming the manifest

### DIFF
--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -198,6 +198,12 @@ Result shapes by action: `{"message":…}` for actions that just report
 - **`eval` needs a permissive CSP.** Pages with a strict Content-Security-Policy
   refuse injected script; prefer `snapshot` and `text`.
 - **`screenshot` captures the visible viewport**, not the full page.
+- **Some pages cannot be scripted at all.** Chrome refuses injection on its own
+  pages (`chrome://`, `view-source:`, `file:`), on the Web Store, and on a
+  blank tab. The agent's tab starts blank, so a `snapshot` before the first
+  `navigate` hits this; the bridge reports which of those it is rather than
+  passing on Chrome's "Extension manifest must request permission" wording,
+  which reads as a broken install.
 - **Chrome and Chromium-family browsers only.** The manifest is MV3; Firefox
   would need its own packaging.
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -238,16 +238,20 @@ async function screenshot() {
 async function evalJS(expression) {
   if (!expression) throw new Error("expression is required");
   const tabId = await targetTab();
-  const [res] = await chrome.scripting.executeScript({
-    target: { tabId },
-    world: "MAIN",
-    func: (expr) => {
-      try { return { result: String(eval(expr)) }; }
-      catch (e) { return { error: String(e && e.message || e) }; }
-    },
-    args: [expression],
-  });
-  return res.result;
+  try {
+    const [res] = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: (expr) => {
+        try { return { result: String(eval(expr)) }; }
+        catch (e) { return { error: String(e && e.message || e) }; }
+      },
+      args: [expression],
+    });
+    return res.result;
+  } catch (e) {
+    throw new Error(await injectionBlockReason(tabId, e));
+  }
 }
 
 // tabsAction lists/opens/focuses/closes tabs. list and focus/close work on the
@@ -299,13 +303,46 @@ async function tabsAction(p) {
 // injectFn runs a page.js function in the target tab's MAIN world and returns
 // its value. A ref/param is passed as args, never string-interpolated.
 async function injectFn(tabId, fn, args) {
-  const [res] = await chrome.scripting.executeScript({
-    target: { tabId },
-    world: "MAIN",
-    func: fn,
-    args: args,
-  });
-  return res && res.result;
+  try {
+    const [res] = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: fn,
+      args: args,
+    });
+    return res && res.result;
+  } catch (e) {
+    throw new Error(await injectionBlockReason(tabId, e));
+  }
+}
+
+// injectionBlockReason turns Chrome's refusal to inject into something the
+// agent can act on. Chrome reports every one of these as "Cannot access
+// contents of url … Extension manifest must request permission to access this
+// host", which reads as a broken install — and the commonest cause is simply
+// that the agent's tab is still the empty one it was opened with, where the
+// fix is to navigate somewhere rather than to touch the manifest.
+async function injectionBlockReason(tabId, cause) {
+  let url = "";
+  try {
+    url = (await chrome.tabs.get(tabId)).url || "";
+  } catch (e) {
+    return "the tab is gone — open one with `bomclaw browser navigate <url>`";
+  }
+  if (!url || url === "about:blank" || url.startsWith("about:")) {
+    return "the agent's tab is empty (" + (url || "no page") +
+      ") — load a page first with `bomclaw browser navigate <url>`, " +
+      "or point the agent at one of the user's tabs with `bomclaw browser tabs focus <id>`";
+  }
+  if (/^(chrome|chrome-untrusted|edge|brave|devtools|view-source|file|data):/i.test(url)) {
+    return "Chrome does not let extensions script " + url.split(":")[0] +
+      ": pages — navigate to an http(s) page instead";
+  }
+  if (/^https:\/\/(chromewebstore\.google\.com|chrome\.google\.com\/webstore)/i.test(url)) {
+    return "Chrome blocks extensions from scripting the Web Store";
+  }
+  // Not a URL restriction we recognise — pass Chrome's own words through.
+  return String((cause && cause.message) || cause || "script injection failed");
 }
 
 function sleep(ms) {


### PR DESCRIPTION
Found while smoke-testing the live bridge after deploying #81.

`navigate about:blank` succeeds, and the `snapshot` right after it fails with Chrome's own words:

```
Cannot access contents of url "about:blank".
Extension manifest must request permission to access this host.
```

The manifest is fine. Chrome simply does not inject into a blank tab — and **the agent's tab is opened blank**, so any action taken before the first `navigate` lands exactly here.

That matters because of who reads the message. An agent told "Extension manifest must request permission" has no reason to try navigating; it has every reason to tell the user their extension is broken. The one recovery that works is the one the message hides.

## What it says now

| Tab state | Message |
|---|---|
| blank / `about:*` | `the agent's tab is empty (about:blank) — load a page first with `bomclaw browser navigate <url>`, or point the agent at one of the user's tabs with `bomclaw browser tabs focus <id>`` |
| `chrome://`, `view-source:`, `file:` | `Chrome does not let extensions script chrome: pages — navigate to an http(s) page instead` |
| Web Store | `Chrome blocks extensions from scripting the Web Store` |
| tab closed mid-action | `the tab is gone — open one with `bomclaw browser navigate <url>`` |
| anything else | Chrome's own text, unchanged |

That last row is deliberate: an unrecognised failure gets passed through rather than given an invented diagnosis.

Both injection paths are covered — the `page.js` helpers via `injectFn`, and `eval`, which called `executeScript` directly.

## Verification

Against **real Chrome** (the paired extension, 24 tabs open) the http(s) path works end to end:

```
navigate https://example.com  → OK
text --property url           → https://example.com/
text --property title         → Example Domain
snapshot                      → [n1] <html> / [n2] <head> / [n3] <title> "Example Domain"
```

Branch selection checked with a stubbed `chrome.tabs` across: blank, `""`, `about:newtab`, `chrome://settings`, `view-source:`, `file://`, Web Store, an ordinary page, and a tab that no longer exists — all 9 correct.

## Note on deploying this one

Extension-only: no Go binary or dashboard change. Chrome does not hot-reload an unpacked extension, so after `main` updates the `extension/` directory it needs a **Reload** in `chrome://extensions` to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)