### PR TITLE
feat(browser): one bridge per agent, and say what each is doing

### DIFF
--- a/cmd/bomclaw/browsercmd.go
+++ b/cmd/bomclaw/browsercmd.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/ngocp/goterm-control/internal/browser"
@@ -83,7 +84,7 @@ func runBrowser(args []string) {
 
 	switch sub {
 	case "status":
-		printJSONField(httpGet(addr+"/api/browser/status"), "")
+		printBrowserStatus(httpGet(addr + "/api/browser/status"))
 
 	case "token":
 		raw := httpGet(addr + "/api/browser/token")
@@ -207,6 +208,7 @@ func runBrowserTabs(addr string, rest []string) {
 				Title  string `json:"title"`
 				URL    string `json:"url"`
 				Active bool   `json:"active"`
+				Owner  string `json:"owner"`
 			} `json:"tabs"`
 		}
 		if err := json.Unmarshal(res, &out); err != nil {
@@ -217,13 +219,23 @@ func runBrowserTabs(addr string, rest []string) {
 			fmt.Println("no open tabs")
 			return
 		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "\tID\tTITLE\tURL")
 		for _, t := range out.Tabs {
 			marker := " "
 			if t.Active {
-				marker = "*"
+				marker = "*" // the tab THIS agent acts on
 			}
-			fmt.Printf("%s %s  %s  %s\n", marker, t.ID, truncate(t.Title, 40), t.URL)
+			title := truncate(t.Title, 40)
+			// A tab another agent is driving is worth flagging: focusing it
+			// would put two agents on one page.
+			if t.Owner != "" && !t.Active {
+				title += " [" + t.Owner + "]"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", marker, t.ID, title, t.URL)
 		}
+		w.Flush()
+		fmt.Println("\n* = the tab this agent acts on. `tabs focus <id>` to switch.")
 	case "open":
 		params["url"] = firstArg(rest[1:], "tabs open <url>")
 		printMessage(browserCall(addr, "tabs", params))
@@ -264,6 +276,60 @@ func twoArgs(args []string, usage string) (string, string) {
 	}
 	// Everything after the ref joins into the text, so an unquoted value works.
 	return args[0], strings.Join(args[1:], " ")
+}
+
+// printBrowserStatus renders the bridge status as a few readable lines. The
+// raw JSON was fine for one agent; with several on a machine the useful
+// questions are which agent this is, whether its browser is attached, and
+// whether it has actually done anything.
+func printBrowserStatus(raw json.RawMessage) {
+	var st struct {
+		Connected    bool   `json:"connected"`
+		AgentID      string `json:"agent_id"`
+		AgentName    string `json:"agent_name"`
+		BrowserName  string `json:"browser_name"`
+		Browser      string `json:"browser"`
+		Client       string `json:"client"`
+		ConnectedAt  string `json:"connected_at"`
+		Actions      int    `json:"actions"`
+		LastAction   string `json:"last_action"`
+		LastActionAt string `json:"last_action_at"`
+		LastError    string `json:"last_error"`
+	}
+	if err := json.Unmarshal(raw, &st); err != nil {
+		fmt.Println(strings.TrimSpace(string(raw)))
+		return
+	}
+
+	agent := orAny(st.AgentName, st.AgentID)
+	if agent == "" {
+		agent = "this agent"
+	}
+	if !st.Connected {
+		fmt.Printf("%s: no browser connected\n\n"+
+			"Pair the BomClaw Browser Bridge extension with the token from\n"+
+			"`bomclaw browser token`, then check the extension popup.\n", agent)
+		return
+	}
+
+	browser := orAny(st.BrowserName, st.Browser)
+	fmt.Printf("%s: connected to %s\n", agent, browser)
+	if st.ConnectedAt != "" {
+		if t, err := time.Parse(time.RFC3339, st.ConnectedAt); err == nil {
+			fmt.Printf("  since    %s\n", t.Local().Format("15:04:05"))
+		}
+	}
+	fmt.Printf("  actions  %d\n", st.Actions)
+	if st.LastAction != "" {
+		line := "  last     " + st.LastAction
+		if t, err := time.Parse(time.RFC3339, st.LastActionAt); err == nil {
+			line += " at " + t.Local().Format("15:04:05")
+		}
+		fmt.Println(line)
+	}
+	if st.LastError != "" {
+		fmt.Printf("  error    %s\n", st.LastError)
+	}
 }
 
 // printMessage prints the {"message":…} an action returns, falling back to the

--- a/dashboard/src/components/StatusBar.tsx
+++ b/dashboard/src/components/StatusBar.tsx
@@ -28,6 +28,8 @@ export default function StatusBar() {
         <StatCard label="Total Tokens" value={totalTokens.toLocaleString()} />
       </div>
 
+      <BrowserBridge browser={status?.browser} />
+
       <h3 className="text-sm font-medium text-gray-400 mb-2">Channels</h3>
       <div className="flex gap-2">
         {(status?.channels || []).map((ch: string) => (
@@ -61,6 +63,54 @@ export default function StatusBar() {
         </table>
       </div>
     </div>
+  )
+}
+
+// BrowserBridge reports the Chrome extension that lets this agent drive the
+// user's own logged-in browser. Absent when the bridge is disabled in config;
+// "not connected" is a normal state, not a fault, so it reads as a status
+// rather than an error.
+function BrowserBridge({ browser }: { browser?: any }) {
+  if (!browser) return null
+  const on = !!browser.connected
+
+  return (
+    <>
+      <h3 className="text-sm font-medium text-gray-400 mb-2">Browser Bridge</h3>
+      <div className="bg-gray-900 rounded-lg border border-gray-800 p-3 mb-6">
+        <div className="flex items-center gap-2">
+          <span className={`w-2 h-2 rounded-full ${on ? 'bg-green-400' : 'bg-gray-600'}`} />
+          <span className={`text-sm ${on ? 'text-gray-200' : 'text-gray-500'}`}>
+            {on ? browser.browser_name || 'browser connected' : 'no browser connected'}
+          </span>
+          {browser.agent_name && (
+            <span className="text-xs text-gray-500 ml-auto">{browser.agent_name}</span>
+          )}
+        </div>
+
+        {on ? (
+          <div className="text-xs text-gray-500 mt-2 space-y-0.5">
+            <div>
+              {browser.actions ?? 0} action{browser.actions === 1 ? '' : 's'}
+              {browser.last_action && <> · last: <span className="text-gray-400">{browser.last_action}</span></>}
+              {browser.last_action_at && <> · {new Date(browser.last_action_at).toLocaleTimeString()}</>}
+            </div>
+            {browser.connected_at && (
+              <div>connected since {new Date(browser.connected_at).toLocaleTimeString()}</div>
+            )}
+            {browser.last_error && (
+              <div className="text-red-400/80">last error: {browser.last_error}</div>
+            )}
+          </div>
+        ) : (
+          <div className="text-xs text-gray-500 mt-2">
+            Pair the BomClaw Browser Bridge extension with{' '}
+            <code className="text-gray-400">bomclaw browser token</code> to let this agent
+            work in your logged-in tabs.
+          </div>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -32,9 +32,29 @@ bomclaw browser click n7
 ```
 
 The extension dials **out** to the gateway on loopback; the gateway never
-connects to the browser. One browser at a time — a newer connection replaces
+connects to the browser. One browser per gateway — a newer connection replaces
 an older one, so reloading the extension never leaves a stale socket holding
 the slot.
+
+## Several agents, one browser
+
+A machine commonly runs more than one agent (agent 1 on `:18789`, agent 2 on
+`:18790`). Each has its own gateway, its own pairing token, and its own
+`/ext` endpoint, and the extension holds **a separate connection to each**.
+Pair them all from the popup: "Pair another agent", one token each.
+
+Every agent drives **its own tab**, opened in its own window. Two agents
+working at the same time therefore never navigate each other's page out from
+under them. `bomclaw browser tabs` marks the tab the calling agent acts on with
+`*`, and labels tabs belonging to another agent with that agent's name — so
+`tabs focus <id>` onto a peer's tab is a deliberate choice rather than an
+accident.
+
+The popup shows, per agent: connection state, how many actions it has run, its
+last action and when, and the page it is currently on. Below that is a rolling
+log of what every agent did — action, target, duration, and any error. With one
+agent that is a convenience; with two it is the only way to tell which of them
+just navigated your browser.
 
 ## Setup
 
@@ -57,7 +77,8 @@ mode**, click **Load unpacked**, and pick the `extension/` directory of this
 repo.
 
 **4. Pair it.** Click the extension's toolbar icon, paste the endpoint and
-token, press **Connect**. The dot turns green and names your agent.
+token, press **Pair**. The dot turns green and names your agent. Repeat for a
+second agent with its own port and token.
 
 **5. Check it from the agent's side.**
 
@@ -71,7 +92,7 @@ bomclaw browser status
 |---|---|
 | `bomclaw browser status` | Is a browser connected? |
 | `bomclaw browser token` | The pairing token and endpoint for the extension |
-| `bomclaw browser tabs` | List open tabs (`id`, title, url) |
+| `bomclaw browser tabs` | List open tabs (`id`, title, url); `*` marks this agent's tab, `[name]` marks a peer's |
 | `bomclaw browser tabs open <url>` | Open a new tab |
 | `bomclaw browser tabs focus <id>` | Act on one of **your** tabs from now on |
 | `bomclaw browser tabs close <id>` | Close a tab |

--- a/extension/README.md
+++ b/extension/README.md
@@ -23,7 +23,11 @@ Full reference, wire protocol and security notes: [`docs/browser-bridge.md`](../
 3. Open `chrome://extensions`, enable **Developer mode**, click **Load
    unpacked**, and choose this directory.
 
-4. Click the extension icon, paste the endpoint and token, press **Connect**.
+4. Click the extension icon, paste the endpoint and token, press **Pair**.
+
+   Running more than one agent? Repeat with that agent's own port and token
+   (agent 2 is usually `ws://127.0.0.1:18790/ext`). The extension holds one
+   connection per agent, and each agent drives its own tab.
 
 5. From the agent's shell:
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,10 +1,12 @@
 // background.js — the BomClaw Browser Bridge service worker.
 //
-// It keeps one WebSocket open to the gateway's /ext endpoint, authenticates
-// with the pairing token, and executes the actions the agent sends. Actions
-// run against a dedicated "agent tab" (a separate window, so your own tabs are
-// left alone) unless you point the agent at one of your tabs with
-// `bomclaw browser tabs focus <id>`.
+// It keeps one WebSocket open PER PAIRED AGENT and executes the actions each
+// one sends. A machine commonly runs several agents (agent 1 on :18789,
+// agent 2 on :18790, …); a single connection would mean whichever agent you
+// paired last owned the browser and the others were permanently unable to use
+// it. Each agent therefore gets its own connection, its own reconnect loop,
+// and — importantly — its own tab, so two agents working at once do not
+// navigate each other's page out from under them.
 //
 // Wire protocol (see docs/browser-bridge.md):
 //   ext→gw {type:"hello",token,client,browser}
@@ -15,163 +17,238 @@
 
 importScripts("page.js");
 
-const CLIENT = "bomclaw-bridge/0.1.0";
+const CLIENT = "bomclaw-bridge/0.2.0";
 const RECONNECT_MIN = 1000;
 const RECONNECT_MAX = 30000;
+const LOG_MAX = 40;
 
-let ws = null;
-let connected = false;      // welcome received
-let agentName = "";
-let reconnectDelay = RECONNECT_MIN;
-let reconnectTimer = null;
-let wantConnected = false;  // user asked to be connected
-let lastError = "";
-let agentTabId = null;      // the tab the agent drives by default
-let currentTabId = null;    // active target for snapshot/act (agent tab, or a focused user tab)
+// agents maps a stable key (the endpoint URL) to its live connection state.
+const agents = new Map();
+
+// activity is a rolling log across all agents, newest first. The popup shows
+// it because "connected" alone never explains what the agent actually did.
+let activity = [];
 
 // --- lifecycle ---
 
-chrome.runtime.onStartup.addListener(() => maybeAutoConnect());
-chrome.runtime.onInstalled.addListener(() => maybeAutoConnect());
+chrome.runtime.onStartup.addListener(() => restoreAgents());
+chrome.runtime.onInstalled.addListener(() => restoreAgents());
+restoreAgents();
 
-async function maybeAutoConnect() {
-  const cfg = await getConfig();
-  if (cfg.token && cfg.url && cfg.autoConnect !== false) connect();
+async function restoreAgents() {
+  const cfg = await storageGet(["agents", "url", "token", "autoConnect"]);
+  let list = Array.isArray(cfg.agents) ? cfg.agents : [];
+
+  // Migrate the single-agent shape this extension shipped with, so an upgrade
+  // does not silently unpair the browser.
+  if (list.length === 0 && cfg.url && cfg.token) {
+    list = [{ url: cfg.url, token: cfg.token, autoConnect: cfg.autoConnect !== false }];
+    await storageSet({ agents: list });
+  }
+  for (const a of list) {
+    upsertAgent(a.url, a.token, a.name);
+    if (a.autoConnect !== false) connect(a.url);
+  }
+  broadcastStatus();
 }
 
-async function getConfig() {
-  return new Promise((resolve) => {
-    chrome.storage.local.get(["token", "url", "autoConnect"], (v) => resolve(v || {}));
-  });
+function storageGet(keys) {
+  return new Promise((resolve) => chrome.storage.local.get(keys, (v) => resolve(v || {})));
+}
+function storageSet(obj) {
+  return new Promise((resolve) => chrome.storage.local.set(obj, resolve));
+}
+
+async function persistAgents() {
+  const list = [...agents.values()].map((a) => ({
+    url: a.url, token: a.token, name: a.name, autoConnect: a.wantConnected,
+  }));
+  await storageSet({ agents: list });
+}
+
+// --- agent registry ---
+
+function upsertAgent(url, token, name) {
+  let a = agents.get(url);
+  if (!a) {
+    a = {
+      url, token, name: name || "",
+      ws: null, connected: false, wantConnected: false,
+      reconnectDelay: RECONNECT_MIN, reconnectTimer: null,
+      lastError: "", actions: 0, lastAction: "", lastActionAt: 0,
+      // Each agent drives its own tab so concurrent agents do not fight.
+      agentTabId: null, currentTabId: null,
+    };
+    agents.set(url, a);
+  } else {
+    a.token = token || a.token;
+    if (name) a.name = name;
+  }
+  return a;
+}
+
+function removeAgent(url) {
+  const a = agents.get(url);
+  if (!a) return;
+  a.wantConnected = false;
+  clearTimeout(a.reconnectTimer);
+  if (a.ws) { try { a.ws.close(1000, "unpaired"); } catch (e) {} }
+  agents.delete(url);
+  persistAgents();
+  broadcastStatus();
 }
 
 // --- connection ---
 
-function connect() {
-  wantConnected = true;
-  clearTimeout(reconnectTimer);
-  getConfig().then((cfg) => {
-    if (!cfg.token || !cfg.url) {
-      lastError = "Set the endpoint and token first.";
+function connect(url) {
+  const a = agents.get(url);
+  if (!a) return;
+  a.wantConnected = true;
+  clearTimeout(a.reconnectTimer);
+
+  if (!a.token || !a.url) {
+    a.lastError = "Set the endpoint and token first.";
+    broadcastStatus();
+    return;
+  }
+  try {
+    a.ws = new WebSocket(a.url);
+  } catch (e) {
+    scheduleReconnect(a, "bad endpoint: " + e.message);
+    return;
+  }
+  a.ws.onopen = () => {
+    a.lastError = "";
+    send(a, { type: "hello", token: a.token, client: CLIENT, browser: navigator.userAgent });
+  };
+  a.ws.onmessage = (ev) => onFrame(a, ev.data);
+  a.ws.onclose = (ev) => {
+    a.connected = false;
+    broadcastStatus();
+    if (ev.code === 4001) {
+      a.lastError = "The gateway rejected the pairing token. Copy a fresh one from `bomclaw browser token`.";
+      a.wantConnected = false; // a wrong token will not fix itself
+      persistAgents();
       broadcastStatus();
       return;
     }
-    try {
-      ws = new WebSocket(cfg.url);
-    } catch (e) {
-      scheduleReconnect("bad endpoint: " + e.message);
-      return;
-    }
-    ws.onopen = () => {
-      lastError = "";
-      ws.send(JSON.stringify({
-        type: "hello",
-        token: cfg.token,
-        client: CLIENT,
-        browser: navigator.userAgent,
-      }));
-    };
-    ws.onmessage = (ev) => onFrame(ev.data);
-    ws.onclose = (ev) => {
-      connected = false;
-      agentName = "";
-      broadcastStatus();
-      if (ev.code === 4001) {
-        lastError = "The gateway rejected the pairing token. Copy a fresh one from `bomclaw browser token`.";
-        wantConnected = false; // a wrong token will not fix itself
-        broadcastStatus();
-        return;
-      }
-      if (wantConnected) scheduleReconnect(ev.reason || ("closed (" + ev.code + ")"));
-    };
-    ws.onerror = () => { /* onclose carries the useful signal */ };
-  });
+    if (a.wantConnected) scheduleReconnect(a, ev.reason || ("closed (" + ev.code + ")"));
+  };
+  a.ws.onerror = () => { /* onclose carries the useful signal */ };
+  persistAgents();
 }
 
-function disconnect() {
-  wantConnected = false;
-  clearTimeout(reconnectTimer);
-  connected = false;
-  agentName = "";
-  if (ws) { try { ws.close(1000, "user disconnected"); } catch (e) {} ws = null; }
+function disconnect(url) {
+  const a = agents.get(url);
+  if (!a) return;
+  a.wantConnected = false;
+  clearTimeout(a.reconnectTimer);
+  a.connected = false;
+  if (a.ws) { try { a.ws.close(1000, "user disconnected"); } catch (e) {} a.ws = null; }
+  persistAgents();
   broadcastStatus();
 }
 
-function scheduleReconnect(reason) {
-  lastError = reason || "";
+function scheduleReconnect(a, reason) {
+  a.lastError = reason || "";
   broadcastStatus();
-  clearTimeout(reconnectTimer);
-  reconnectTimer = setTimeout(connect, reconnectDelay);
-  reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX);
+  clearTimeout(a.reconnectTimer);
+  a.reconnectTimer = setTimeout(() => connect(a.url), a.reconnectDelay);
+  a.reconnectDelay = Math.min(a.reconnectDelay * 2, RECONNECT_MAX);
 }
 
-function onFrame(data) {
+function onFrame(a, data) {
   let f;
   try { f = JSON.parse(data); } catch (e) { return; }
   switch (f.type) {
     case "welcome":
-      connected = true;
-      agentName = f.name || f.agent || "agent";
-      reconnectDelay = RECONNECT_MIN;
-      lastError = "";
+      a.connected = true;
+      a.name = f.name || f.agent || a.name || "agent";
+      a.agentId = f.agent || "";
+      a.reconnectDelay = RECONNECT_MIN;
+      a.lastError = "";
+      persistAgents();
       broadcastStatus();
       break;
     case "call":
-      handleCall(f);
+      handleCall(a, f);
       break;
     case "ping":
-      send({ type: "pong" });
+      send(a, { type: "pong" });
       break;
   }
 }
 
-function send(obj) {
-  if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(obj));
-  }
+function send(a, obj) {
+  if (a.ws && a.ws.readyState === WebSocket.OPEN) a.ws.send(JSON.stringify(obj));
 }
 
 // --- action dispatch ---
 
-async function handleCall(f) {
+async function handleCall(a, f) {
+  const started = Date.now();
   try {
-    const result = await runAction(f.action, f.params || {});
-    // An action can report a per-element failure without throwing.
+    const result = await runAction(a, f.action, f.params || {});
     if (result && result.error) {
-      send({ type: "result", id: f.id, ok: false, error: result.error });
+      note(a, f.action, f.params, result.error, started);
+      send(a, { type: "result", id: f.id, ok: false, error: result.error });
     } else {
-      send({ type: "result", id: f.id, ok: true, result: result });
+      note(a, f.action, f.params, "", started);
+      send(a, { type: "result", id: f.id, ok: true, result: result });
     }
   } catch (e) {
-    send({ type: "result", id: f.id, ok: false, error: String(e && e.message || e) });
+    const msg = String((e && e.message) || e);
+    note(a, f.action, f.params, msg, started);
+    send(a, { type: "result", id: f.id, ok: false, error: msg });
   }
 }
 
-async function runAction(action, p) {
+// note records one action for the popup. The detail is the single most useful
+// parameter — a URL or a ref — because "click" alone says nothing about what
+// the agent is doing to your browser.
+function note(a, action, params, error, started) {
+  a.actions++;
+  a.lastAction = action;
+  a.lastActionAt = Date.now();
+  const p = params || {};
+  const detail = p.url || p.ref || p.expression || p.text || p.action || "";
+  activity.unshift({
+    at: Date.now(),
+    ms: Date.now() - started,
+    agent: a.name || a.url,
+    action,
+    detail: String(detail).slice(0, 80),
+    error: error || "",
+  });
+  if (activity.length > LOG_MAX) activity.length = LOG_MAX;
+  broadcastStatus();
+}
+
+async function runAction(a, action, p) {
   switch (action) {
-    case "navigate": return navigate(p.url);
-    case "snapshot": return injectFn(await targetTab(), bcSnapshot, [p.selector || ""]);
-    case "click":    return injectFn(await targetTab(), bcClick, [p.ref]);
-    case "fill":     return injectFn(await targetTab(), bcFill, [p.ref, p.text || ""]);
-    case "type":     return injectFn(await targetTab(), bcType, [p.ref, p.text || ""]);
-    case "select":   return injectFn(await targetTab(), bcSelect, [p.ref, p.value || ""]);
-    case "scroll":   return injectFn(await targetTab(), bcScroll, [p.direction || "down", p.pixels || 0]);
-    case "text":     return injectFn(await targetTab(), bcText, [p.ref || "", p.property || "text"]);
-    case "back":     return goBack();
-    case "wait":     return waitFor(p);
-    case "screenshot": return screenshot();
-    case "eval":     return evalJS(p.expression || "");
-    case "tabs":     return tabsAction(p);
+    case "navigate": return navigate(a, p.url);
+    case "snapshot": return injectFn(a, await targetTab(a), bcSnapshot, [p.selector || ""]);
+    case "click":    return injectFn(a, await targetTab(a), bcClick, [p.ref]);
+    case "fill":     return injectFn(a, await targetTab(a), bcFill, [p.ref, p.text || ""]);
+    case "type":     return injectFn(a, await targetTab(a), bcType, [p.ref, p.text || ""]);
+    case "select":   return injectFn(a, await targetTab(a), bcSelect, [p.ref, p.value || ""]);
+    case "scroll":   return injectFn(a, await targetTab(a), bcScroll, [p.direction || "down", p.pixels || 0]);
+    case "text":     return injectFn(a, await targetTab(a), bcText, [p.ref || "", p.property || "text"]);
+    case "back":     return goBack(a);
+    case "wait":     return waitFor(a, p);
+    case "screenshot": return screenshot(a);
+    case "eval":     return evalJS(a, p.expression || "");
+    case "tabs":     return tabsAction(a, p);
     default: throw new Error("unknown action: " + action);
   }
 }
 
-// targetTab returns the tab the agent is currently acting on, creating the
-// agent tab if none exists yet.
-async function targetTab() {
-  if (currentTabId != null && await tabExists(currentTabId)) return currentTabId;
-  if (agentTabId != null && await tabExists(agentTabId)) { currentTabId = agentTabId; return agentTabId; }
-  const tab = await createAgentTab("about:blank");
+// targetTab returns the tab this agent is acting on, creating its own tab if
+// it has none. Per-agent, so two agents never steer the same page.
+async function targetTab(a) {
+  if (a.currentTabId != null && await tabExists(a.currentTabId)) return a.currentTabId;
+  if (a.agentTabId != null && await tabExists(a.agentTabId)) { a.currentTabId = a.agentTabId; return a.agentTabId; }
+  const tab = await createAgentTab(a, "about:blank");
   return tab.id;
 }
 
@@ -179,36 +256,36 @@ async function tabExists(id) {
   try { await chrome.tabs.get(id); return true; } catch (e) { return false; }
 }
 
-async function createAgentTab(url) {
+async function createAgentTab(a, url) {
   // A separate window keeps the agent's page out of the user's tab strip.
   const win = await chrome.windows.create({ url, focused: false });
   const tab = win.tabs[0];
-  agentTabId = tab.id;
-  currentTabId = tab.id;
+  a.agentTabId = tab.id;
+  a.currentTabId = tab.id;
   return tab;
 }
 
-async function navigate(url) {
+async function navigate(a, url) {
   if (!url) throw new Error("url is required");
-  let tabId = agentTabId;
+  let tabId = a.agentTabId;
   if (tabId == null || !(await tabExists(tabId))) {
-    const tab = await createAgentTab(url);
+    const tab = await createAgentTab(a, url);
     tabId = tab.id;
   } else {
     await chrome.tabs.update(tabId, { url });
   }
-  currentTabId = tabId;
+  a.currentTabId = tabId;
   await waitForLoad(tabId, 15000);
   return { message: "Navigated to " + url };
 }
 
-async function goBack() {
-  const tabId = await targetTab();
-  await injectFn(tabId, () => { history.back(); return true; }, []);
+async function goBack(a) {
+  const tabId = await targetTab(a);
+  await injectFn(a, tabId, () => { history.back(); return true; }, []);
   return { message: "Navigated back" };
 }
 
-async function waitFor(p) {
+async function waitFor(a, p) {
   const ms = p.ms || 0;
   if (ms > 0 && !p.ref && !p.text) {
     await sleep(ms);
@@ -216,28 +293,25 @@ async function waitFor(p) {
   }
   const timeout = ms > 0 ? ms : 10000;
   const deadline = Date.now() + timeout;
-  const tabId = await targetTab();
+  const tabId = await targetTab(a);
   while (Date.now() < deadline) {
-    const r = await injectFn(tabId, bcExists, [p.ref || "", p.text || ""]);
+    const r = await injectFn(a, tabId, bcExists, [p.ref || "", p.text || ""]);
     if (r && r.found) return { message: "Condition met" };
     await sleep(200);
   }
   throw new Error("timed out waiting for " + (p.ref || JSON.stringify(p.text)));
 }
 
-async function screenshot() {
-  const tabId = await targetTab();
+async function screenshot(a) {
+  const tabId = await targetTab(a);
   const tab = await chrome.tabs.get(tabId);
-  // captureVisibleTab needs the target window to be the one captured; it does
-  // not need focus stolen from the user, only the window id.
   const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" });
-  const base64 = dataUrl.replace(/^data:image\/png;base64,/, "");
-  return { data: base64, format: "png" };
+  return { data: dataUrl.replace(/^data:image\/png;base64,/, ""), format: "png" };
 }
 
-async function evalJS(expression) {
+async function evalJS(a, expression) {
   if (!expression) throw new Error("expression is required");
-  const tabId = await targetTab();
+  const tabId = await targetTab(a);
   try {
     const [res] = await chrome.scripting.executeScript({
       target: { tabId },
@@ -254,33 +328,39 @@ async function evalJS(expression) {
   }
 }
 
-// tabsAction lists/opens/focuses/closes tabs. list and focus/close work on the
-// user's own tabs by id; focus also makes that tab the agent's active target.
-async function tabsAction(p) {
+// tabsAction lists/opens/focuses/closes tabs. The listing marks which tab THIS
+// agent is driving, and which belong to another agent, so a two-agent setup is
+// legible instead of a flat list of everything open.
+async function tabsAction(a, p) {
   const action = p.action || "list";
   switch (action) {
     case "list": {
       const tabs = await chrome.tabs.query({});
+      const owners = new Map();
+      for (const other of agents.values()) {
+        if (other.agentTabId != null) owners.set(other.agentTabId, other.name || other.url);
+      }
       return {
         tabs: tabs.map((t) => ({
           id: String(t.id),
           title: t.title || "",
           url: t.url || "",
-          active: t.id === currentTabId,
+          active: t.id === a.currentTabId,
+          owner: owners.get(t.id) || "",
         })),
       };
     }
     case "open": {
       if (!p.url) throw new Error("url is required");
       const tab = await chrome.tabs.create({ url: p.url, active: false });
-      currentTabId = tab.id;
+      a.currentTabId = tab.id;
       await waitForLoad(tab.id, 15000);
       return { tabId: String(tab.id), message: "Opened tab " + tab.id };
     }
     case "focus": {
       const id = parseInt(p.tab_id, 10);
       if (!(await tabExists(id))) throw new Error("no tab with id " + p.tab_id);
-      currentTabId = id;
+      a.currentTabId = id;
       const t = await chrome.tabs.get(id);
       await chrome.tabs.update(id, { active: true });
       await chrome.windows.update(t.windowId, { focused: true });
@@ -289,8 +369,8 @@ async function tabsAction(p) {
     case "close": {
       const id = parseInt(p.tab_id, 10);
       await chrome.tabs.remove(id);
-      if (currentTabId === id) currentTabId = null;
-      if (agentTabId === id) agentTabId = null;
+      if (a.currentTabId === id) a.currentTabId = null;
+      if (a.agentTabId === id) a.agentTabId = null;
       return { message: "Closed tab " + id };
     }
     default:
@@ -302,7 +382,7 @@ async function tabsAction(p) {
 
 // injectFn runs a page.js function in the target tab's MAIN world and returns
 // its value. A ref/param is passed as args, never string-interpolated.
-async function injectFn(tabId, fn, args) {
+async function injectFn(a, tabId, fn, args) {
   try {
     const [res] = await chrome.scripting.executeScript({
       target: { tabId },
@@ -334,14 +414,13 @@ async function injectionBlockReason(tabId, cause) {
       ") — load a page first with `bomclaw browser navigate <url>`, " +
       "or point the agent at one of the user's tabs with `bomclaw browser tabs focus <id>`";
   }
-  if (/^(chrome|chrome-untrusted|edge|brave|devtools|view-source|file|data):/i.test(url)) {
+  if (/^(chrome|chrome-untrusted|chrome-extension|edge|brave|devtools|view-source|file|data):/i.test(url)) {
     return "Chrome does not let extensions script " + url.split(":")[0] +
       ": pages — navigate to an http(s) page instead";
   }
   if (/^https:\/\/(chromewebstore\.google\.com|chrome\.google\.com\/webstore)/i.test(url)) {
     return "Chrome blocks extensions from scripting the Web Store";
   }
-  // Not a URL restriction we recognise — pass Chrome's own words through.
   return String((cause && cause.message) || cause || "script injection failed");
 }
 
@@ -349,8 +428,6 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-// waitForLoad resolves when the tab finishes loading, or after a timeout —
-// navigation should not hang an action forever on a slow page.
 function waitForLoad(tabId, timeout) {
   return new Promise((resolve) => {
     let done = false;
@@ -364,31 +441,62 @@ function waitForLoad(tabId, timeout) {
 
 // --- popup messaging ---
 
-function statusPayload() {
-  return { type: "status", connected, wantConnected, agentName, lastError };
+async function statusPayload() {
+  const list = [];
+  for (const a of agents.values()) {
+    let tab = null;
+    if (a.currentTabId != null) {
+      try {
+        const t = await chrome.tabs.get(a.currentTabId);
+        tab = { id: String(t.id), title: t.title || "", url: t.url || "" };
+      } catch (e) { /* the tab went away; report none */ }
+    }
+    list.push({
+      url: a.url,
+      name: a.name || "",
+      agentId: a.agentId || "",
+      connected: a.connected,
+      wantConnected: a.wantConnected,
+      lastError: a.lastError || "",
+      actions: a.actions,
+      lastAction: a.lastAction || "",
+      lastActionAt: a.lastActionAt || 0,
+      tab,
+    });
+  }
+  list.sort((x, y) => x.url.localeCompare(y.url));
+  return { type: "status", agents: list, activity };
 }
 
 function broadcastStatus() {
-  chrome.runtime.sendMessage(statusPayload()).catch(() => {});
+  statusPayload().then((p) => chrome.runtime.sendMessage(p).catch(() => {})).catch(() => {});
 }
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   switch (msg && msg.type) {
     case "getStatus":
-      sendResponse(statusPayload());
-      return false;
+      statusPayload().then(sendResponse);
+      return true;
+    case "pair":
+      upsertAgent(msg.url, msg.token);
+      connect(msg.url);
+      statusPayload().then(sendResponse);
+      return true;
     case "connect":
-      chrome.storage.local.set({ token: msg.token, url: msg.url, autoConnect: true }, () => {
-        reconnectDelay = RECONNECT_MIN;
-        connect();
-        sendResponse(statusPayload());
-      });
+      connect(msg.url);
+      statusPayload().then(sendResponse);
       return true;
     case "disconnect":
-      chrome.storage.local.set({ autoConnect: false }, () => {
-        disconnect();
-        sendResponse(statusPayload());
-      });
+      disconnect(msg.url);
+      statusPayload().then(sendResponse);
+      return true;
+    case "forget":
+      removeAgent(msg.url);
+      statusPayload().then(sendResponse);
+      return true;
+    case "clearActivity":
+      activity = [];
+      statusPayload().then(sendResponse);
       return true;
   }
   return false;

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,36 +1,66 @@
 :root { color-scheme: light dark; }
 body {
-  width: 320px;
-  margin: 0;
-  padding: 14px;
+  width: 360px; margin: 0; padding: 12px;
   font: 13px/1.45 -apple-system, system-ui, sans-serif;
 }
-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+header { margin-bottom: 10px; }
 h1 { font-size: 14px; margin: 0; font-weight: 600; }
+h2 { font-size: 11px; margin: 0; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: #777; }
+
+/* agent cards */
+.agent { border: 1px solid #d8d8d8; border-radius: 8px; padding: 8px 9px; margin-bottom: 8px; }
+.agent-top { display: flex; align-items: center; gap: 7px; }
 .dot { width: 9px; height: 9px; border-radius: 50%; background: #b91c1c; flex: none; }
 .dot.on { background: #16a34a; }
 .dot.wait { background: #d97706; }
-.state { margin: 0 0 8px; color: #555; }
-.error { margin: 0 0 8px; color: #b91c1c; font-size: 12px; }
+.agent-name { font-weight: 600; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-meta { color: #777; font-size: 11px; margin-top: 3px; word-break: break-all; }
+.agent-tab { font-size: 11px; margin-top: 4px; padding: 4px 6px; background: rgba(127,127,127,.12); border-radius: 5px; }
+.agent-tab .t { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-tab .u { color: #777; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-actions { display: flex; gap: 6px; margin-top: 7px; }
+.error { color: #b91c1c; font-size: 11px; margin: 5px 0 0; }
+.empty { color: #777; font-size: 12px; margin: 0 0 10px; }
+
+/* forms + buttons */
 label { display: block; margin: 8px 0 2px; font-size: 12px; color: #444; }
 input {
   width: 100%; box-sizing: border-box; padding: 6px 8px; margin-top: 2px;
   border: 1px solid #ccc; border-radius: 6px; font-size: 13px;
 }
-.row { display: flex; gap: 8px; margin-top: 12px; }
 button {
-  flex: 1; padding: 7px 10px; border: 0; border-radius: 6px;
-  font-size: 13px; font-weight: 500; cursor: pointer; background: #e5e7eb;
+  padding: 5px 10px; border: 0; border-radius: 6px;
+  font-size: 12px; font-weight: 500; cursor: pointer; background: #e5e7eb; color: #222;
 }
-button.primary { background: #2563eb; color: #fff; }
-button:disabled { opacity: .5; cursor: default; }
-.hint { margin: 12px 0 0; font-size: 11px; color: #777; }
+button.primary { background: #2563eb; color: #fff; width: 100%; margin-top: 10px; padding: 7px; }
+button.link { background: none; color: #777; padding: 0; font-weight: 400; font-size: 11px; }
+details { border-top: 1px solid #e2e2e2; padding-top: 8px; }
+summary { cursor: pointer; font-size: 12px; color: #555; }
+.hint { margin: 8px 0 0; font-size: 11px; color: #777; }
 code { background: rgba(127,127,127,.18); padding: 1px 4px; border-radius: 4px; }
+
+/* activity */
+#activity-box { border-top: 1px solid #e2e2e2; margin-top: 10px; padding-top: 8px; }
+.act-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 5px; }
+#activity { list-style: none; margin: 0; padding: 0; max-height: 190px; overflow-y: auto; }
+#activity li { font-size: 11px; padding: 3px 0; border-bottom: 1px solid rgba(127,127,127,.14); display: flex; gap: 6px; }
+#activity li:last-child { border-bottom: 0; }
+.act-time { color: #999; flex: none; font-variant-numeric: tabular-nums; }
+.act-body { flex: 1; overflow: hidden; }
+.act-action { font-weight: 600; }
+.act-agent { color: #777; }
+.act-detail { color: #555; word-break: break-all; }
+.act-err { color: #b91c1c; }
+.act-ok { color: #16a34a; }
+
 @media (prefers-color-scheme: dark) {
   body { background: #1e1e1e; color: #e5e5e5; }
-  .state { color: #aaa; }
+  h2, .agent-meta, .agent-tab .u, .hint, summary, .act-agent, .empty { color: #999; }
+  .agent { border-color: #3a3a3a; }
   label { color: #bbb; }
   input { background: #2a2a2a; border-color: #444; color: #eee; }
   button { background: #3a3a3a; color: #eee; }
   button.primary { background: #2563eb; color: #fff; }
+  details, #activity-box { border-color: #3a3a3a; }
+  .act-detail { color: #bbb; }
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,30 +6,35 @@
 </head>
 <body>
   <header>
-    <span class="dot" id="dot"></span>
     <h1>BomClaw Browser Bridge</h1>
   </header>
 
-  <p id="state" class="state">Not connected</p>
-  <p id="error" class="error" hidden></p>
+  <section id="agents"></section>
 
-  <label>Gateway endpoint
-    <input id="url" type="text" placeholder="ws://127.0.0.1:18789/ext" spellcheck="false" />
-  </label>
-  <label>Pairing token
-    <input id="token" type="password" placeholder="from `bomclaw browser token`" spellcheck="false" />
-  </label>
+  <details id="pair-box">
+    <summary>Pair another agent</summary>
+    <label>Gateway endpoint
+      <input id="url" type="text" placeholder="ws://127.0.0.1:18789/ext" spellcheck="false" />
+    </label>
+    <label>Pairing token
+      <input id="token" type="password" placeholder="from `bomclaw browser token`" spellcheck="false" />
+    </label>
+    <p id="pair-error" class="error" hidden></p>
+    <button id="pair" class="primary">Pair</button>
+    <p class="hint">
+      Each agent has its own token and port — agent 1 on 18789, agent 2 on
+      18790. Pair both and each drives its own tab.
+    </p>
+  </details>
 
-  <div class="row">
-    <button id="connect" class="primary">Connect</button>
-    <button id="disconnect" hidden>Disconnect</button>
-  </div>
+  <section id="activity-box">
+    <div class="act-head">
+      <h2>Recent activity</h2>
+      <button id="clear" class="link">clear</button>
+    </div>
+    <ol id="activity"></ol>
+  </section>
 
-  <p class="hint">
-    Run <code>bomclaw browser token</code> on the machine running the gateway,
-    then paste the endpoint and token above. While connected, your agent can
-    drive this browser with your logged-in sessions.
-  </p>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,33 +1,142 @@
 const $ = (id) => document.getElementById(id);
 const DEFAULT_URL = "ws://127.0.0.1:18789/ext";
 
+// Everything the popup shows is rendered from one status payload, so the view
+// can never disagree with the service worker about who is connected.
 function render(s) {
-  const dot = $("dot");
-  dot.className = "dot" + (s.connected ? " on" : s.wantConnected ? " wait" : "");
-  $("state").textContent = s.connected
-    ? "Connected to " + (s.agentName || "agent")
-    : s.wantConnected ? "Connecting…" : "Not connected";
-  $("error").hidden = !s.lastError;
-  $("error").textContent = s.lastError || "";
-  $("connect").hidden = s.connected || s.wantConnected;
-  $("disconnect").hidden = !(s.connected || s.wantConnected);
+  renderAgents(s.agents || []);
+  renderActivity(s.activity || []);
 }
 
-chrome.storage.local.get(["url", "token"], (v) => {
-  $("url").value = v.url || DEFAULT_URL;
-  $("token").value = v.token || "";
-});
+function renderAgents(list) {
+  const host = $("agents");
+  host.textContent = "";
+  if (list.length === 0) {
+    const p = el("p", "empty", "No agent paired yet. Run `bomclaw browser token` and pair below.");
+    host.appendChild(p);
+    $("pair-box").open = true;
+    return;
+  }
+  for (const a of list) host.appendChild(agentCard(a));
+}
 
-chrome.runtime.sendMessage({ type: "getStatus" }).then(render).catch(() => {});
+function agentCard(a) {
+  const card = el("div", "agent");
+
+  const top = el("div", "agent-top");
+  const dot = el("span", "dot" + (a.connected ? " on" : a.wantConnected ? " wait" : ""));
+  const name = el("span", "agent-name", a.name || a.agentId || hostOf(a.url));
+  top.append(dot, name);
+  card.appendChild(top);
+
+  const state = a.connected
+    ? `connected · ${a.actions} action${a.actions === 1 ? "" : "s"}` +
+      (a.lastAction ? ` · last: ${a.lastAction} ${ago(a.lastActionAt)}` : "")
+    : a.wantConnected ? "connecting…" : "disconnected";
+  card.appendChild(el("div", "agent-meta", `${state}\n${a.url}`));
+
+  // Which page this agent is driving — the question the popup exists to
+  // answer once more than one agent is attached.
+  if (a.connected && a.tab) {
+    const t = el("div", "agent-tab");
+    t.appendChild(el("span", "t", a.tab.title || "(untitled tab)"));
+    t.appendChild(el("span", "u", a.tab.url || ""));
+    card.appendChild(t);
+  }
+
+  if (a.lastError) card.appendChild(el("p", "error", a.lastError));
+
+  const row = el("div", "agent-actions");
+  const toggle = el("button", "", a.connected || a.wantConnected ? "Disconnect" : "Connect");
+  toggle.onclick = () => sendMsg({
+    type: a.connected || a.wantConnected ? "disconnect" : "connect", url: a.url,
+  });
+  const forget = el("button", "", "Forget");
+  forget.onclick = () => { if (confirm("Unpair " + (a.name || a.url) + "?")) sendMsg({ type: "forget", url: a.url }); };
+  row.append(toggle, forget);
+  card.appendChild(row);
+  return card;
+}
+
+function renderActivity(list) {
+  const host = $("activity");
+  host.textContent = "";
+  if (list.length === 0) {
+    host.appendChild(el("li", "empty", "Nothing yet."));
+    return;
+  }
+  for (const a of list) {
+    const li = document.createElement("li");
+    li.appendChild(el("span", "act-time", clock(a.at)));
+    const body = el("div", "act-body");
+    const head = document.createElement("div");
+    head.appendChild(el("span", "act-action" + (a.error ? " act-err" : " act-ok"), a.action));
+    head.appendChild(document.createTextNode(" "));
+    head.appendChild(el("span", "act-agent", a.agent));
+    body.appendChild(head);
+    if (a.detail) body.appendChild(el("div", "act-detail", a.detail));
+    if (a.error) body.appendChild(el("div", "act-err", a.error));
+    li.appendChild(body);
+    host.appendChild(li);
+  }
+}
+
+// --- helpers ---
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+}
+
+function hostOf(url) {
+  try { return new URL(url).host; } catch (e) { return url; }
+}
+
+function clock(ms) {
+  const d = new Date(ms);
+  return String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0") + ":" +
+    String(d.getSeconds()).padStart(2, "0");
+}
+
+function ago(ms) {
+  if (!ms) return "";
+  const s = Math.round((Date.now() - ms) / 1000);
+  if (s < 60) return s + "s ago";
+  if (s < 3600) return Math.round(s / 60) + "m ago";
+  return Math.round(s / 3600) + "h ago";
+}
+
+function sendMsg(msg) {
+  return chrome.runtime.sendMessage(msg).then(render).catch(() => {});
+}
+
+// --- wiring ---
+
+sendMsg({ type: "getStatus" });
 chrome.runtime.onMessage.addListener((msg) => { if (msg && msg.type === "status") render(msg); });
 
-$("connect").addEventListener("click", () => {
-  const url = $("url").value.trim() || DEFAULT_URL;
-  const token = $("token").value.trim();
-  if (!token) { $("error").hidden = false; $("error").textContent = "Paste a pairing token first."; return; }
-  chrome.runtime.sendMessage({ type: "connect", url, token }).then(render).catch(() => {});
+chrome.storage.local.get(["agents"], (v) => {
+  const used = new Set((v.agents || []).map((a) => a.url));
+  // Offer the next unpaired port rather than one already in the list, so
+  // pairing a second agent is one click and a token.
+  $("url").value = [DEFAULT_URL, "ws://127.0.0.1:18790/ext"].find((u) => !used.has(u)) || DEFAULT_URL;
 });
 
-$("disconnect").addEventListener("click", () => {
-  chrome.runtime.sendMessage({ type: "disconnect" }).then(render).catch(() => {});
+$("pair").addEventListener("click", () => {
+  const url = $("url").value.trim() || DEFAULT_URL;
+  const token = $("token").value.trim();
+  const err = $("pair-error");
+  if (!token) { err.hidden = false; err.textContent = "Paste a pairing token first."; return; }
+  err.hidden = true;
+  sendMsg({ type: "pair", url, token }).then(() => {
+    $("token").value = "";
+    $("pair-box").open = false;
+  });
 });
+
+$("clear").addEventListener("click", () => sendMsg({ type: "clearActivity" }));
+
+// Keep "last: click 12s ago" honest while the popup stays open.
+setInterval(() => sendMsg({ type: "getStatus" }), 3000);

--- a/internal/browserbridge/hub.go
+++ b/internal/browserbridge/hub.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -73,14 +74,29 @@ type Options struct {
 	Logf         func(format string, args ...any)
 }
 
-// Status describes the connected browser, for `bomclaw browser status` and
-// the dashboard.
+// Status describes the connected browser, for `bomclaw browser status`, the
+// dashboard and the extension popup. It names the agent as well as the
+// browser: with several agents on one machine, "connected" alone does not say
+// whose browser this is, and that is the first thing anyone debugging a
+// two-agent setup needs to know.
 type Status struct {
-	Connected   bool   `json:"connected"`
+	Connected bool   `json:"connected"`
+	AgentID   string `json:"agent_id,omitempty"`
+	AgentName string `json:"agent_name,omitempty"`
+
 	Client      string `json:"client,omitempty"`
 	Browser     string `json:"browser,omitempty"`
+	BrowserName string `json:"browser_name,omitempty"` // "Chrome 149 on macOS", from the UA
 	ConnectedAt string `json:"connected_at,omitempty"`
 	LastSeen    string `json:"last_seen,omitempty"`
+
+	// What this browser has actually been asked to do. Without it the popup
+	// can only say "connected", which looks identical whether the agent is
+	// working or has never touched the browser at all.
+	Actions      int    `json:"actions"`
+	LastAction   string `json:"last_action,omitempty"`
+	LastActionAt string `json:"last_action_at,omitempty"`
+	LastError    string `json:"last_error,omitempty"`
 }
 
 type frame struct {
@@ -246,15 +262,29 @@ func (h *Hub) Connected() bool { return h.current() != nil }
 func (h *Hub) Status() Status {
 	c := h.current()
 	if c == nil {
-		return Status{}
+		// Still name the agent: a disconnected bridge is the common case
+		// while pairing, and "which agent am I looking at" is exactly the
+		// question then.
+		return Status{AgentID: h.opts.AgentID, AgentName: h.opts.AgentName}
 	}
-	return Status{
+	act := c.activity()
+	st := Status{
 		Connected:   true,
+		AgentID:     h.opts.AgentID,
+		AgentName:   h.opts.AgentName,
 		Client:      c.client,
 		Browser:     c.browser,
+		BrowserName: describeUA(c.browser),
 		ConnectedAt: c.connectedAt.Format(time.RFC3339),
 		LastSeen:    c.lastSeen().Format(time.RFC3339),
+		Actions:     act.count,
+		LastAction:  act.name,
+		LastError:   act.err,
 	}
+	if !act.at.IsZero() {
+		st.LastActionAt = act.at.Format(time.RFC3339)
+	}
+	return st
 }
 
 func (h *Hub) current() *conn {
@@ -296,16 +326,64 @@ func (h *Hub) Call(ctx context.Context, action string, params json.RawMessage) (
 	select {
 	case f := <-ch:
 		if !f.OK {
+			c.record(action, f.Error)
 			return nil, &ActionError{Action: action, Message: f.Error}
 		}
+		c.record(action, "")
 		return f.Result, nil
 	case <-c.closed:
 		return nil, ErrDisconnected
 	case <-timer.C:
-		return nil, fmt.Errorf("%s: the browser did not answer within %s", action, wait)
+		err := fmt.Errorf("%s: the browser did not answer within %s", action, wait)
+		c.record(action, err.Error())
+		return nil, err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// describeUA reduces a user-agent string to something a person can read at a
+// glance in the popup or the dashboard. Unrecognised agents keep their raw
+// string rather than being guessed at.
+func describeUA(ua string) string {
+	if ua == "" {
+		return ""
+	}
+	var browser string
+	switch {
+	case strings.Contains(ua, "Edg/"):
+		browser = "Edge " + uaVersion(ua, "Edg/")
+	case strings.Contains(ua, "OPR/"):
+		browser = "Opera " + uaVersion(ua, "OPR/")
+	case strings.Contains(ua, "Chrome/"):
+		browser = "Chrome " + uaVersion(ua, "Chrome/")
+	case strings.Contains(ua, "Firefox/"):
+		browser = "Firefox " + uaVersion(ua, "Firefox/")
+	default:
+		return shorten(ua, 40)
+	}
+	switch {
+	case strings.Contains(ua, "Mac OS X"), strings.Contains(ua, "Macintosh"):
+		return browser + " on macOS"
+	case strings.Contains(ua, "Windows"):
+		return browser + " on Windows"
+	case strings.Contains(ua, "Linux"), strings.Contains(ua, "X11"):
+		return browser + " on Linux"
+	}
+	return browser
+}
+
+// uaVersion pulls the major version that follows a token like "Chrome/".
+func uaVersion(ua, token string) string {
+	i := strings.Index(ua, token)
+	if i < 0 {
+		return ""
+	}
+	rest := ua[i+len(token):]
+	if dot := strings.IndexAny(rest, ".; )"); dot >= 0 {
+		return rest[:dot]
+	}
+	return rest
 }
 
 func (h *Hub) authorize(action string, params json.RawMessage) error {
@@ -362,6 +440,12 @@ type conn struct {
 	pendMu  sync.Mutex
 	pending map[string]chan frame
 
+	actMu   sync.Mutex
+	actName string
+	actAt   time.Time
+	actErr  string
+	actN    int
+
 	closed    chan struct{}
 	closeOnce sync.Once
 }
@@ -387,6 +471,30 @@ func (c *conn) describe() string {
 		return c.client
 	}
 	return c.client + " (" + shorten(c.browser, 60) + ")"
+}
+
+// record notes what the browser was last asked to do, so the popup and the
+// dashboard can show activity rather than a bare "connected".
+func (c *conn) record(action, errMsg string) {
+	c.actMu.Lock()
+	defer c.actMu.Unlock()
+	c.actName = action
+	c.actAt = time.Now()
+	c.actErr = errMsg
+	c.actN++
+}
+
+type activitySnapshot struct {
+	name  string
+	at    time.Time
+	err   string
+	count int
+}
+
+func (c *conn) activity() activitySnapshot {
+	c.actMu.Lock()
+	defer c.actMu.Unlock()
+	return activitySnapshot{name: c.actName, at: c.actAt, err: c.actErr, count: c.actN}
 }
 
 func (c *conn) touch()              { c.seen.Store(time.Now().UnixNano()) }

--- a/internal/browserbridge/hub_test.go
+++ b/internal/browserbridge/hub_test.go
@@ -308,3 +308,90 @@ func TestHubAnswersExtensionPings(t *testing.T) {
 		t.Fatalf("expected pong, got %+v (err %v)", f, err)
 	}
 }
+
+// Status has to answer "whose browser is this, and has it done anything?".
+// With two agents on one machine a bare "connected" is ambiguous, and it looks
+// identical whether the agent is working or has never touched the browser.
+func TestStatusNamesTheAgentAndItsActivity(t *testing.T) {
+	hub, wsURL := newTestHub(t, nil)
+
+	// Disconnected: the agent is still named, because "which agent am I
+	// pairing with" is exactly the question at that moment.
+	if st := hub.Status(); st.Connected || st.AgentID != "a1" || st.AgentName != "Agent One" {
+		t.Fatalf("disconnected status should still name the agent, got %+v", st)
+	}
+
+	ws := fakeExtension(t, wsURL, testToken)
+	expectWelcome(t, ws)
+	waitConnected(t, hub)
+
+	if st := hub.Status(); st.Actions != 0 || st.LastAction != "" {
+		t.Fatalf("a fresh connection has run nothing, got %+v", st)
+	}
+
+	go func() {
+		f, err := readFrame(t, ws)
+		if err != nil {
+			return
+		}
+		_ = ws.WriteJSON(frame{Type: "result", ID: f.ID, OK: true, Result: json.RawMessage(`{"nodes":[]}`)})
+	}()
+	if _, err := hub.Call(context.Background(), "snapshot", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	st := hub.Status()
+	if st.Actions != 1 || st.LastAction != "snapshot" || st.LastActionAt == "" {
+		t.Errorf("a successful action should be recorded, got %+v", st)
+	}
+	if st.LastError != "" {
+		t.Errorf("a successful action must not leave an error, got %q", st.LastError)
+	}
+	if st.AgentID != "a1" || st.BrowserName != "TestBrowser/1" {
+		t.Errorf("status should carry agent + browser identity, got %+v", st)
+	}
+}
+
+// A failed action is still activity, and the reason is what the operator needs.
+func TestStatusRecordsTheLastFailure(t *testing.T) {
+	hub, wsURL := newTestHub(t, nil)
+	ws := fakeExtension(t, wsURL, testToken)
+	expectWelcome(t, ws)
+	waitConnected(t, hub)
+
+	go func() {
+		f, err := readFrame(t, ws)
+		if err != nil {
+			return
+		}
+		_ = ws.WriteJSON(frame{Type: "result", ID: f.ID, OK: false, Error: "element n9 not found"})
+	}()
+	_, _ = hub.Call(context.Background(), "click", json.RawMessage(`{"ref":"n9"}`))
+
+	st := hub.Status()
+	if st.Actions != 1 || st.LastAction != "click" {
+		t.Errorf("a failed action still counts, got %+v", st)
+	}
+	if !strings.Contains(st.LastError, "n9 not found") {
+		t.Errorf("status should carry the failure reason, got %q", st.LastError)
+	}
+}
+
+func TestDescribeUA(t *testing.T) {
+	cases := []struct{ ua, want string }{
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36", "Chrome 149 on macOS"},
+		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/141.0.0.0 Safari/537.36 Edg/141.0.0.0", "Edge 141 on Windows"},
+		{"Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/133.0", "Firefox 133 on Linux"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := describeUA(c.ua); got != c.want {
+			t.Errorf("describeUA(%.40q) = %q, want %q", c.ua, got, c.want)
+		}
+	}
+	// An agent string nothing matches keeps its own words rather than being
+	// guessed at.
+	if got := describeUA("SomeBot/2.0"); got != "SomeBot/2.0" {
+		t.Errorf("unknown UA should pass through, got %q", got)
+	}
+}


### PR DESCRIPTION
Two agents run on this machine, and the bridge was built for one.

The extension held a **single** socket, so whichever agent was paired last owned the browser and the other was permanently locked out. Live proof before this change:

```
agent 1 (:18789)  {"connected":true, ...}
agent 2 (:18790)  {"connected":false}     ← could never use the feature
```

And the popup showed one dot — "connected" — with no way to tell *which* agent that was, whether it had ever done anything, or what page it was on.

## A connection per agent

One socket, one reconnect loop and one token **per gateway**. Pair as many as you like from the popup. The old single-agent storage shape is migrated on upgrade, so your existing pairing survives instead of silently unpairing.

## A tab per agent

`agentTabId` was module-level. With two agents attached they would have taken turns navigating one page out from under each other. Each connection now owns its own tab and window.

`bomclaw browser tabs` makes that legible:

```
   ID   TITLE                        URL
*  42   Example Domain               https://example.com
   43   Inbox [BomClaw (agent 2)]    https://mail.example.com

* = the tab this agent acts on. `tabs focus <id>` to switch.
```

Focusing onto a tab a peer is driving is now a deliberate choice, not an accident.

## Say what happened

The hub records each action against the connection — count, last action, when, last error — and `Status` carries the agent's id/name plus a readable browser string (`Chrome 149 on macOS`, parsed from the UA; an unrecognised UA passes through rather than being guessed at). A **disconnected** hub still names its agent, because "which agent am I pairing with" is precisely the question at that moment.

That fixes three places that were all showing less than they had:

| Surface | Before | After |
|---|---|---|
| Popup | one dot | per-agent state, action count, last action + when, the page it's on, and a rolling log across all agents (action, target, duration, error) |
| `bomclaw browser status` | raw JSON | a few readable lines |
| Dashboard **Status** tab | **nothing** | connection, agent, actions, last action, last error |

That last row is worth calling out: `StatusResult` has carried a `Browser` field since the bridge landed and **nothing ever rendered it**. It was dead payload.

## Security note

The popup builds its DOM with `textContent`/`createElement` throughout — no `innerHTML`. Tab titles come from arbitrary web pages, and this view exists to display them.

## Tests

New coverage on the hub: Status names its agent when disconnected, records a successful action, records a failed action *with the reason*, and `describeUA` across Chrome/Edge/Firefox/macOS/Windows/Linux plus an unknown agent that must pass through unchanged.

`go build ./... && go test ./...` green; `tsc --noEmit` clean; extension JS syntax-checked.

## Deploying

Go + dashboard changes → binary and `dashboard/dist` need redeploy. Extension changes → **Reload** in `chrome://extensions`, then pair agent 2 with its own token (`BOMCLAW_GATEWAY_ADDR=http://127.0.0.1:18790 bomclaw browser token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)