### PR TITLE
feat(accounts): rotate sessions across a pool of logins, per provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ bomclaw send        Send a message via the gateway
 bomclaw status      Show gateway status
 bomclaw models      List available models
 bomclaw browser     Drive your own browser via the Browser Bridge extension
+bomclaw accounts    Show the credential pool and which accounts are healthy
 ```
 
 ### Examples

--- a/cmd/bomclaw/accountscmd.go
+++ b/cmd/bomclaw/accountscmd.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/credentials"
+	"github.com/ngocp/goterm-control/internal/gateway"
+)
+
+// runAccounts shows the credential pool this agent rotates sessions across:
+// which accounts exist, how many sessions are pinned to each, and which are
+// cooling down after a rate limit.
+func runAccounts(args []string) {
+	fs := flag.NewFlagSet("accounts", flag.ExitOnError)
+	addr := fs.String("addr", gatewayHTTPAddr(), "Gateway base URL")
+	asJSON := fs.Bool("json", false, "Print the raw status payload")
+	fs.Parse(args)
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Get(*addr + "/api/status")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "accounts: gateway unreachable at %s (%v)\n", *addr, err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	var st gateway.StatusResult
+	if err := json.Unmarshal(raw, &st); err != nil {
+		fmt.Fprintf(os.Stderr, "accounts: bad response: %s\n", raw)
+		os.Exit(1)
+	}
+	if *asJSON {
+		b, _ := json.MarshalIndent(st.Accounts, "", "  ")
+		fmt.Println(string(b))
+		return
+	}
+
+	agent := orAny(st.AgentName, st.AgentID)
+	if len(st.Accounts) == 0 {
+		fmt.Printf("%s: no credential pool configured — running on the ambient %s login.\n\n"+
+			"Add an `accounts:` section to config.yaml to rotate sessions across several.\n",
+			orAny(agent, "this agent"), st.DefaultModel)
+		return
+	}
+
+	fmt.Printf("%s · provider %s\n\n", orAny(agent, "agent"), st.Accounts[0].Provider)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "  ACCOUNT\tSESSIONS\tLAST USED\tSTATE")
+	now := time.Now()
+	for _, a := range st.Accounts {
+		state := "ready"
+		if a.CoolingHint != "" {
+			if until, err := time.Parse(time.RFC3339, a.CoolingHint); err == nil {
+				state = fmt.Sprintf("cooling %s", until.Sub(now).Round(time.Minute))
+			} else {
+				state = "cooling"
+			}
+		}
+		fmt.Fprintf(w, "  %s\t%d\t%s\t%s\n", a.Name, a.Sessions, clockOr(a.LastUsed, "never"), state)
+	}
+	w.Flush()
+
+	// Errors go underneath rather than in a column: they are long, and the
+	// reason an account is sidelined is worth reading in full.
+	for _, a := range st.Accounts {
+		if a.LastError != "" {
+			fmt.Printf("\n  %s: %s\n", a.Name, a.LastError)
+		}
+	}
+}
+
+// clockOr renders an RFC3339 stamp as a local time, or a fallback when empty.
+func clockOr(stamp, fallback string) string {
+	if stamp == "" {
+		return fallback
+	}
+	t, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return stamp
+	}
+	return t.Local().Format("15:04:05")
+}
+
+// assert at compile time that the CLI and the pool agree on the status shape.
+var _ = []credentials.Status(nil)

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -120,6 +120,8 @@ func main() {
 		runChat(os.Args[2:])
 	case "browser":
 		runBrowser(os.Args[2:])
+	case "accounts":
+		runAccounts(os.Args[2:])
 	case "help", "--help", "-h":
 		printUsage()
 	default:
@@ -148,6 +150,7 @@ Commands:
   models             List available models
   chat               Interactive CLI chat with the agent (no gateway needed)
   browser            Drive the user's browser via the Browser Bridge extension
+  accounts           Show the credential pool and which accounts are healthy
   agents             List agents registered in the shared database
   task               Create, claim and finish work shared between agents
   note               Record and search what the agents have learned
@@ -326,6 +329,16 @@ func runGateway(args []string) {
 		}
 	}
 
+	// Credential pool: which accounts this agent rotates sessions across.
+	// Built before the bot so both it and the gateway report the same pool.
+	credPool, err := bot.PoolFromConfig(cfg)
+	if err != nil {
+		log.Fatalf("accounts: %v", err)
+	}
+	if !credPool.Empty() {
+		log.Printf("gateway: credential pool for %s: %s", cfg.Provider, strings.Join(credPool.Names(), ", "))
+	}
+
 	// Create the Telegram bot first so the gateway status RPC can report its
 	// live run state (menu bar tray polls /api/status).
 	var tgBot *bot.Bot
@@ -344,7 +357,7 @@ func runGateway(args []string) {
 	// task runs with full machine access and nobody is watching.
 	var runner *taskrunner.Runner
 	if coordDB != nil && cfg.Tasks.AutoClaim {
-		runner = taskrunner.New(coordDB, bot.NewChatClient(cfg, nil), gwTrace, taskrunner.Config{
+		runner = taskrunner.New(coordDB, bot.NewChatClientWithPool(cfg, nil, credPool), gwTrace, taskrunner.Config{
 			AgentID:  cfg.Agent.ID,
 			Model:    resolver.Default(),
 			Interval: time.Duration(cfg.Tasks.PollIntervalSeconds) * time.Second,
@@ -360,6 +373,7 @@ func runGateway(args []string) {
 		Resolver:      resolver,
 		Provider:      provider,
 		Browser:       browserHub,
+		Accounts:      credPool,
 		System:        cfg.Claude.SystemPrompt,
 		DataDir:       cfg.Session.DataDir,
 		Uptime:        func() time.Duration { return time.Since(startTime) },

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,36 @@ tasks:
   poll_interval_seconds: 60
   timeout_minutes: 15
 
+# Credential pool. Leave `pool` empty (the default) and the agent runs on the
+# ambient login, exactly as before this existed.
+#
+# Rotation is per SESSION, never per turn. Both CLIs keep their session store
+# inside the same directory as their credentials — CLAUDE_CONFIG_DIR for claude,
+# CODEX_HOME for codex — so switching account mid-conversation would lose the
+# conversation. An account is chosen when a session starts and pinned for life;
+# `bomclaw accounts` shows which account holds what.
+#
+# Each account needs its OWN directory, logged in separately
+# (`CLAUDE_CONFIG_DIR=~/.claude-work claude` then /login, or
+#  `CODEX_HOME=~/.codex-work codex login`). Point two accounts at one directory
+# and they are the same identity, so rotating achieves nothing.
+accounts:
+  cooldown_minutes: 15        # after a rate limit, new sessions skip that account this long
+  pool: []
+  # pool:
+  #   # claude on separate OAuth subscriptions
+  #   - name: "personal"
+  #     config_dir: "~/.claude"
+  #   - name: "work"
+  #     config_dir: "~/.claude-work"
+  #   # claude on plain API keys instead (api_key_env keeps the secret out of this file)
+  #   - name: "key-a"
+  #     api_key_env: "ANTHROPIC_KEY_A"
+  #   # codex accounts — only used by an agent whose provider is codex
+  #   - name: "codex-main"
+  #     provider: "codex"
+  #     config_dir: "~/.codex"
+
 # Browser Bridge — the BomClaw Browser Bridge Chrome extension connects to this
 # gateway's /ext endpoint so the agent can drive the user's own, logged-in
 # browser through `bomclaw browser …`. Pair the extension with the token from

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -29,6 +29,7 @@
         <a href="{{ '/telegram-bot' | relative_url }}" {% if page.url == '/telegram-bot' %}class="active"{% endif %}>Telegram Bot</a>
         <a href="{{ '/dashboard' | relative_url }}" {% if page.url == '/dashboard' %}class="active"{% endif %}>Dashboard</a>
         <a href="{{ '/browser-bridge' | relative_url }}" {% if page.url == '/browser-bridge' %}class="active"{% endif %}>Browser Bridge</a>
+        <a href="{{ '/credential-pools' | relative_url }}" {% if page.url == '/credential-pools' %}class="active"{% endif %}>Accounts</a>
         <a href="{{ '/configuration' | relative_url }}" {% if page.url == '/configuration' %}class="active"{% endif %}>Config</a>
         <a href="{{ '/api-reference' | relative_url }}" {% if page.url == '/api-reference' %}class="active"{% endif %}>API</a>
         <a href="{{ '/changelog' | relative_url }}" {% if page.url == '/changelog' %}class="active"{% endif %}>Changelog</a>
@@ -66,6 +67,7 @@
           <a href="{{ '/telegram-bot' | relative_url }}">Telegram Bot</a>
           <a href="{{ '/dashboard' | relative_url }}">Web Dashboard</a>
           <a href="{{ '/browser-bridge' | relative_url }}">Browser Bridge</a>
+          <a href="{{ '/credential-pools' | relative_url }}">Credential Pools</a>
           <a href="{{ '/api-reference' | relative_url }}">API Reference</a>
         </div>
         <div class="footer-links">

--- a/docs/credential-pools.md
+++ b/docs/credential-pools.md
@@ -1,0 +1,134 @@
+---
+title: Credential Pools
+layout: default
+---
+
+<section class="doc-page">
+<div class="doc-content" markdown="1">
+
+# Credential Pools
+
+<p class="lead">Rotate an agent's sessions across several logins — separate Claude subscriptions, API keys, or Codex accounts — so one account's rate limit does not stop the agent.</p>
+
+Off by default. With no `accounts:` section the agent runs on the ambient
+login, exactly as it always has.
+
+## The one rule that shapes everything
+
+**Both CLIs keep their session store inside the same directory as their
+credentials.**
+
+| CLI | Directory | Holds |
+|---|---|---|
+| claude | `CLAUDE_CONFIG_DIR` | the login **and** `sessions/`, `projects/` |
+| codex | `CODEX_HOME` | the login **and** the thread database |
+
+So a conversation cannot be read from any other account. Rotation is therefore
+**per session, never per turn**: an account is chosen when a session starts and
+pinned to it for life. Every later turn of that conversation returns to the
+same account.
+
+A consequence worth stating plainly: when a session's account is rate-limited,
+that session waits. It cannot be moved — its history is not there. New sessions
+go elsewhere; this one reports the error.
+
+## Setting it up
+
+Each account needs its **own directory, logged in separately**. Two accounts
+pointing at one directory are one identity, and rotating between them achieves
+nothing.
+
+```bash
+# a second Claude subscription
+CLAUDE_CONFIG_DIR=~/.claude-work claude     # then /login
+
+# a second Codex account
+CODEX_HOME=~/.codex-work codex login
+```
+
+Then declare them:
+
+```yaml
+accounts:
+  cooldown_minutes: 15
+  pool:
+    - name: "personal"
+      config_dir: "~/.claude"
+    - name: "work"
+      config_dir: "~/.claude-work"
+```
+
+Claude can also run on plain API keys instead of the OAuth subscription.
+`api_key_env` names an environment variable, keeping the secret out of
+`config.yaml`:
+
+```yaml
+    - name: "key-a"
+      api_key_env: "ANTHROPIC_KEY_A"
+```
+
+An agent only uses pool entries matching its own `provider`, so one config file
+can describe both backends:
+
+```yaml
+    - name: "codex-main"
+      provider: "codex"
+      config_dir: "~/.codex"
+```
+
+## How an account is chosen
+
+- **New session** → the least recently used account that is not cooling down,
+  so load spreads instead of piling onto the first entry.
+- **Existing session** → always its pinned account, cooldown or not.
+- **A rate-limit error** → that account cools down for `cooldown_minutes`, so
+  new sessions avoid it. A later success lifts the cooldown early.
+- **Every account cooling down** → the agent still tries the one that recovers
+  soonest. A cooldown is a guess about someone else's rate limiter, not a fact,
+  and idling on a guess is worse than trying.
+
+Only account-specific signals count as rate limits (`429`, `rate limit`,
+`quota`, `usage limit`). A server-side `overloaded` error is the provider's own
+capacity problem and does not sideline a working account. Cancelling a turn is
+not held against the account either.
+
+## Seeing what is going on
+
+```bash
+bomclaw accounts
+```
+
+```
+BomClaw (agent 1) · provider claude
+
+  ACCOUNT   SESSIONS  LAST USED  STATE
+  personal  7         14:22:01   ready
+  work      3         14:19:44   cooling 12m0s
+
+  work: 429 rate limit exceeded
+```
+
+The same data is in `/api/status` under `accounts`, so the dashboard and the
+menu bar can show it too.
+
+## Renaming and removing accounts
+
+A session pins the account **by name**. Renaming an entry strands every session
+pinned to the old name: the next turn fails with a clear error rather than
+silently starting a fresh conversation under a different login. Removing an
+account has the same effect.
+
+If you need to retire an account, let its sessions finish (or `/new` them)
+before taking it out of the pool.
+
+## Before you pool many accounts
+
+Spreading your **own** accounts to manage rate limits is ordinary capacity
+work. Collecting accounts specifically to exceed the limits a provider sets per
+account is a different thing, and both Anthropic's and OpenAI's terms speak to
+it. This feature does not know the difference — it will rotate whatever you
+give it. Check your plan's terms before pooling accounts you do not own, or
+many accounts you created for the purpose.
+
+</div>
+</section>

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/codex"
 	"github.com/ngocp/goterm-control/internal/config"
 	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/credentials"
 	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/memory"
 	"github.com/ngocp/goterm-control/internal/models"
@@ -52,14 +54,41 @@ func (b *Bot) Handler() *Handler { return b.handler }
 // Exported because the task runner needs its own client: it executes queued
 // work in isolated sessions, alongside whatever the bot is chatting about.
 func NewChatClient(cfg *config.Config, executor *tools.Executor) chat.Client {
+	return NewChatClientWithPool(cfg, executor, nil)
+}
+
+// NewChatClientWithPool is NewChatClient with a credential pool attached. A
+// nil or empty pool leaves the client running on the ambient credentials,
+// which is what every install without an `accounts:` section does.
+func NewChatClientWithPool(cfg *config.Config, executor *tools.Executor, pool *credentials.Pool) chat.Client {
 	if cfg.Provider == config.ProviderCodex {
 		c := codex.New(cfg.Claude.SystemPrompt)
 		c.SetWorkspace(cfg.Claude.Workspace)
+		c.SetPool(pool)
 		return c
 	}
 	c := claude.New(cfg.Claude.SystemPrompt, executor)
 	c.SetWorkspace(cfg.Claude.Workspace)
+	c.SetPool(pool)
 	return c
+}
+
+// PoolFromConfig builds this agent's credential pool from config. Accounts for
+// the other backend are ignored: an agent runs one CLI, and a codex login is
+// unreadable by claude.
+func PoolFromConfig(cfg *config.Config) (*credentials.Pool, error) {
+	accts := make([]credentials.Account, 0, len(cfg.Accounts.Pool))
+	for _, a := range cfg.Accounts.Pool {
+		accts = append(accts, credentials.Account{
+			Name:      a.Name,
+			Provider:  a.Provider,
+			ConfigDir: a.ConfigDir,
+			APIKey:    a.APIKey,
+			APIKeyEnv: a.APIKeyEnv,
+		})
+	}
+	return credentials.NewPool(cfg.Provider, accts,
+		time.Duration(cfg.Accounts.CooldownMinutes)*time.Minute)
 }
 
 func New(cfg *config.Config, db *storage.DB, coordDB *coord.DB, sessions *session.Manager) (*Bot, error) {
@@ -114,7 +143,14 @@ func New(cfg *config.Config, db *storage.DB, coordDB *coord.DB, sessions *sessio
 	// Nil coordDB (coord disabled) yields a nil recorder, which is a no-op.
 	rec := trace.New(coordDB, cfg.Agent.ID)
 
-	llm := NewChatClient(cfg, executor)
+	pool, err := PoolFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: %w", err)
+	}
+	if !pool.Empty() {
+		log.Printf("bot: credential pool for %s: %s", cfg.Provider, strings.Join(pool.Names(), ", "))
+	}
+	llm := NewChatClientWithPool(cfg, executor, pool)
 
 	// Message store (SQLite — conversation history)
 	messageStore := storage.NewMessageStore(db)

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/credentials"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -34,6 +36,7 @@ type StreamCallbacks = chat.StreamCallbacks
 type Client struct {
 	systemPrompt string
 	workspace    string // working directory for the CLI subprocess
+	pool         *credentials.Pool
 }
 
 // New creates a Claude client backed by the claude CLI subprocess.
@@ -44,6 +47,48 @@ func New(systemPrompt string, executor *tools.Executor) *Client {
 	log.Printf("claude: subprocess client initialized")
 	return &Client{
 		systemPrompt: systemPrompt,
+	}
+}
+
+// SetPool attaches the credential pool this client rotates sessions across.
+// Nil, or an empty pool, keeps the previous behaviour exactly: run on whatever
+// credentials the process already has.
+func (c *Client) SetPool(p *credentials.Pool) { c.pool = p }
+
+// account resolves which credential this session runs under, pinning one on
+// the first turn. The pin is permanent for the session because the CLI stores
+// the conversation inside the account's own config directory — resuming it
+// from a different account would silently start a new one.
+func (c *Client) account(sess *session.Session) (credentials.Account, error) {
+	if c.pool.Empty() {
+		return credentials.Account{}, nil
+	}
+	pinned := sess.GetAccount()
+	acct, err := c.pool.Pick(pinned)
+	if err != nil {
+		return credentials.Account{}, err
+	}
+	if pinned == "" && acct.Name != "" {
+		sess.SetAccount(acct.Name)
+		c.pool.MarkStarted(acct.Name)
+		log.Printf("claude: session %s pinned to account %s", sess.ID, acct.Name)
+	}
+	return acct, nil
+}
+
+// recordOutcome feeds the pool this turn's result. Cancellation is the user
+// stopping the agent, not the account failing, so it is not held against it.
+func (c *Client) recordOutcome(acct credentials.Account, err error) {
+	if c.pool.Empty() || acct.Name == "" {
+		return
+	}
+	switch {
+	case err == nil:
+		c.pool.MarkSuccess(acct.Name)
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		// not the account's fault
+	default:
+		c.pool.MarkFailure(acct.Name, err)
 	}
 }
 
@@ -102,7 +147,7 @@ type pendingCall struct {
 // modelID is the resolved model to use for this call.
 // memoryContext is appended to the system prompt (new sessions) or prepended to
 // the user message (resumed sessions) to inject cross-session memory.
-func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID string, userText string, memoryContext string, cb StreamCallbacks) error {
+func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID string, userText string, memoryContext string, cb StreamCallbacks) (err error) {
 	sessionID := sess.GetSessionID()
 	isNewSession := sessionID == ""
 
@@ -114,6 +159,18 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	if memoryContext != "" && isNewSession {
 		systemPrompt += memoryContext
 	}
+
+	// Resolve the credential before spawning: a pin that no longer names a
+	// configured account must fail the turn, not start a blank conversation
+	// under someone else's login.
+	acct, err := c.account(sess)
+	if err != nil {
+		return err
+	}
+	// Report how this account fared, on every exit path. A rate limit puts it
+	// on cooldown so NEW sessions go elsewhere; this one stays where its
+	// history is.
+	defer func() { c.recordOutcome(acct, err) }()
 
 	args := buildArgs(modelID, sessionID, isNewSession, systemPrompt)
 
@@ -129,8 +186,10 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	// Pass user message via stdin (safe for arbitrary text).
 	cmd.Stdin = strings.NewReader(userText)
 
-	// Remove ANTHROPIC_API_KEY so CLI uses its own OAuth subscription.
-	cmd.Env = filteredEnv(envVarsToRemove)
+	// Remove ANTHROPIC_API_KEY so the CLI uses its own OAuth subscription,
+	// then let the chosen account override that: an API-key account puts one
+	// back, an OAuth account points CLAUDE_CONFIG_DIR at its own login.
+	cmd.Env = credentials.ApplyEnv(filteredEnv(envVarsToRemove), acct)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/codex/client.go
+++ b/internal/codex/client.go
@@ -13,6 +13,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/credentials"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -35,11 +37,52 @@ const ProviderName = "codex"
 // Client wraps the codex CLI subprocess.
 type Client struct {
 	systemPrompt string
+	pool         *credentials.Pool
 	workspace    string // working directory for the CLI subprocess
 }
 
 // New creates a Codex client backed by the codex CLI subprocess.
 // The CLI manages its own auth (`codex login`) and its own tool loop.
+// SetPool attaches the credential pool this client rotates sessions across.
+// Nil, or an empty pool, keeps the previous behaviour: run on whatever
+// credentials the process already has.
+func (c *Client) SetPool(p *credentials.Pool) { c.pool = p }
+
+// account resolves which credential this thread runs under, pinning one on the
+// first turn. codex keeps its thread store inside CODEX_HOME alongside the
+// login, so a thread can only ever be resumed from the account that created it.
+func (c *Client) account(sess *session.Session) (credentials.Account, error) {
+	if c.pool.Empty() {
+		return credentials.Account{}, nil
+	}
+	pinned := sess.GetAccount()
+	acct, err := c.pool.Pick(pinned)
+	if err != nil {
+		return credentials.Account{}, err
+	}
+	if pinned == "" && acct.Name != "" {
+		sess.SetAccount(acct.Name)
+		c.pool.MarkStarted(acct.Name)
+		log.Printf("codex: session %s pinned to account %s", sess.ID, acct.Name)
+	}
+	return acct, nil
+}
+
+// recordOutcome feeds the pool this turn's result. Cancellation is the user
+// stopping the agent, not the account failing.
+func (c *Client) recordOutcome(acct credentials.Account, err error) {
+	if c.pool.Empty() || acct.Name == "" {
+		return
+	}
+	switch {
+	case err == nil:
+		c.pool.MarkSuccess(acct.Name)
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	default:
+		c.pool.MarkFailure(acct.Name, err)
+	}
+}
+
 func New(systemPrompt string) *Client {
 	log.Printf("codex: subprocess client initialized")
 	return &Client{systemPrompt: systemPrompt}
@@ -59,7 +102,13 @@ func (c *Client) Name() string { return ProviderName }
 // them to <workspace>/AGENTS.md, which codex loads automatically — that writes
 // into the user's workspace, so it is deliberately not done here.)
 func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID string,
-	userText string, memoryContext string, cb chat.StreamCallbacks) error {
+	userText string, memoryContext string, cb chat.StreamCallbacks) (err error) {
+
+	acct, err := c.account(sess)
+	if err != nil {
+		return err
+	}
+	defer func() { c.recordOutcome(acct, err) }()
 
 	threadID := sess.GetSessionID()
 	// A thread started by another CLI cannot be resumed by codex — a provider
@@ -74,6 +123,9 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	args := buildArgs(modelID, threadID, isNewThread)
 
 	cmd := exec.CommandContext(ctx, codexBin, args...)
+	// codex has always inherited the ambient environment; the account layers
+	// CODEX_HOME on top so each login keeps its own threads.
+	cmd.Env = credentials.ApplyEnv(os.Environ(), acct)
 	if c.workspace != "" {
 		_ = os.MkdirAll(c.workspace, 0755)
 		cmd.Dir = c.workspace

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Memory   MemoryConfig   `yaml:"memory"`
 	Gateway  GatewayConfig  `yaml:"gateway"`
 	Browser  BrowserConfig  `yaml:"browser"`
+	Accounts AccountsConfig `yaml:"accounts"`
 }
 
 // AgentConfig names this agent. Two agents on one machine MUST NOT share an
@@ -73,6 +74,35 @@ type TasksConfig struct {
 }
 
 // GatewayConfig holds gateway HTTP server settings.
+// AccountsConfig is the pool of credentials this agent rotates sessions
+// across. Leave `pool` empty and the agent runs on the ambient credentials,
+// exactly as it did before this existed.
+//
+// Rotation is per SESSION, never per turn: both CLIs keep their session store
+// inside the same directory as their credentials, so an account switch mid
+// conversation would lose the conversation. See internal/credentials.
+type AccountsConfig struct {
+	CooldownMinutes int             `yaml:"cooldown_minutes"` // skip an account this long after it reports a rate limit (default 15)
+	Pool            []AccountConfig `yaml:"pool"`
+}
+
+// AccountConfig is one credential in the pool.
+type AccountConfig struct {
+	Name     string `yaml:"name"`     // required; sessions pin to it, so renaming one strands its sessions
+	Provider string `yaml:"provider"` // "claude" | "codex"; defaults to the agent's provider
+
+	// ConfigDir is the CLI's own config+session directory — CLAUDE_CONFIG_DIR
+	// for claude, CODEX_HOME for codex. Each account needs a separate one,
+	// logged in separately, or they are all the same identity.
+	ConfigDir string `yaml:"config_dir"`
+
+	// APIKey runs a claude account on a plain API key instead of the OAuth
+	// subscription. APIKeyEnv names an environment variable to read it from,
+	// so the secret need not sit in config.yaml.
+	APIKey    string `yaml:"api_key"`
+	APIKeyEnv string `yaml:"api_key_env"`
+}
+
 // BrowserConfig groups browser control. Extension is the Browser Bridge: a
 // Chrome extension in the user's own browser that the agent drives through the
 // gateway (`bomclaw browser …`).
@@ -112,7 +142,7 @@ type AuthConfig struct {
 // ClaudeConfig is kept for backward compatibility — the claude CLI subprocess config.
 type ClaudeConfig struct {
 	APIKey           string `yaml:"api_key"`
-	Model            string `yaml:"model"`             // default model ID
+	Model            string `yaml:"model"` // default model ID
 	MaxTokens        int    `yaml:"max_tokens"`
 	SystemPrompt     string `yaml:"system_prompt"`
 	Workspace        string `yaml:"workspace"`         // working directory for claude CLI subprocess
@@ -121,8 +151,8 @@ type ClaudeConfig struct {
 
 // ModelsConfig defines available models and custom providers.
 type ModelsConfig struct {
-	Default  string                `yaml:"default"`  // default model ID (overrides claude.model)
-	Custom   []models.Model        `yaml:"custom"`   // additional model definitions
+	Default string         `yaml:"default"` // default model ID (overrides claude.model)
+	Custom  []models.Model `yaml:"custom"`  // additional model definitions
 }
 
 type TelegramConfig struct {
@@ -291,6 +321,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Browser.Extension.CallTimeoutSeconds == 0 {
 		cfg.Browser.Extension.CallTimeoutSeconds = 30
+	}
+	if cfg.Accounts.CooldownMinutes == 0 {
+		cfg.Accounts.CooldownMinutes = 15
 	}
 	if cfg.Telegram.Indicator.Enabled {
 		if len(cfg.Telegram.Indicator.Frames) == 0 {

--- a/internal/credentials/pool.go
+++ b/internal/credentials/pool.go
@@ -1,0 +1,373 @@
+// Package credentials manages the pool of accounts an agent runs its sessions
+// under, for both CLI backends.
+//
+// Both CLIs keep their credentials AND their session store under one
+// directory — CLAUDE_CONFIG_DIR for claude, CODEX_HOME for codex — which is
+// the fact the whole design turns on: switching account switches the session
+// store with it. A conversation therefore cannot migrate between accounts. An
+// account is chosen once, when the session starts, and pinned to it for life;
+// rotation happens across sessions, never inside one.
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Provider keys, matching internal/config.
+const (
+	ProviderClaude = "claude"
+	ProviderCodex  = "codex"
+)
+
+// Account is one credential a session can run under.
+type Account struct {
+	Name     string
+	Provider string
+
+	// ConfigDir is the CLI's config/session directory: CLAUDE_CONFIG_DIR for
+	// claude, CODEX_HOME for codex. Each account needs its own, logged in
+	// separately, or they share one identity and rotating achieves nothing.
+	ConfigDir string
+
+	// APIKey (claude only) runs the CLI on a plain API key instead of the
+	// OAuth subscription. APIKeyEnv reads it from the environment instead, so
+	// the key itself need not sit in config.yaml.
+	APIKey    string
+	APIKeyEnv string
+}
+
+// resolvedKey returns the API key, from the env var when one is named.
+func (a Account) resolvedKey() string {
+	if a.APIKeyEnv != "" {
+		if v := strings.TrimSpace(os.Getenv(a.APIKeyEnv)); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(a.APIKey)
+}
+
+// Env returns the environment overrides for running under this account:
+// values to set, and names to unset.
+func (a Account) Env() (set map[string]string, unset []string) {
+	set = map[string]string{}
+	// The zero account means "leave the process environment exactly as it is".
+	// Anything else here would change behaviour for every install that has no
+	// pool configured, which is all of them until someone opts in.
+	if a.Zero() {
+		return set, nil
+	}
+	switch a.Provider {
+	case ProviderCodex:
+		if a.ConfigDir != "" {
+			set["CODEX_HOME"] = a.ConfigDir
+		}
+	default: // claude
+		if a.ConfigDir != "" {
+			set["CLAUDE_CONFIG_DIR"] = a.ConfigDir
+		}
+		if key := a.resolvedKey(); key != "" {
+			set["ANTHROPIC_API_KEY"] = key
+		} else {
+			// No key for this account: the CLI must fall back to the OAuth
+			// login in its config dir, so an ambient key must not leak in.
+			unset = append(unset, "ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD")
+		}
+	}
+	return set, unset
+}
+
+// Zero reports whether this is the implicit "whatever the process already has"
+// account, used when no pool is configured. It asks whether the account
+// carries any credential information at all, not merely whether it is named:
+// an account that selects a config dir still selects an identity, named or
+// not, and treating it as ambient would quietly ignore it.
+func (a Account) Zero() bool {
+	return a.ConfigDir == "" && a.APIKey == "" && a.APIKeyEnv == ""
+}
+
+// Status is one account's health, for `bomclaw accounts` and the dashboard.
+type Status struct {
+	Name        string `json:"name"`
+	Provider    string `json:"provider"`
+	Sessions    int    `json:"sessions"`                // sessions currently pinned here
+	LastUsed    string `json:"last_used,omitempty"`     // RFC3339
+	CoolingHint string `json:"cooling_until,omitempty"` // RFC3339 while rate-limited
+	LastError   string `json:"last_error,omitempty"`
+}
+
+type accountState struct {
+	acct      Account
+	lastUsed  time.Time
+	sessions  int
+	coolUntil time.Time
+	lastErr   string
+}
+
+// Pool holds the accounts for ONE provider — an agent runs one backend, and
+// mixing claude and codex credentials in one rotation would hand a session a
+// login its CLI cannot read.
+type Pool struct {
+	provider string
+	cooldown time.Duration
+
+	mu    sync.Mutex
+	accts []*accountState
+	next  int // round-robin cursor, used to break ties between equal accounts
+}
+
+// NewPool builds the pool for provider from accounts. Entries for other
+// providers are ignored. An empty result is not an error: it means "run with
+// the ambient credentials", which is what every existing install does.
+func NewPool(provider string, accounts []Account, cooldown time.Duration) (*Pool, error) {
+	if cooldown <= 0 {
+		cooldown = 15 * time.Minute
+	}
+	p := &Pool{provider: provider, cooldown: cooldown}
+	seen := map[string]bool{}
+	for _, a := range accounts {
+		if a.Provider == "" {
+			a.Provider = provider
+		}
+		if a.Provider != provider {
+			continue
+		}
+		if a.Name == "" {
+			return nil, fmt.Errorf("credentials: every account needs a name")
+		}
+		if seen[a.Name] {
+			return nil, fmt.Errorf("credentials: duplicate account name %q", a.Name)
+		}
+		seen[a.Name] = true
+		a.ConfigDir = expandHome(a.ConfigDir)
+		p.accts = append(p.accts, &accountState{acct: a})
+	}
+	return p, nil
+}
+
+// Empty reports whether no pool is configured for this provider.
+func (p *Pool) Empty() bool {
+	if p == nil {
+		return true
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.accts) == 0
+}
+
+// Names lists the configured account names, in config order.
+func (p *Pool) Names() []string {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, 0, len(p.accts))
+	for _, s := range p.accts {
+		out = append(out, s.acct.Name)
+	}
+	return out
+}
+
+// Pick returns the account a session should run under.
+//
+// A pinned name always wins, even while that account is cooling down: the
+// session's history lives in its config directory and cannot be read from
+// anywhere else, so moving it would silently start a new conversation. The
+// caller surfaces the rate-limit error instead.
+//
+// With nothing pinned, the least recently used healthy account is chosen, so
+// load spreads instead of piling onto whichever entry happens to be first.
+func (p *Pool) Pick(pinned string) (Account, error) {
+	if p == nil {
+		return Account{}, nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.accts) == 0 {
+		return Account{}, nil // ambient credentials
+	}
+
+	if pinned != "" {
+		for _, s := range p.accts {
+			if s.acct.Name == pinned {
+				s.lastUsed = time.Now()
+				return s.acct, nil
+			}
+		}
+		// The pin names an account this agent no longer has. Refusing is
+		// safer than silently rehoming: the CLI would not find the session
+		// either, and a fresh conversation under another identity is a
+		// surprising thing to hand someone mid-thread.
+		return Account{}, fmt.Errorf("credentials: session is pinned to account %q, which is not configured for provider %s", pinned, p.provider)
+	}
+
+	now := time.Now()
+	var best *accountState
+	for i := range p.accts {
+		s := p.accts[(p.next+i)%len(p.accts)]
+		if now.Before(s.coolUntil) {
+			continue
+		}
+		if best == nil || s.lastUsed.Before(best.lastUsed) {
+			best = s
+		}
+	}
+	if best == nil {
+		// Everything is cooling down. Hand back whichever recovers soonest and
+		// let the turn try: a cooldown is a guess about someone else's rate
+		// limiter, not a fact, and refusing outright would idle the agent.
+		for _, s := range p.accts {
+			if best == nil || s.coolUntil.Before(best.coolUntil) {
+				best = s
+			}
+		}
+	}
+	best.lastUsed = now
+	p.next = (p.next + 1) % len(p.accts)
+	return best.acct, nil
+}
+
+// MarkStarted records that a session is now pinned to an account.
+func (p *Pool) MarkStarted(name string) {
+	p.each(name, func(s *accountState) { s.sessions++ })
+}
+
+// MarkFailure notes a turn failure. A rate-limit style error puts the account
+// on cooldown so NEW sessions go elsewhere; sessions already pinned to it stay
+// where their history is.
+func (p *Pool) MarkFailure(name string, err error) {
+	if err == nil {
+		return
+	}
+	p.each(name, func(s *accountState) {
+		s.lastErr = truncateErr(err.Error())
+		if IsRateLimit(err) {
+			s.coolUntil = time.Now().Add(p.cooldown)
+		}
+	})
+}
+
+// MarkSuccess clears a recorded error and lifts any cooldown: the account
+// evidently works again.
+func (p *Pool) MarkSuccess(name string) {
+	p.each(name, func(s *accountState) {
+		s.lastErr = ""
+		s.coolUntil = time.Time{}
+	})
+}
+
+func (p *Pool) each(name string, fn func(*accountState)) {
+	if p == nil || name == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, s := range p.accts {
+		if s.acct.Name == name {
+			fn(s)
+			return
+		}
+	}
+}
+
+// Status reports every account's health.
+func (p *Pool) Status() []Status {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	out := make([]Status, 0, len(p.accts))
+	for _, s := range p.accts {
+		st := Status{
+			Name:      s.acct.Name,
+			Provider:  s.acct.Provider,
+			Sessions:  s.sessions,
+			LastError: s.lastErr,
+		}
+		if !s.lastUsed.IsZero() {
+			st.LastUsed = s.lastUsed.Format(time.RFC3339)
+		}
+		if now.Before(s.coolUntil) {
+			st.CoolingHint = s.coolUntil.Format(time.RFC3339)
+		}
+		out = append(out, st)
+	}
+	return out
+}
+
+// IsRateLimit reports whether err looks like the provider throttling this
+// account, as opposed to a bug or a transient server fault. Only signals that
+// are specific to an account count: "overloaded" is the provider's own
+// capacity problem and would cool down a perfectly good account.
+func IsRateLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, sig := range []string{
+		"rate limit",
+		"rate_limit",
+		"429",
+		"quota",
+		"usage limit",
+		"too many requests",
+		"insufficient_quota",
+	} {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+func truncateErr(s string) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if r := []rune(s); len(r) > 160 {
+		return string(r[:159]) + "…"
+	}
+	return s
+}
+
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+// ApplyEnv returns environ with the account's overrides applied: values set or
+// replaced, named variables removed.
+func ApplyEnv(environ []string, a Account) []string {
+	set, unset := a.Env()
+	drop := map[string]bool{}
+	for _, k := range unset {
+		drop[k] = true
+	}
+	for k := range set {
+		drop[k] = true // replaced below
+	}
+	out := make([]string, 0, len(environ)+len(set))
+	for _, kv := range environ {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		if !drop[key] {
+			out = append(out, kv)
+		}
+	}
+	for k, v := range set {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/internal/credentials/pool_test.go
+++ b/internal/credentials/pool_test.go
@@ -1,0 +1,292 @@
+package credentials
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustPool(t *testing.T, provider string, accts []Account) *Pool {
+	t.Helper()
+	p, err := NewPool(provider, accts, time.Minute)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	return p
+}
+
+// No pool configured must behave exactly as before this feature existed: the
+// CLI runs on whatever credentials the process already has.
+func TestEmptyPoolYieldsAmbientAccount(t *testing.T) {
+	p := mustPool(t, ProviderClaude, nil)
+	if !p.Empty() {
+		t.Fatal("a pool with no accounts must report empty")
+	}
+	a, err := p.Pick("")
+	if err != nil || !a.Zero() {
+		t.Fatalf("Pick on an empty pool = (%+v, %v), want the zero account", a, err)
+	}
+	// A nil pool is the same thing, so callers need no nil checks.
+	var nilPool *Pool
+	if !nilPool.Empty() {
+		t.Error("a nil pool must report empty")
+	}
+	if a, err := nilPool.Pick(""); err != nil || !a.Zero() {
+		t.Errorf("nil pool Pick = (%+v, %v)", a, err)
+	}
+}
+
+// Accounts belonging to the other backend must never enter the rotation: a
+// codex login is unreadable by the claude CLI.
+func TestPoolFiltersByProvider(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{
+		{Name: "c1", Provider: ProviderClaude, ConfigDir: "/tmp/c1"},
+		{Name: "x1", Provider: ProviderCodex, ConfigDir: "/tmp/x1"},
+		{Name: "c2"}, // no provider: inherits the pool's
+	})
+	got := p.Names()
+	if len(got) != 2 || got[0] != "c1" || got[1] != "c2" {
+		t.Fatalf("names = %v, want [c1 c2]", got)
+	}
+}
+
+func TestPoolRejectsBadConfig(t *testing.T) {
+	if _, err := NewPool(ProviderClaude, []Account{{ConfigDir: "/tmp/x"}}, 0); err == nil {
+		t.Error("an unnamed account must be rejected — the name is what a session pins to")
+	}
+	if _, err := NewPool(ProviderClaude, []Account{{Name: "a"}, {Name: "a"}}, 0); err == nil {
+		t.Error("duplicate names must be rejected — a pin would be ambiguous")
+	}
+}
+
+// Unpinned sessions spread across the pool instead of piling onto the first
+// entry.
+func TestPickSpreadsAcrossAccounts(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{
+		{Name: "a"}, {Name: "b"}, {Name: "c"},
+	})
+	seen := map[string]int{}
+	for i := 0; i < 6; i++ {
+		a, err := p.Pick("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[a.Name]++
+	}
+	for _, n := range []string{"a", "b", "c"} {
+		if seen[n] != 2 {
+			t.Errorf("account %s picked %d times, want 2 (even spread): %v", n, seen[n], seen)
+		}
+	}
+}
+
+// The pin is the whole point: a session's history lives in its account's
+// config dir, so every later turn must return to the same account.
+func TestPickHonoursThePin(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a"}, {Name: "b"}})
+	for i := 0; i < 5; i++ {
+		got, err := p.Pick("b")
+		if err != nil || got.Name != "b" {
+			t.Fatalf("Pick(\"b\") = (%q, %v), want b", got.Name, err)
+		}
+	}
+}
+
+// A pinned account that is rate-limited is still returned: the conversation
+// cannot be read anywhere else, so the turn must fail loudly rather than be
+// silently restarted under another identity.
+func TestPinnedAccountIsUsedEvenWhileCoolingDown(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a"}, {Name: "b"}})
+	p.MarkFailure("a", errors.New("429 rate limit exceeded"))
+
+	got, err := p.Pick("a")
+	if err != nil || got.Name != "a" {
+		t.Fatalf("a pinned cooling account must still be returned, got (%q, %v)", got.Name, err)
+	}
+	// …while new sessions avoid it.
+	fresh, err := p.Pick("")
+	if err != nil || fresh.Name != "b" {
+		t.Fatalf("a new session should avoid the cooling account, got (%q, %v)", fresh.Name, err)
+	}
+}
+
+// A pin naming an account that is gone must fail rather than rehome the
+// session, which would hand the user a blank conversation under another login.
+func TestUnknownPinIsAnError(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a"}})
+	_, err := p.Pick("removed")
+	if err == nil || !strings.Contains(err.Error(), "removed") {
+		t.Fatalf("expected an error naming the missing account, got %v", err)
+	}
+}
+
+// When every account is cooling down the agent still tries, rather than
+// idling on a guess about someone else's rate limiter.
+func TestAllCoolingStillReturnsSomething(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a"}, {Name: "b"}})
+	p.MarkFailure("a", errors.New("429 rate limit"))
+	p.MarkFailure("b", errors.New("429 rate limit"))
+	got, err := p.Pick("")
+	if err != nil || got.Name == "" {
+		t.Fatalf("expected an account anyway, got (%+v, %v)", got, err)
+	}
+}
+
+func TestMarkSuccessLiftsCooldown(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a"}, {Name: "b"}})
+	p.MarkFailure("a", errors.New("429 rate limit"))
+	p.MarkSuccess("a")
+	if st := p.Status()[0]; st.CoolingHint != "" || st.LastError != "" {
+		t.Errorf("success must clear the cooldown and the error, got %+v", st)
+	}
+}
+
+// Only account-specific throttling counts. "overloaded" is the provider's own
+// capacity problem and would sideline a perfectly good account.
+func TestIsRateLimit(t *testing.T) {
+	yes := []string{
+		"429 Too Many Requests", "rate limit exceeded", "monthly quota reached",
+		"usage limit reached", "insufficient_quota",
+	}
+	no := []string{
+		"connection refused", "overloaded_error: server is overloaded",
+		"context deadline exceeded", "invalid model",
+	}
+	for _, m := range yes {
+		if !IsRateLimit(errors.New(m)) {
+			t.Errorf("IsRateLimit(%q) = false, want true", m)
+		}
+	}
+	for _, m := range no {
+		if IsRateLimit(errors.New(m)) {
+			t.Errorf("IsRateLimit(%q) = true, want false", m)
+		}
+	}
+	if IsRateLimit(nil) {
+		t.Error("IsRateLimit(nil) must be false")
+	}
+}
+
+func TestAccountEnvClaude(t *testing.T) {
+	// OAuth account: the config dir selects the identity, and an ambient API
+	// key must be removed or the CLI would silently bill the wrong thing.
+	set, unset := Account{Provider: ProviderClaude, ConfigDir: "/tmp/a"}.Env()
+	if set["CLAUDE_CONFIG_DIR"] != "/tmp/a" {
+		t.Errorf("CLAUDE_CONFIG_DIR not set: %v", set)
+	}
+	if _, ok := set["ANTHROPIC_API_KEY"]; ok {
+		t.Error("an OAuth account must not set an API key")
+	}
+	if !contains(unset, "ANTHROPIC_API_KEY") {
+		t.Errorf("an ambient API key must be unset, got %v", unset)
+	}
+
+	// API-key account.
+	set, unset = Account{Provider: ProviderClaude, APIKey: "sk-test"}.Env()
+	if set["ANTHROPIC_API_KEY"] != "sk-test" {
+		t.Errorf("API key not set: %v", set)
+	}
+	if len(unset) != 0 {
+		t.Errorf("nothing should be unset for a key account, got %v", unset)
+	}
+}
+
+// The key can live in the environment so it need not sit in config.yaml.
+func TestAccountEnvFromEnvVar(t *testing.T) {
+	t.Setenv("POOL_KEY_A", "sk-from-env")
+	set, _ := Account{Provider: ProviderClaude, APIKeyEnv: "POOL_KEY_A"}.Env()
+	if set["ANTHROPIC_API_KEY"] != "sk-from-env" {
+		t.Errorf("key should come from the named env var, got %v", set)
+	}
+
+	// An unset variable falls back to OAuth rather than exporting an empty key.
+	set, unset := Account{Provider: ProviderClaude, APIKeyEnv: "POOL_KEY_MISSING"}.Env()
+	if _, ok := set["ANTHROPIC_API_KEY"]; ok {
+		t.Errorf("a missing env var must not export an empty key: %v", set)
+	}
+	if !contains(unset, "ANTHROPIC_API_KEY") {
+		t.Errorf("expected the ambient key to be unset, got %v", unset)
+	}
+}
+
+func TestAccountEnvCodex(t *testing.T) {
+	set, unset := Account{Provider: ProviderCodex, ConfigDir: "/tmp/cx"}.Env()
+	if set["CODEX_HOME"] != "/tmp/cx" {
+		t.Errorf("CODEX_HOME not set: %v", set)
+	}
+	if len(unset) != 0 {
+		t.Errorf("codex needs nothing unset, got %v", unset)
+	}
+}
+
+func TestApplyEnvReplacesAndRemoves(t *testing.T) {
+	base := []string{"PATH=/bin", "ANTHROPIC_API_KEY=ambient", "CLAUDE_CONFIG_DIR=/old"}
+
+	got := ApplyEnv(base, Account{Provider: ProviderClaude, ConfigDir: "/new"})
+	if !contains(got, "CLAUDE_CONFIG_DIR=/new") {
+		t.Errorf("config dir not replaced: %v", got)
+	}
+	if contains(got, "CLAUDE_CONFIG_DIR=/old") {
+		t.Errorf("stale config dir survived: %v", got)
+	}
+	if hasPrefix(got, "ANTHROPIC_API_KEY=") {
+		t.Errorf("ambient key must be removed for an OAuth account: %v", got)
+	}
+	if !contains(got, "PATH=/bin") {
+		t.Errorf("unrelated variables must survive: %v", got)
+	}
+
+	// The zero account changes nothing, which is what an unconfigured install
+	// relies on.
+	if len(ApplyEnv(base, Account{})) != len(base) {
+		t.Error("the zero account must leave the environment untouched")
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a", ConfigDir: "~/.claude-alt"}})
+	a, _ := p.Pick("a")
+	if a.ConfigDir != home+"/.claude-alt" {
+		t.Errorf("~ not expanded: %q", a.ConfigDir)
+	}
+}
+
+func TestStatusReportsHealth(t *testing.T) {
+	p := mustPool(t, ProviderClaude, []Account{{Name: "a"}, {Name: "b"}})
+	_, _ = p.Pick("")
+	p.MarkStarted("a")
+	p.MarkFailure("b", errors.New("429 rate limit exceeded"))
+
+	st := p.Status()
+	if len(st) != 2 {
+		t.Fatalf("want 2 statuses, got %d", len(st))
+	}
+	byName := map[string]Status{st[0].Name: st[0], st[1].Name: st[1]}
+	if byName["a"].Sessions != 1 {
+		t.Errorf("account a should show 1 pinned session, got %+v", byName["a"])
+	}
+	if byName["b"].CoolingHint == "" || !strings.Contains(byName["b"].LastError, "rate limit") {
+		t.Errorf("account b should show the cooldown and the reason, got %+v", byName["b"])
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPrefix(ss []string, prefix string) bool {
+	for _, s := range ss {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/browserbridge"
 	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/credentials"
 	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
@@ -68,6 +69,10 @@ type Deps struct {
 	// Browser relays actions to the user's own browser through the Browser
 	// Bridge extension. Nil when the bridge is disabled in config.
 	Browser *browserbridge.Hub
+
+	// Accounts is the credential pool sessions rotate across. Nil or empty
+	// means the ambient credentials.
+	Accounts *credentials.Pool
 }
 
 // TurnRunner is the slice of *bot.Handler the gateway needs. Declared here so
@@ -204,6 +209,7 @@ func handleStatus(deps Deps) (json.RawMessage, error) {
 		st := deps.Browser.Status()
 		result.Browser = &st
 	}
+	result.Accounts = deps.Accounts.Status()
 	return json.Marshal(result)
 }
 

--- a/internal/gateway/protocol.go
+++ b/internal/gateway/protocol.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/ngocp/goterm-control/internal/browserbridge"
+	"github.com/ngocp/goterm-control/internal/credentials"
 )
 
 // Request is a JSON-RPC-style request from a client.
@@ -59,6 +60,10 @@ type StatusResult struct {
 	Channels       []string              `json:"channels"`
 	Runs           []RunInfo             `json:"runs,omitempty"`    // in-flight agent runs (live)
 	Browser        *browserbridge.Status `json:"browser,omitempty"` // Browser Bridge; nil when disabled
+
+	// Accounts is the credential pool this agent rotates sessions across.
+	// Empty when none is configured, which means the ambient credentials.
+	Accounts []credentials.Status `json:"accounts,omitempty"`
 }
 
 // RunInfo describes one in-flight agent run for status consumers

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -14,6 +14,7 @@ type Session struct {
 	UpdatedAt       time.Time `json:"updated_at"`
 	ClaudeSessionID string    `json:"claude_session_id,omitempty"`
 	Provider        string    `json:"provider,omitempty"` // CLI that owns ClaudeSessionID ("claude", "codex")
+	Account         string    `json:"account,omitempty"`  // credential pool entry this session is pinned to
 	MessageCount    int       `json:"message_count"`
 	InputTokens     int       `json:"input_tokens"`
 	OutputTokens    int       `json:"output_tokens"`
@@ -57,6 +58,7 @@ type SessionSnapshot struct {
 	UpdatedAt       time.Time
 	ClaudeSessionID string
 	Provider        string
+	Account         string
 	MessageCount    int
 	InputTokens     int
 	OutputTokens    int
@@ -125,6 +127,25 @@ func (s *Session) SetProvider(name string) {
 	s.UpdatedAt = time.Now()
 }
 
+// GetAccount returns the credential pool entry this session is pinned to.
+// Empty means it was started before a pool existed, or with none configured —
+// the ambient credentials.
+func (s *Session) GetAccount() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Account
+}
+
+// SetAccount pins the session to a pool entry. Called once, when the CLI
+// session is created: both backends store the conversation inside the
+// account's own directory, so this is the only place it can ever be read from.
+func (s *Session) SetAccount(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Account = name
+	s.UpdatedAt = time.Now()
+}
+
 // IncrementMessages increments the turn counter after each exchange.
 func (s *Session) IncrementMessages() {
 	s.mu.Lock()
@@ -178,6 +199,9 @@ func (s *Session) Reset() {
 	defer s.mu.Unlock()
 	s.ClaudeSessionID = ""
 	s.Provider = ""
+	// The CLI session is gone, so the pin that pointed at where it lived must
+	// go too: the next turn picks an account fresh.
+	s.Account = ""
 	s.MessageCount = 0
 	s.MemoryFlushed = false
 	s.lastContextTokens = 0
@@ -305,6 +329,7 @@ func (s *Session) Snapshot() SessionSnapshot {
 		UpdatedAt:       s.UpdatedAt,
 		ClaudeSessionID: s.ClaudeSessionID,
 		Provider:        s.Provider,
+		Account:         s.Account,
 		MessageCount:    s.MessageCount,
 		InputTokens:     s.InputTokens,
 		OutputTokens:    s.OutputTokens,

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const schemaVersion = 6
+const schemaVersion = 7
 
 // conversationDDL is shared by fresh installs (via ddl) and the v5→v6
 // migration, so the two can never drift apart.
@@ -50,7 +50,8 @@ var ddl = append([]string{
 		label             TEXT DEFAULT '',
 		seq               INTEGER DEFAULT 0,
 		memory_flushed    INTEGER DEFAULT 0,
-		provider          TEXT DEFAULT 'claude'
+		provider          TEXT DEFAULT 'claude',
+		account           TEXT DEFAULT ''
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_sessions_chat ON sessions(chat_id)`,
 
@@ -143,9 +144,30 @@ func (db *DB) migrate() error {
 		if err := db.migrateV5ToV6(); err != nil {
 			return fmt.Errorf("migrate v5→v6: %w", err)
 		}
-		return db.setVersion(6)
+		if err := db.setVersion(6); err != nil {
+			return err
+		}
+		ver = 6
+	}
+	if ver < 7 {
+		if err := db.migrateV6ToV7(); err != nil {
+			return fmt.Errorf("migrate v6→v7: %w", err)
+		}
+		return db.setVersion(7)
 	}
 	return nil
+}
+
+// migrateV6ToV7 adds the account column: which credential in the pool a
+// session runs under. Both CLIs keep their session store inside the same
+// directory as their credentials, so a session cannot be read from any other
+// account — the pin is what sends every later turn back to the right one.
+//
+// Existing rows stay empty, meaning "the ambient credentials", which is what
+// they were started on.
+func (db *DB) migrateV6ToV7() error {
+	_, err := db.conn.Exec(`ALTER TABLE sessions ADD COLUMN account TEXT DEFAULT ''`)
+	return err
 }
 
 // migrateV5ToV6 introduces conversations and channel bindings, and folds the

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -23,7 +23,7 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 	rows, err := s.db.conn.Query(`SELECT
 		id, chat_id, created_at, updated_at, claude_session_id,
 		message_count, input_tokens, output_tokens, compact_summary,
-		label, seq, memory_flushed, provider
+		label, seq, memory_flushed, provider, account
 		FROM sessions`)
 	if err != nil {
 		return nil, fmt.Errorf("query sessions: %w", err)
@@ -38,11 +38,11 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 			createdStr, updatedStr       string
 			msgCount, inTok, outTok, seq int
 			memFlushed                   int
-			provider                     string
+			provider, account            string
 		)
 		if err := rows.Scan(&id, &chatID, &createdStr, &updatedStr, &claudeID,
 			&msgCount, &inTok, &outTok, &summary, &label, &seq, &memFlushed,
-			&provider); err != nil {
+			&provider, &account); err != nil {
 			continue
 		}
 
@@ -51,6 +51,7 @@ func (s *SQLiteSessionStore) Load() (map[int64]*session.ChatState, error) {
 
 		sess := session.NewFromDB(id, chatID, created, updated, claudeID, msgCount, inTok, outTok, summary, label, seq, memFlushed != 0)
 		sess.Provider = provider
+		sess.Account = account
 
 		cs, ok := chats[chatID]
 		if !ok {
@@ -115,12 +116,13 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 	sessStmt, err := tx.Prepare(`INSERT INTO sessions
 		(id, chat_id, created_at, updated_at, claude_session_id,
 		 message_count, input_tokens, output_tokens, compact_summary, label, seq,
-		 memory_flushed, provider)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 memory_flushed, provider, account)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			updated_at = excluded.updated_at,
 			claude_session_id = excluded.claude_session_id,
 			provider = excluded.provider,
+			account = excluded.account,
 			message_count = excluded.message_count,
 			input_tokens = excluded.input_tokens,
 			output_tokens = excluded.output_tokens,
@@ -155,7 +157,7 @@ func (s *SQLiteSessionStore) Save(chats map[int64]*session.ChatState) error {
 				snap.CreatedAt.Format(time.RFC3339), snap.UpdatedAt.Format(time.RFC3339),
 				snap.ClaudeSessionID, snap.MessageCount,
 				snap.InputTokens, snap.OutputTokens, snap.CompactSummary,
-				snap.Label, snap.Seq, memFlushed, snap.Provider,
+				snap.Label, snap.Seq, memFlushed, snap.Provider, snap.Account,
 			)
 			if err != nil {
 				return fmt.Errorf("upsert session %s: %w", snap.ID, err)


### PR DESCRIPTION
Both backends stay where they are — agent 1 on claude, agent 2 on codex — and each can now spread its work over several accounts instead of one.

## The constraint that shaped the design

I measured this against both CLIs rather than assuming. **They keep their session store inside the directory that holds their credentials:**

| CLI | Directory | Contains |
|---|---|---|
| claude | `CLAUDE_CONFIG_DIR` | the login **and** `sessions/`, `projects/` |
| codex | `CODEX_HOME` | the login **and** the thread database |

Pointing either at a fresh directory produced a new session store beside a "Not logged in" error.

So **a conversation cannot be read from any other account**, and rotating per turn would silently abandon it.

Rotation is therefore **per session**: an account is chosen when the session starts, pinned, and every later turn returns there. New sessions take the least recently used healthy account, so load spreads instead of piling onto the first entry.

Demonstrated end to end:

```
session 1 → acct-a        resume ×3 → always acct-b ✓
session 2 → acct-b        env: [PATH=/bin CLAUDE_CONFIG_DIR=/tmp/pool/a]
session 3 → acct-a              (ambient ANTHROPIC_API_KEY removed)
```

## Failure semantics, and why each way

- **Rate limit** → that account cools down so *new* sessions avoid it. Sessions already pinned to it **stay and surface the error** — their history is not anywhere else, so moving them would hand the user a blank conversation.
- **Only account-specific signals count** (`429`, `rate limit`, `quota`, `usage limit`). A server-side `overloaded` is the provider's own capacity problem and must not sideline a working account. A cancelled turn is the user stopping the agent, not the account failing.
- **Everything cooling** → still try the one recovering soonest. A cooldown is a guess about someone else's rate limiter, not a fact, and idling on a guess is worse.
- **Unknown pin** → an error, not a silent rehome. Renaming or removing an account strands its sessions; failing loudly beats a blank conversation under a different login mid-thread.

## Account shapes

```yaml
accounts:
  cooldown_minutes: 15
  pool:
    - name: "personal"                    # claude OAuth subscription
      config_dir: "~/.claude"
    - name: "work"
      config_dir: "~/.claude-work"
    - name: "key-a"                       # claude API key, secret stays out of the file
      api_key_env: "ANTHROPIC_KEY_A"
    - name: "codex-main"                  # only used by an agent whose provider is codex
      provider: "codex"
      config_dir: "~/.codex"
```

Entries carry a provider and an agent only uses its own, so one config file describes both backends.

## Backwards compatible

With no `accounts:` section the pool is empty and both clients run on the ambient credentials, byte for byte as before. **Verified against the two live configs**, which have no such section:

```
~/.bomclaw/config.yaml    provider=claude  pool empty=true
~/.bomclaw2/config.yaml   provider=codex   pool empty=true
```

Sessions gained an `account` column (schema **v7**). Existing rows stay empty — the ambient credentials, which is what they were started on.

## Visibility

```
$ bomclaw accounts
BomClaw (agent 1) · provider claude

  ACCOUNT   SESSIONS  LAST USED  STATE
  personal  7         14:22:01   ready
  work      3         14:19:44   cooling 12m0s

  work: 429 rate limit exceeded
```

Same data on `/api/status` under `accounts`, for the dashboard and menu bar.

## Tests

Covering the parts that are easy to get subtly wrong: the empty pool being a true no-op, provider filtering, the pin surviving a cooldown, the unknown pin failing, rate-limit classification (including what must *not* count), and the env overrides for each account shape.

**Two of them caught real bugs while writing this** — a zero account that still stripped `ANTHROPIC_API_KEY`, and `Zero()` keyed on the name so a credential-bearing account read as ambient.

`go build ./... && go test ./...` green.

## One thing worth reading before using it

The docs say this plainly: spreading your **own** accounts to manage rate limits is ordinary capacity work; collecting accounts specifically to exceed per-account limits is a different thing that both providers' terms speak to. The feature does not know the difference — it rotates whatever you give it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)