### PR TITLE
feat(tray): watch every agent, and make Restart work at all

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -365,6 +365,8 @@ func runGateway(args []string) {
 		Uptime:        func() time.Duration { return time.Since(startTime) },
 		Coord:         coordDB,
 		AgentID:       cfg.Agent.ID,
+		AgentName:     cfg.Agent.Name,
+		Workspace:     cfg.Claude.Workspace,
 		ProviderName:  cfg.Provider,
 		Trace:         gwTrace,
 		PokeTasks:     runner.Poke,

--- a/cmd/bomtray/install_darwin.go
+++ b/cmd/bomtray/install_darwin.go
@@ -8,7 +8,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
+
+// xmlEscape keeps a path or URL safe inside the plist.
+func xmlEscape(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+	return r.Replace(s)
+}
 
 const trayAgentLabel = "com.bomclaw.tray"
 
@@ -20,8 +27,7 @@ const trayPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 	<string>%s</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>%s</string>
-	</array>
+%s	</array>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
@@ -52,7 +58,19 @@ func runInstall() {
 	logPath := filepath.Join(home, ".goterm/logs/tray.err.log")
 	_ = os.MkdirAll(filepath.Dir(logPath), 0755)
 
-	plist := fmt.Sprintf(trayPlistTemplate, trayAgentLabel, binPath, logPath)
+	// Spell the agent list out in the plist rather than relying on the
+	// binary's defaults: the defaults can change, and a plist that says what
+	// it watches is one you can read when the menu shows the wrong thing.
+	args := []string{binPath}
+	for _, u := range defaultAgents {
+		args = append(args, "-agent", u)
+	}
+	var argXML strings.Builder
+	for _, a := range args {
+		fmt.Fprintf(&argXML, "\t\t<string>%s</string>\n", xmlEscape(a))
+	}
+
+	plist := fmt.Sprintf(trayPlistTemplate, trayAgentLabel, argXML.String(), logPath)
 	path := trayPlistPath()
 	if err := os.WriteFile(path, []byte(plist), 0644); err != nil {
 		log.Fatalf("bomtray: write plist: %v", err)

--- a/cmd/bomtray/main.go
+++ b/cmd/bomtray/main.go
@@ -1,12 +1,17 @@
 //go:build darwin
 
-// bomtray is a macOS menu bar companion for the bomclaw gateway.
-// It polls the gateway's /api/status endpoint, shows live agent state in the
-// menu bar, exposes quick actions, and can keep the Mac awake while the
-// agent is running (IOKit power assertion, kwota pattern).
+// bomtray is a macOS menu bar companion for the bomclaw gateways.
+// It polls each gateway's /api/status endpoint, shows live agent state in the
+// menu bar, exposes quick actions, and can keep the Mac awake while an agent
+// is running (IOKit power assertion, kwota pattern).
 //
-// It is a separate binary on purpose: when the gateway dies, the tray icon
+// It is a separate binary on purpose: when a gateway dies, the tray icon
 // survives and turns red instead of vanishing.
+//
+// A machine normally runs more than one gateway (agent 1 on :18789, agent 2 on
+// :18790), so the tray polls a list. An address that never answers is hidden
+// rather than shown as down: someone running a single agent should see exactly
+// one agent in the menu, not one plus a permanent error.
 package main
 
 import (
@@ -18,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"fyne.io/systray"
@@ -29,34 +35,91 @@ type awakeMode string
 
 const (
 	awakeOff    awakeMode = "off"
-	awakeAuto   awakeMode = "auto" // hold only while the agent is running
+	awakeAuto   awakeMode = "auto" // hold only while an agent is running
 	awakeAlways awakeMode = "always"
 )
 
+// defaultAgents is the standard local layout. Both are probed; whichever
+// answers is shown.
+var defaultAgents = []string{"http://127.0.0.1:18789", "http://127.0.0.1:18790"}
+
+// agent is one gateway the tray watches, plus the menu rows that render it.
+type agent struct {
+	url string
+
+	// Menu rows. Created once at startup — systray cannot grow a menu later —
+	// and hidden until the gateway first answers.
+	head    *systray.MenuItem // 🟢 name · uptime · model · sessions
+	run     *systray.MenuItem // ⚡ current task, or 💤 Idle
+	browser *systray.MenuItem // 🌐 the paired browser, or nothing paired
+
+	mu        sync.Mutex
+	st        *gateway.StatusResult
+	up        bool
+	seen      bool // has this address EVER answered? unseen agents stay hidden
+	upKnown   bool
+	wasUp     bool
+	wasRun    bool
+	prevTask  string
+	workspace string
+}
+
+// name is what to call this agent in menus and notifications.
+func (ag *agent) name() string {
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	if ag.st != nil {
+		if ag.st.AgentName != "" {
+			return ag.st.AgentName
+		}
+		if ag.st.AgentID != "" {
+			return ag.st.AgentID
+		}
+	}
+	return shortURL(ag.url)
+}
+
+// launchdLabel derives the gateway's service label from its agent id, which is
+// how the installer names it (com.<id>.gateway). Previously the tray had a
+// single hardcoded default that did not match any installed service, so
+// "Restart Gateway" silently did nothing.
+func (ag *agent) launchdLabel(override string) string {
+	if override != "" {
+		return override
+	}
+	ag.mu.Lock()
+	id := ""
+	if ag.st != nil {
+		id = ag.st.AgentID
+	}
+	ag.mu.Unlock()
+	if id == "" {
+		return ""
+	}
+	return "com." + id + ".gateway"
+}
+
 type app struct {
-	url          string
-	workspace    string
-	gatewayLabel string
-	logPath      string
-	interval     time.Duration
+	agents   []*agent
+	logPath  string
+	label    string // optional override for every agent's launchd label
+	interval time.Duration
 
 	mem   *memory.Manager
 	awake *awake
 	mode  awakeMode
 
-	statusItem *systray.MenuItem
-	runItem    *systray.MenuItem
 	memItem    *systray.MenuItem
 	modeOff    *systray.MenuItem
 	modeAuto   *systray.MenuItem
 	modeAlways *systray.MenuItem
-
-	// previous poll state, for transition notifications
-	upKnown    bool
-	wasUp      bool
-	prevTask   string
-	prevRunning bool
 }
+
+// urlList collects a repeatable flag.
+type urlList []string
+
+func (u *urlList) String() string     { return strings.Join(*u, ",") }
+func (u *urlList) Set(v string) error { *u = append(*u, strings.TrimRight(v, "/")); return nil }
 
 func main() {
 	if len(os.Args) > 1 {
@@ -71,25 +134,31 @@ func main() {
 	}
 
 	home, _ := os.UserHomeDir()
-	url := flag.String("url", "http://127.0.0.1:18789", "Gateway base URL")
-	workspace := flag.String("workspace", filepath.Join(home, "goterm-workspace"), "Agent workspace (memory files)")
-	label := flag.String("gateway-label", "com.nanoclaw.gateway", "launchd label of the gateway service")
+	var urls urlList
+	flag.Var(&urls, "agent", "Gateway base URL; repeat for each agent (default: :18789 and :18790)")
+	workspace := flag.String("workspace", filepath.Join(home, "goterm-workspace"), "Fallback workspace for memory stats when a gateway does not report one")
+	label := flag.String("gateway-label", "", "Override the launchd label (default: com.<agent-id>.gateway, from the gateway itself)")
 	logPath := flag.String("log", filepath.Join(home, ".goterm/logs/gateway.err.log"), "Gateway log file for Tail Logs")
 	interval := flag.Int("interval", 3, "Poll interval in seconds")
 	flag.Parse()
 
+	if len(urls) == 0 {
+		urls = defaultAgents
+	}
+
 	a := &app{
-		url:          strings.TrimRight(*url, "/"),
-		workspace:    *workspace,
-		gatewayLabel: *label,
-		logPath:      *logPath,
-		interval:     time.Duration(*interval) * time.Second,
-		awake:        &awake{},
-		mode:         loadAwakeMode(),
+		logPath:  *logPath,
+		label:    *label,
+		interval: time.Duration(*interval) * time.Second,
+		awake:    &awake{},
+		mode:     loadAwakeMode(),
 		mem: memory.NewManager(memory.Config{
 			Enabled: true,
 			Dir:     *workspace,
 		}),
+	}
+	for _, u := range urls {
+		a.agents = append(a.agents, &agent{url: u})
 	}
 
 	systray.Run(a.onReady, a.onExit)
@@ -97,12 +166,22 @@ func main() {
 
 func (a *app) onReady() {
 	systray.SetTitle("🤖")
-	systray.SetTooltip("bomclaw gateway")
+	systray.SetTooltip("bomclaw gateways")
 
-	a.statusItem = systray.AddMenuItem("⏳ Connecting...", "")
-	a.statusItem.Disable()
-	a.runItem = systray.AddMenuItem("💤 Idle", "")
-	a.runItem.Disable()
+	// One block of rows per agent. Hidden until that gateway answers, so a
+	// single-agent machine shows a single-agent menu.
+	for _, ag := range a.agents {
+		ag.head = systray.AddMenuItem("⏳ "+shortURL(ag.url), "Open this agent's dashboard")
+		ag.run = systray.AddMenuItem("", "")
+		ag.run.Disable()
+		ag.browser = systray.AddMenuItem("", "")
+		ag.browser.Disable()
+		ag.head.Hide()
+		ag.run.Hide()
+		ag.browser.Hide()
+	}
+
+	systray.AddSeparator()
 	a.memItem = systray.AddMenuItem("💾 Memory: ...", "Open MEMORY.md")
 
 	systray.AddSeparator()
@@ -112,34 +191,56 @@ func (a *app) onReady() {
 	a.modeAlways = awakeMenu.AddSubMenuItemCheckbox("Always", "", a.mode == awakeAlways)
 
 	systray.AddSeparator()
-	openDash := systray.AddMenuItem("Open Dashboard", "")
 	openWs := systray.AddMenuItem("Open Workspace", "")
 	tailLogs := systray.AddMenuItem("Tail Logs", "Open Terminal tailing the gateway log")
-	restart := systray.AddMenuItem("Restart Gateway", "launchctl kickstart -k")
+
+	// Restart is per agent: restarting the wrong one of two gateways is a
+	// confusing way to lose a conversation.
+	restartMenu := systray.AddMenuItem("Restart Gateway", "")
+	restartItems := make([]*systray.MenuItem, len(a.agents))
+	for i, ag := range a.agents {
+		restartItems[i] = restartMenu.AddSubMenuItem(shortURL(ag.url), "launchctl kickstart -k")
+	}
 
 	systray.AddSeparator()
 	quit := systray.AddMenuItem("Quit bomtray", "")
 
-	// Click handler loop
+	// Click handlers. Each agent's header opens its own dashboard.
+	for _, ag := range a.agents {
+		go func(ag *agent) {
+			for range ag.head.ClickedCh {
+				openPath(ag.url)
+			}
+		}(ag)
+	}
+	for i, ag := range a.agents {
+		go func(i int, ag *agent) {
+			for range restartItems[i].ClickedCh {
+				lbl := ag.launchdLabel(a.label)
+				if lbl == "" {
+					notify("Bomclaw", "Cannot restart "+ag.name()+": its launchd label is unknown")
+					continue
+				}
+				restartGateway(lbl)
+			}
+		}(i, ag)
+	}
+
 	go func() {
 		for {
 			select {
 			case <-a.memItem.ClickedCh:
-				openPath(filepath.Join(a.workspace, "MEMORY.md"))
+				openPath(filepath.Join(a.memDir(), "MEMORY.md"))
 			case <-a.modeOff.ClickedCh:
 				a.setMode(awakeOff)
 			case <-a.modeAuto.ClickedCh:
 				a.setMode(awakeAuto)
 			case <-a.modeAlways.ClickedCh:
 				a.setMode(awakeAlways)
-			case <-openDash.ClickedCh:
-				openPath(a.url)
 			case <-openWs.ClickedCh:
-				openPath(a.workspace)
+				openPath(a.memDir())
 			case <-tailLogs.ClickedCh:
 				openTerminalTail(a.logPath)
-			case <-restart.ClickedCh:
-				restartGateway(a.gatewayLabel)
 			case <-quit.ClickedCh:
 				systray.Quit()
 				return
@@ -147,7 +248,6 @@ func (a *app) onReady() {
 		}
 	}()
 
-	// Poll loop
 	go func() {
 		a.poll()
 		ticker := time.NewTicker(a.interval)
@@ -162,33 +262,52 @@ func (a *app) onExit() {
 	a.awake.Release()
 }
 
-// poll fetches gateway status and updates the menu, awake assertion, and
-// transition notifications.
-func (a *app) poll() {
-	st, err := fetchStatus(a.url)
-	up := err == nil
-	running := up && len(st.Runs) > 0
+// memDir is the workspace memory stats are read from: the first agent that
+// reports one, else the -workspace flag.
+func (a *app) memDir() string {
+	for _, ag := range a.agents {
+		ag.mu.Lock()
+		ws := ag.workspace
+		ag.mu.Unlock()
+		if ws != "" {
+			return ws
+		}
+	}
+	return a.mem.Dir()
+}
 
-	// --- transition notifications ---
-	if a.upKnown && up != a.wasUp {
-		if up {
-			notify("Bomclaw", "Gateway is back up ✅")
-		} else {
-			notify("Bomclaw", "Gateway is DOWN ⛔")
-		}
+// poll refreshes every agent in parallel, then updates the menu, the awake
+// assertion and any transition notifications.
+func (a *app) poll() {
+	var wg sync.WaitGroup
+	for _, ag := range a.agents {
+		wg.Add(1)
+		go func(ag *agent) {
+			defer wg.Done()
+			st, err := fetchStatus(ag.url)
+			ag.mu.Lock()
+			ag.st, ag.up = st, err == nil
+			if err == nil {
+				ag.seen = true
+				if st.Workspace != "" {
+					ag.workspace = st.Workspace
+				}
+			}
+			ag.mu.Unlock()
+		}(ag)
 	}
-	if a.prevRunning && !running && up {
-		task := a.prevTask
-		if task == "" {
-			task = "agent task"
+	wg.Wait()
+
+	anyRunning := false
+	anyDown := false
+	for _, ag := range a.agents {
+		running := a.renderAgent(ag)
+		anyRunning = anyRunning || running
+		ag.mu.Lock()
+		if ag.seen && !ag.up {
+			anyDown = true
 		}
-		notify("Bomclaw", "✅ Done: "+task)
-	}
-	a.upKnown = true
-	a.wasUp = up
-	a.prevRunning = running
-	if running {
-		a.prevTask = st.Runs[0].Task
+		ag.mu.Unlock()
 	}
 
 	// --- awake assertion ---
@@ -196,7 +315,7 @@ func (a *app) poll() {
 	case awakeAlways:
 		a.holdAwake()
 	case awakeAuto:
-		if running {
+		if anyRunning {
 			a.holdAwake()
 		} else {
 			a.awake.Release()
@@ -208,9 +327,9 @@ func (a *app) poll() {
 	// --- menu bar title ---
 	title := "🤖"
 	switch {
-	case !up:
+	case anyDown:
 		title = "🤖⛔"
-	case running:
+	case anyRunning:
 		title = "🤖⚡"
 	}
 	if a.awake.Held() {
@@ -218,27 +337,100 @@ func (a *app) poll() {
 	}
 	systray.SetTitle(title)
 
-	// --- menu items ---
-	if up {
-		a.statusItem.SetTitle(fmt.Sprintf("🟢 Gateway up · %s · %s", st.Uptime, st.DefaultModel))
-	} else {
-		a.statusItem.SetTitle("🔴 Gateway down")
-	}
-
-	if running {
-		r := st.Runs[0]
-		line := fmt.Sprintf("⚡ %s · %d tools", truncate(r.Task, 40), r.ToolCount)
-		if r.LastTool != "" {
-			line += " · " + truncate(r.LastTool, 20)
-		}
-		a.runItem.SetTitle(line)
-	} else {
-		a.runItem.SetTitle("💤 Idle")
-	}
-
-	if stats, err := a.mem.Stats(time.Now()); err == nil {
+	if stats, err := a.mem.StatsIn(a.memDir(), time.Now()); err == nil {
 		a.memItem.SetTitle(fmt.Sprintf("💾 Memory: %s · %d notes", humanBytes(stats.MemoryMDBytes), stats.DailyNoteCount))
 	}
+}
+
+// renderAgent updates one agent's rows and fires its transition
+// notifications. Returns whether it is running.
+func (ag *agent) snapshot() (*gateway.StatusResult, bool, bool) {
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	return ag.st, ag.up, ag.seen
+}
+
+func (a *app) renderAgent(ag *agent) bool {
+	st, up, seen := ag.snapshot()
+	if !seen {
+		return false // never answered: stay hidden
+	}
+	ag.head.Show()
+	ag.run.Show()
+
+	running := up && st != nil && len(st.Runs) > 0
+	name := ag.name()
+
+	// --- transitions, named so two agents are distinguishable ---
+	if ag.upKnown && up != ag.wasUp {
+		if up {
+			notify("Bomclaw", name+" is back up ✅")
+		} else {
+			notify("Bomclaw", name+" is DOWN ⛔")
+		}
+	}
+	if ag.wasRun && !running && up {
+		task := ag.prevTask
+		if task == "" {
+			task = "agent task"
+		}
+		notify("Bomclaw", "✅ "+name+": "+task)
+	}
+	ag.upKnown = true
+	ag.wasUp = up
+	ag.wasRun = running
+	if running {
+		ag.prevTask = st.Runs[0].Task
+	}
+
+	// --- header ---
+	if !up {
+		ag.head.SetTitle("🔴 " + name + " · down")
+	} else {
+		head := fmt.Sprintf("🟢 %s · %s · %s", name, st.Uptime, shortModel(st.DefaultModel))
+		if st.ActiveSessions > 0 {
+			head += fmt.Sprintf(" · %d sess", st.ActiveSessions)
+		}
+		ag.head.SetTitle(head)
+	}
+
+	// --- current run ---
+	if running {
+		r := st.Runs[0]
+		line := fmt.Sprintf("   ⚡ %s · %d tools", truncate(r.Task, 34), r.ToolCount)
+		if r.LastTool != "" {
+			line += " · " + truncate(r.LastTool, 18)
+		}
+		ag.run.SetTitle(line)
+	} else if up {
+		ag.run.SetTitle("   💤 Idle")
+	} else {
+		ag.run.SetTitle("   —")
+	}
+
+	// --- browser bridge ---
+	// Only shown when the gateway reports the bridge at all, so a build with
+	// it disabled does not grow a permanently blank row.
+	if up && st.Browser != nil {
+		ag.browser.Show()
+		b := st.Browser
+		if b.Connected {
+			line := "   🌐 " + orFirst(b.BrowserName, b.Browser, "browser")
+			if b.Actions > 0 {
+				line += fmt.Sprintf(" · %d actions", b.Actions)
+			}
+			if b.LastAction != "" {
+				line += " · " + b.LastAction
+			}
+			ag.browser.SetTitle(line)
+		} else {
+			ag.browser.SetTitle("   🌐 no browser paired")
+		}
+	} else {
+		ag.browser.Hide()
+	}
+
+	return running
 }
 
 func (a *app) holdAwake() {
@@ -256,18 +448,18 @@ func (a *app) setMode(m awakeMode) {
 	switch m {
 	case awakeOff:
 		a.modeOff.Check()
+		a.awake.Release()
 	case awakeAuto:
 		a.modeAuto.Check()
 	case awakeAlways:
 		a.modeAlways.Check()
+		a.holdAwake()
 	}
 	saveAwakeMode(m)
-	a.poll() // apply immediately
 }
 
-// fetchStatus GETs /api/status with a short timeout.
 func fetchStatus(baseURL string) (*gateway.StatusResult, error) {
-	client := &http.Client{Timeout: 2500 * time.Millisecond}
+	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(baseURL + "/api/status")
 	if err != nil {
 		return nil, err
@@ -283,27 +475,27 @@ func fetchStatus(baseURL string) (*gateway.StatusResult, error) {
 	return &st, nil
 }
 
-// --- awake mode persistence (~/.goterm/tray.json) ---
-
 func trayStatePath() string {
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".goterm", "tray.json")
+	return filepath.Join(home, ".goterm", "tray-state.json")
 }
 
 func loadAwakeMode() awakeMode {
-	data, err := os.ReadFile(trayStatePath())
+	b, err := os.ReadFile(trayStatePath())
 	if err != nil {
 		return awakeOff
 	}
 	var s struct {
-		AwakeMode string `json:"awake_mode"`
+		Awake string `json:"awake"`
 	}
-	if json.Unmarshal(data, &s) != nil {
+	if err := json.Unmarshal(b, &s); err != nil {
 		return awakeOff
 	}
-	switch awakeMode(s.AwakeMode) {
-	case awakeAuto, awakeAlways:
-		return awakeMode(s.AwakeMode)
+	switch awakeMode(s.Awake) {
+	case awakeAuto:
+		return awakeAuto
+	case awakeAlways:
+		return awakeAlways
 	}
 	return awakeOff
 }
@@ -311,18 +503,44 @@ func loadAwakeMode() awakeMode {
 func saveAwakeMode(m awakeMode) {
 	path := trayStatePath()
 	_ = os.MkdirAll(filepath.Dir(path), 0755)
-	data, _ := json.Marshal(map[string]string{"awake_mode": string(m)})
-	_ = os.WriteFile(path, data, 0644)
+	b, _ := json.Marshal(map[string]string{"awake": string(m)})
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		log.Printf("bomtray: save state: %v", err)
+	}
 }
 
-// --- helpers ---
-
 func truncate(s string, max int) string {
-	r := []rune(strings.TrimSpace(s))
-	if len(r) > max {
-		return string(r[:max]) + "…"
+	r := []rune(s)
+	if len(r) <= max {
+		return s
 	}
-	return s
+	return string(r[:max-1]) + "…"
+}
+
+// shortModel drops the vendor prefix so the header stays readable:
+// "claude-opus-5" → "opus-5".
+func shortModel(id string) string {
+	for _, p := range []string{"claude-", "openai-"} {
+		if strings.HasPrefix(id, p) {
+			return strings.TrimPrefix(id, p)
+		}
+	}
+	return id
+}
+
+// shortURL is the host:port, used before a gateway has told us its name.
+func shortURL(u string) string {
+	s := strings.TrimPrefix(strings.TrimPrefix(u, "http://"), "https://")
+	return strings.TrimSuffix(s, "/")
+}
+
+func orFirst(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func humanBytes(n int64) string {

--- a/cmd/bomtray/main_darwin_test.go
+++ b/cmd/bomtray/main_darwin_test.go
@@ -1,0 +1,102 @@
+//go:build darwin
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/gateway"
+)
+
+// The tray used to carry a single hardcoded launchd label that matched no
+// installed service, so "Restart Gateway" silently did nothing. The label now
+// comes from the agent id the gateway reports.
+func TestAgentLaunchdLabel(t *testing.T) {
+	cases := []struct {
+		name     string
+		id       string
+		override string
+		want     string
+	}{
+		{"derived from the agent id", "bomclaw", "", "com.bomclaw.gateway"},
+		{"second agent gets its own label", "bomclaw2", "", "com.bomclaw2.gateway"},
+		{"an explicit override wins", "bomclaw", "com.custom.gateway", "com.custom.gateway"},
+		// Empty rather than a guess: restarting the wrong service is worse
+		// than telling the user the label is unknown.
+		{"unknown id yields no label", "", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ag := &agent{url: "http://127.0.0.1:18789"}
+			if c.id != "" {
+				ag.st = &gateway.StatusResult{AgentID: c.id}
+			}
+			if got := ag.launchdLabel(c.override); got != c.want {
+				t.Errorf("launchdLabel = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// With two agents in one menu, every row has to say which agent it is.
+func TestAgentName(t *testing.T) {
+	ag := &agent{url: "http://127.0.0.1:18790"}
+	if got := ag.name(); got != "127.0.0.1:18790" {
+		t.Errorf("before the gateway answers, fall back to host:port; got %q", got)
+	}
+
+	ag.st = &gateway.StatusResult{AgentID: "bomclaw2"}
+	if got := ag.name(); got != "bomclaw2" {
+		t.Errorf("id is used when there is no display name; got %q", got)
+	}
+
+	ag.st.AgentName = "BomClaw (agent 2)"
+	if got := ag.name(); got != "BomClaw (agent 2)" {
+		t.Errorf("display name wins; got %q", got)
+	}
+}
+
+func TestShortModel(t *testing.T) {
+	cases := map[string]string{
+		"claude-opus-5": "opus-5",
+		"gpt-6-astra":   "gpt-6-astra",
+		"":              "",
+	}
+	for in, want := range cases {
+		if got := shortModel(in); got != want {
+			t.Errorf("shortModel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTruncateIsRuneSafe(t *testing.T) {
+	// Vietnamese task labels are common here; byte slicing would split them.
+	got := truncate("Đánh giá đất đầu tư Hòa Hiệp Nam", 10)
+	if []rune(got)[len([]rune(got))-1] != '…' {
+		t.Errorf("expected an ellipsis, got %q", got)
+	}
+	if n := len([]rune(got)); n != 10 {
+		t.Errorf("expected 10 runes, got %d (%q)", n, got)
+	}
+	if truncate("short", 10) != "short" {
+		t.Error("a short string must be returned unchanged")
+	}
+}
+
+func TestShortURL(t *testing.T) {
+	for in, want := range map[string]string{
+		"http://127.0.0.1:18789":  "127.0.0.1:18789",
+		"https://example.com/":    "example.com",
+		"http://127.0.0.1:18790/": "127.0.0.1:18790",
+	} {
+		if got := shortURL(in); got != want {
+			t.Errorf("shortURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestXMLEscape(t *testing.T) {
+	if got := xmlEscape(`a&b<c>"d"`); got != "a&amp;b&lt;c&gt;&quot;d&quot;" {
+		t.Errorf("xmlEscape = %q", got)
+	}
+}

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -41,6 +41,8 @@ type Deps struct {
 	// then reports that rather than failing obscurely.
 	Coord        *coord.DB
 	AgentID      string
+	AgentName    string          // display name, for the menu bar and dashboard
+	Workspace    string          // this agent's workspace directory
 	ProviderName string          // "claude" | "codex", for trace metadata
 	Trace        *trace.Recorder // nil-safe: nil disables tracing on this path
 
@@ -187,6 +189,9 @@ func handleStatus(deps Deps) (json.RawMessage, error) {
 	sessions := deps.Sessions.List()
 	result := StatusResult{
 		Running:        true,
+		AgentID:        deps.AgentID,
+		AgentName:      deps.AgentName,
+		Workspace:      deps.Workspace,
 		Uptime:         deps.Uptime().Round(time.Second).String(),
 		DefaultModel:   deps.Resolver.Default(),
 		ActiveSessions: len(sessions),

--- a/internal/gateway/protocol.go
+++ b/internal/gateway/protocol.go
@@ -44,7 +44,15 @@ type SendParams struct {
 
 // StatusResult is returned by the "status" method.
 type StatusResult struct {
-	Running        bool                  `json:"running"`
+	Running bool `json:"running"`
+
+	// Who this gateway is. A machine runs several, and every consumer — the
+	// menu bar, the dashboard, a peer — otherwise has to infer identity from
+	// the port it happened to dial.
+	AgentID   string `json:"agent_id,omitempty"`
+	AgentName string `json:"agent_name,omitempty"`
+	Workspace string `json:"workspace,omitempty"` // where this agent's files live
+
 	Uptime         string                `json:"uptime"`
 	DefaultModel   string                `json:"default_model"`
 	ActiveSessions int                   `json:"active_sessions"`

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -167,6 +167,21 @@ type Stats struct {
 const previewChars = 600
 
 // Stats returns a summary of the memory files on disk.
+// Dir returns the memory root this manager was configured with.
+func (m *Manager) Dir() string { return m.cfg.Dir }
+
+// StatsIn reports stats for an arbitrary memory directory. The menu bar needs
+// this: it watches several agents, each with its own workspace, and learns
+// which directory to read only once a gateway answers — too late to have been
+// baked into the manager at startup.
+func (m *Manager) StatsIn(dir string, now time.Time) (Stats, error) {
+	if dir == "" || dir == m.cfg.Dir {
+		return m.Stats(now)
+	}
+	scoped := &Manager{cfg: Config{Enabled: true, Dir: dir}, loc: m.loc}
+	return scoped.Stats(now)
+}
+
 func (m *Manager) Stats(now time.Time) (Stats, error) {
 	st := Stats{Dir: m.cfg.Dir}
 	if !m.Enabled() {


### PR DESCRIPTION
The menu bar was written when there was one gateway. There are two — and it showed one. Agent 2 was invisible from the menu bar entirely: uptime, current task, browser, all of it.

## Restart Gateway had never worked

The tray's default launchd label was `com.nanoclaw.gateway`. The installed services are `com.bomclaw.gateway` and `com.bomclaw2.gateway` — and the tray's own plist passes **no arguments**, so the wrong default was always the one in effect.

```
tray default:      com.nanoclaw.gateway
launchctl list:    com.bomclaw.gateway
                   com.bomclaw2.gateway
```

`launchctl kickstart` on a nonexistent label fails quietly, so the menu item looked like it worked.

The label is now derived per agent from the id the gateway reports. When the id is unknown the tray **says so** rather than guessing — restarting the wrong one of two gateways is a confusing way to lose a conversation.

## A block of rows per agent

Hidden until that address answers, so a single-agent machine still sees a single-agent menu.

```
🟢 BomClaw (agent 1) · 1h38m · opus-5 · 3 sess
   ⚡ Đánh giá đất đầu tư · 12 tools · Bash
   🌐 Chrome 149 on macOS · 24 actions · snapshot
🟢 BomClaw (agent 2) · 1h38m · gpt-6-astra
   💤 Idle
   🌐 no browser paired
```

Compared with before:

| | Before | After |
|---|---|---|
| Agents shown | 1 | all that answer |
| Session count | — | ✅ (was already in the payload) |
| Browser bridge | — | ✅ (was already in the payload) |
| Model name | `claude-opus-5` | `opus-5` |
| Open Dashboard | one, fixed | click any agent's header |
| Restart | one, **broken** | submenu, per agent, working |
| Notifications | "Gateway is DOWN" | "BomClaw (agent 2) is DOWN" |

Session count and browser status were **already in the status payload and simply not displayed** — the same dead-payload problem the dashboard Status tab had.

## Supporting changes

The gateway now reports **who it is**: `agent_id`, `agent_name`, `workspace`. Every consumer previously had to infer identity from the port it happened to dial.

The tray reads memory stats from the workspace the gateway reports rather than a flag fixed at startup — hence `memory.Manager.StatsIn`.

The installer spells the agent list out in the plist instead of relying on the binary's defaults: defaults change, and a plist that says what it watches is one you can read when the menu shows the wrong thing.

## Tests

`cmd/bomtray` had none. Now covers the label derivation (including the "don't guess" case), agent naming fallback chain, model shortening, rune-safe truncation (Vietnamese task labels would be split by byte slicing), and XML escaping for the plist.

`go build ./... && go test ./...` green.

## Deploying

Gateway binary + tray binary, then `bomtray install` to rewrite the plist with the agent list, then restart the tray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)