### PR TITLE
fix(claude): send the system prompt on every turn, and stop killing the operator's sessions

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -45,13 +45,20 @@ artifacts into `~/.bomclaw/` and restart.
    ln -sf ~/.bomclaw/bomclaw ~/.local/bin/bomclaw
    ```
 
-4. **Stop** the gateway and kill stale processes (orphaned `claude --resume`
-   subprocesses hold Telegram's getUpdates poll and cause Conflict errors):
+4. **Stop** the gateway and kill stale processes (orphaned `claude -p --resume`
+   subprocesses hold Telegram's getUpdates poll and cause Conflict errors).
+
+   The pattern MUST be `claude -p .*--resume`, not `claude.*--resume`. The
+   broad one also matches your own interactive Claude Code sessions — which
+   resume too — and has killed one mid-deploy. The gateway always spawns with
+   `-p` immediately after the binary (`internal/claude/client.go` `buildArgs`),
+   and interactive Claude Code never does, so `-p` is what separates them.
+   Check before you kill: `pgrep -lf "claude -p .*--resume"`.
    ```bash
    launchctl stop com.bomclaw.gateway
    sleep 1
    pkill -f "bomclaw gateway" 2>/dev/null || true
-   pkill -f "claude.*--resume" 2>/dev/null || true
+   pkill -f "claude -p .*--resume" 2>/dev/null || true
    sleep 1
    ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@
 When restarting the gateway service, stale Claude CLI subprocesses (spawned by previous bot sessions) can hold Telegram's `getUpdates` polling connection. This causes `"Conflict: terminated by other getUpdates request"` errors and the bot stops receiving messages.
 
 **Fix checklist before restart:**
-1. Kill any orphaned claude subprocesses: `pgrep -lf "claude.*--resume" | grep -v grep` then `kill <pid>`
+1. Kill any orphaned claude subprocesses: `pgrep -lf "claude -p .*--resume"` then `kill <pid>`
+
+   Match on `claude -p .*--resume`, never `claude.*--resume`. The broad pattern
+   also matches your own interactive Claude Code sessions, which resume too,
+   and has killed one during a deploy. The gateway spawns the CLI with `-p`
+   right after the binary (see `buildArgs` in `internal/claude/client.go`);
+   interactive Claude Code does not, and that is the only reliable difference.
 2. Clear Telegram state: `curl "https://api.telegram.org/bot${TOKEN}/deleteWebhook?drop_pending_updates=true"`
 3. Then restart: `./bomclaw gateway restart`
 

--- a/internal/claude/args_test.go
+++ b/internal/claude/args_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -32,12 +33,42 @@ func TestBuildArgsIsolationSurvivesResume(t *testing.T) {
 	if !slices.Contains(resumed, "--resume") {
 		t.Error("--resume missing on a resumed turn")
 	}
-	if slices.Contains(resumed, "--append-system-prompt") {
-		t.Error("resumed turns must not re-send the system prompt (the CLI already has it)")
+}
+
+// The system prompt must go on EVERY turn. --append-system-prompt applies to
+// the invocation, not the stored session: a session created with it and then
+// resumed without it stops following the prompt entirely (measured against the
+// CLI). Sending it only on the first message gave the agent its operating
+// instructions for exactly one message per session.
+func TestBuildArgsResendsSystemPromptOnResume(t *testing.T) {
+	resumed := buildArgs("m", "sess-1", false, "you are a test")
+
+	i := slices.Index(resumed, "--append-system-prompt")
+	if i < 0 {
+		t.Fatal("a resumed turn must carry the system prompt — the CLI does not remember it")
+	}
+	if resumed[i+1] != "you are a test" {
+		t.Errorf("resumed prompt = %q, want the system prompt", resumed[i+1])
+	}
+	if !slices.Contains(resumed, "--resume") {
+		t.Error("--resume missing")
+	}
+	// Once, not twice: a stacked flag would double the prefix every turn.
+	if n := strings.Count(strings.Join(resumed, " "), "--append-system-prompt"); n != 1 {
+		t.Errorf("--append-system-prompt appears %d times, want exactly 1", n)
 	}
 }
 
-func TestBuildArgsSystemPromptOnFirstTurnOnly(t *testing.T) {
+func TestBuildArgsOmitsEmptySystemPrompt(t *testing.T) {
+	for _, isNew := range []bool{true, false} {
+		args := buildArgs("m", "s", isNew, "")
+		if slices.Contains(args, "--append-system-prompt") {
+			t.Errorf("isNew=%v: an empty prompt must not be passed as a flag", isNew)
+		}
+	}
+}
+
+func TestBuildArgsFirstTurnCarriesPromptAndDoesNotResume(t *testing.T) {
 	first := buildArgs("m", "s", true, "you are a test")
 	i := slices.Index(first, "--append-system-prompt")
 	if i < 0 || first[i+1] != "you are a test" {

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -291,8 +291,23 @@ func buildArgs(model, sessionID string, isNew bool, systemPrompt string) []strin
 
 	if !isNew {
 		args = append(args, "--resume", sessionID)
-	} else if systemPrompt != "" {
-		// --append-system-prompt on first message only (openclaw pattern).
+	}
+
+	// Every turn, resumed ones included. --append-system-prompt applies to the
+	// invocation, not to the stored session: measured against the CLI, a
+	// session created with an appended prompt and then resumed WITHOUT the flag
+	// no longer follows it at all. Sending it only on the first message meant
+	// the agent had its operating instructions — workspace rules, the
+	// coordination commands, the browser guide — for exactly one message per
+	// session and ran bare from the second onwards.
+	//
+	// It does not accumulate: passing it again replaces the invocation's
+	// appended prompt rather than stacking, and the prefix is cached, so the
+	// repeat costs a cache read.
+	//
+	// (The codex path needs no equivalent: it folds the instructions into the
+	// opening message, so they live in the thread history and survive resume.)
+	if systemPrompt != "" {
 		args = append(args, "--append-system-prompt", systemPrompt)
 	}
 


### PR DESCRIPTION
Two follow-ups, both bigger than they looked.

## 1. The agent ran without its system prompt from message 2 onwards

`--append-system-prompt` was passed only when *starting* a session, on the assumption that a resumed session carries it. **Measured against the CLI, it does not:**

| Turn | Args | Reply |
|---|---|---|
| 1 | `--append-system-prompt "…end every reply with ZEBRA"` | …**ZEBRA** |
| 2 | `--resume <id>` (no flag) | *no ZEBRA* |
| 3 | `--resume <id> --append-system-prompt "…GIRAFFE"` | …**GIRAFFE** |

The flag applies to the **invocation**, not the stored session.

So the agent had its operating instructions — workspace rules, screenshot rules, the `bomclaw task/note/msg` coordination commands, and lately the browser guide — for **exactly one message per session**, and ran bare after that.

It also explains the symptom that started this thread: a freshly deployed capability appeared not to exist until `/new`, because nothing was ever re-sent.

Turn 3 also settles the two things that made this look risky: the flag **works** with `--resume`, and it **replaces** rather than stacks. The prefix is cached, so the repeat is a cache read — measured at ~660 extra cached tokens on a turn, against an agent that actually follows its instructions.

Memory injection is untouched: it stays first-turn-only, which was a separate and correct decision (re-injecting it every turn would pollute the context, as the existing comment says).

**The codex path needs no equivalent** — it folds the instructions into the opening message, so they live in the thread history and survive `resume`. Worth knowing the two providers differ here.

## 2. The documented restart pattern killed interactive Claude Code sessions

`pkill -f "claude.*--resume"` matches *any* resumed claude — and the operator's own sessions resume too. It killed one mid-deploy earlier today (PIDs 19691/19952).

The gateway spawns with `-p` immediately after the binary (`buildArgs`); interactive Claude Code never does. That is the only reliable difference. Proven with two synthetic processes of each shape:

```
claude.*--resume       → 2 matches:  the gateway's AND the operator's
claude -p .*--resume   → 1 match:    the gateway's
```

Both `CLAUDE.md` and `.claude/commands/deploy.md` now carry the narrow pattern, **why** it has to be narrow, and a `pgrep` to check before killing.

## Tests

A test asserted the old first-turn-only behaviour — it encoded the wrong assumption, so it is replaced. The new one fails if a resumed turn loses the prompt **or** passes it twice (a stacked flag would double the prefix every turn).

```
--- PASS: TestBuildArgsResendsSystemPromptOnResume
--- PASS: TestBuildArgsOmitsEmptySystemPrompt
--- PASS: TestBuildArgsFirstTurnCarriesPromptAndDoesNotResume
--- PASS: TestBuildArgsIsolatesSkillsAndMCP
--- PASS: TestBuildArgsIsolationSurvivesResume
```

`go build ./... && go test ./...` green.

## After this

`/new` is no longer required to pick up a newly deployed capability — existing sessions get the current system prompt on their next message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)