### PR TITLE
feat(taskrunner): long tasks finish — runs resume their session, stay visible, ring over HTTP (P0 2/2)

### DIFF
--- a/cmd/bomclaw/coordcmd.go
+++ b/cmd/bomclaw/coordcmd.go
@@ -150,6 +150,111 @@ func runTask(args []string) {
 		}
 		fmt.Printf("%s → %s\n", *id, state)
 
+	case "progress":
+		// The agent's own "here is how far I got". Fed into the next run's
+		// prompt, so a run that hits its time cap loses nothing it wrote down.
+		fs := flag.NewFlagSet("task progress", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		id := fs.String("id", "", "Task id (required)")
+		note := fs.String("note", "", "Where the work stands and what is left (required)")
+		attempts := fs.Int("attempts", 0, "The attempts value from claim (default: read from the task)")
+		fs.Parse(rest)
+		if *note == "" && fs.NArg() > 0 {
+			*note = strings.Join(fs.Args(), " ")
+		}
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		if *attempts == 0 {
+			*attempts = currentAttempts(db, *id, "task progress")
+		}
+		if err := db.SetCheckpoint(*id, requireAgent(*agent), *attempts, *note); err != nil {
+			fmt.Fprintf(os.Stderr, "task progress: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s checkpoint recorded\n", *id)
+
+	case "block":
+		// Park the task until a person answers or its children finish. The
+		// run ends right after; the system calls you back when it is unblocked.
+		fs := flag.NewFlagSet("task block", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		id := fs.String("id", "", "Task id (required)")
+		on := fs.String("on", coord.BlockedOnHuman, "What it waits for: human | children")
+		note := fs.String("note", "", "What you need (required for --on human)")
+		attempts := fs.Int("attempts", 0, "The attempts value from claim (default: read from the task)")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		if *attempts == 0 {
+			*attempts = currentAttempts(db, *id, "task block")
+		}
+		if err := db.BlockTask(*id, requireAgent(*agent), *attempts, *on, *note); err != nil {
+			fmt.Fprintf(os.Stderr, "task block: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s → blocked on %s\n", *id, *on)
+
+	case "unblock", "answer":
+		// A person (or the last child) freeing a blocked task. --note is the
+		// answer; it lands in the checkpoint so the next run reads it.
+		fs := flag.NewFlagSet("task "+sub, flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		id := fs.String("id", "", "Task id (required)")
+		note := fs.String("note", "", "The answer, or why it is free now")
+		fs.Parse(rest)
+		if *note == "" && fs.NArg() > 0 {
+			*note = strings.Join(fs.Args(), " ")
+		}
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		by := *agent
+		if strings.TrimSpace(by) == "" {
+			by = "human"
+		}
+		if *note != "" {
+			// Append the answer under the agent's own checkpoint rather than
+			// replacing it: the next run needs both.
+			if t, err := db.GetTask(*id); err == nil {
+				merged := strings.TrimSpace(t.Checkpoint)
+				if merged != "" {
+					merged += "\n\n"
+				}
+				merged += "Answer from " + by + ": " + *note
+				_, _ = db.Conn().Exec(`UPDATE tasks SET checkpoint = ? WHERE id = ?`, merged, *id)
+			}
+		}
+		if err := db.UnblockTask(*id, by, *note); err != nil {
+			fmt.Fprintf(os.Stderr, "task %s: %v\n", sub, err)
+			os.Exit(1)
+		}
+		gateway.NotifyAgents(db, "", "", "about unblocked "+*id)
+		fmt.Printf("%s → submitted\n", *id)
+
+	case "resume":
+		// Reopen a task the system gave up on (exhausted attempts or
+		// continuations). A person's call; grants more of whichever ran out.
+		fs := flag.NewFlagSet("task resume", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		id := fs.String("id", "", "Task id (required)")
+		more := fs.Int("more", 5, "How many more attempts/continuations to allow")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		by := *agent
+		if strings.TrimSpace(by) == "" {
+			by = "human"
+		}
+		if err := db.ResumeTask(*id, by, *more); err != nil {
+			fmt.Fprintf(os.Stderr, "task resume: %v\n", err)
+			os.Exit(1)
+		}
+		gateway.NotifyAgents(db, "", "", "about resumed "+*id)
+		fmt.Printf("%s → submitted (+%d)\n", *id, *more)
+
 	case "list":
 		fs := flag.NewFlagSet("task list", flag.ExitOnError)
 		agent, dbPath := agentFlag(fs), dbFlag(fs)
@@ -204,14 +309,43 @@ func runTask(args []string) {
 			os.Exit(1)
 		}
 		events, _ := db.TaskEvents(*id)
-		fmt.Printf("%s  [%s]  %s\n", task.ID, task.State, task.Title)
-		fmt.Printf("from %s → %s   attempts %d/%d   depth %d\n",
-			task.CreatedBy, orAny(task.ClaimedBy, task.AssignedTo), task.Attempts, task.MaxAttempts, task.Depth)
+		runs, _ := db.TaskRuns(*id)
+		state := task.State
+		if task.FailReason != "" {
+			state += " (" + task.FailReason + ")"
+		} else if task.BlockedOn != "" {
+			state += " on " + task.BlockedOn
+		}
+		fmt.Printf("%s  [%s]  %s\n", task.ID, state, task.Title)
+		fmt.Printf("from %s → %s   attempts %d/%d   continuations %d/%d   depth %d   kind %s\n",
+			task.CreatedBy, orAny(task.ClaimedBy, task.AssignedTo), task.Attempts, task.MaxAttempts,
+			task.Continuations, task.MaxContinuations, task.Depth, task.Kind)
+		if ref := coord.ParseSessionRef(task.SessionRef); ref.SessionID != "" {
+			fmt.Printf("session: %s/%s%s (next run resumes it on %s)\n",
+				ref.Provider, shortID(ref.SessionID), accountSuffix(ref.Account), orAny(task.AssignedTo, "any agent"))
+		}
 		if task.Body != "" {
 			fmt.Printf("\n%s\n", task.Body)
 		}
+		if task.Checkpoint != "" {
+			fmt.Printf("\ncheckpoint:\n%s\n", task.Checkpoint)
+		}
 		if task.Result != "" {
 			fmt.Printf("\nresult:\n%s\n", task.Result)
+		}
+		if len(runs) > 0 {
+			fmt.Println("\nruns:")
+			for i, r := range runs {
+				dur := "…"
+				if !r.EndedAt.IsZero() {
+					dur = r.EndedAt.Sub(r.StartedAt).Round(time.Second).String()
+				}
+				line := fmt.Sprintf("  %d. %s  %-10s %-8s %s", i+1, r.StartedAt.Local().Format("15:04:05"), r.Liveness, dur, r.AgentID)
+				if r.Note != "" {
+					line += "  — " + truncate(r.Note, 70)
+				}
+				fmt.Println(line)
+			}
 		}
 		if len(events) > 0 {
 			fmt.Println("\nhistory:")
@@ -227,6 +361,31 @@ func runTask(args []string) {
 	}
 }
 
+// currentAttempts reads the fencing token off the row when the caller did not
+// pass one — correct for the common single-claim case, same as `task done`.
+func currentAttempts(db *coord.DB, id, cmd string) int {
+	t, err := db.GetTask(id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, err)
+		os.Exit(1)
+	}
+	return t.Attempts
+}
+
+func shortID(s string) string {
+	if len(s) > 12 {
+		return s[:12] + "…"
+	}
+	return s
+}
+
+func accountSuffix(a string) string {
+	if a == "" {
+		return ""
+	}
+	return " (account " + a + ")"
+}
+
 func taskUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: bomclaw task <command>
 
@@ -234,8 +393,12 @@ func taskUsage() {
   claim  [--json]                                           take the next claimable task
   done   --id ID [--result R] [--attempts N]                finish it
   fail   --id ID [--result R] [--attempts N]                give up on it
+  progress --id ID --note "..."                             record how far you got (fed to the next run)
+  block  --id ID --on human|children [--note "..."]         park it until answered / children finish
+  answer --id ID --note "..."                               (person) unblock with an answer
+  resume --id ID [--more N]                                 (person) reopen a task the system gave up on
   list   [--state S] [--mine] [--limit N]                   see the queue
-  show   --id ID                                            one task with its history
+  show   --id ID                                            one task: runs, checkpoint, history
 
 Every command accepts --agent (default $BOMCLAW_AGENT_ID) and --db.`)
 }

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -391,8 +391,14 @@ func runGateway(args []string) {
 		// Dashboard messages run through the bot's turn engine, so both
 		// channels share one execution path: CLI tool loop, memory, trace.
 		deps.Turn = tgBot.Handler()
-		deps.Runs = func() []gateway.RunInfo {
-			var out []gateway.RunInfo
+	}
+	// Everything running right now, from both sources: chat turns and claimed
+	// tasks. The tray's awake-while-running mode, `bomclaw status` and the
+	// dashboard all read this list — a task run missing from it meant the Mac
+	// could sleep in the middle of one.
+	deps.Runs = func() []gateway.RunInfo {
+		var out []gateway.RunInfo
+		if tgBot != nil {
 			for _, s := range tgBot.Sessions().List() {
 				info := s.RunInfo()
 				if !info.Running {
@@ -406,10 +412,24 @@ func runGateway(args []string) {
 					LastTool:  info.LastTool,
 					ToolCount: info.ToolCount,
 					StartedAt: info.StartedAt.Format(time.RFC3339),
+					Kind:      "chat",
 				})
 			}
-			return out
 		}
+		for _, s := range runner.Live() {
+			info := s.RunInfo()
+			out = append(out, gateway.RunInfo{
+				ChatID:    s.ChatID,
+				SessionID: s.ID,
+				Task:      info.CurrentTask,
+				LastTool:  info.LastTool,
+				ToolCount: info.ToolCount,
+				StartedAt: info.StartedAt.Format(time.RFC3339),
+				Kind:      "task",
+				TaskID:    strings.TrimPrefix(s.ID, "task_"),
+			})
+		}
+		return out
 	}
 
 	srv := gateway.NewServer(addr, gateway.NewMethodHandler(deps), gateway.NewStreamSendHandler(deps), resolveDashboardDir(), authMgr)
@@ -432,10 +452,29 @@ func runGateway(args []string) {
 		// else would tell a browser showing that session to refresh.
 		tgBot.Handler().SetTurnListener(func(ev bot.TurnEvent) {
 			data, _ := json.Marshal(map[string]any{
-				"session_id": ev.SessionID, "chat_id": ev.ChatID, "phase": ev.Phase,
+				"session_id": ev.SessionID, "chat_id": ev.ChatID, "phase": ev.Phase, "kind": "chat",
 			})
 			srv.Broadcast(gateway.StreamEvent{Type: "event", Event: "session.turn", Data: string(data)})
 		})
+	}
+	// Task runs ride the same event so the task board updates the moment a run
+	// starts or ends, instead of on its next poll.
+	runner.SetEventListener(func(ev taskrunner.Event) {
+		data, _ := json.Marshal(map[string]any{
+			"session_id": ev.SessionID, "chat_id": -1, "phase": ev.Phase, "kind": "task", "task_id": ev.TaskID,
+		})
+		srv.Broadcast(gateway.StreamEvent{Type: "event", Event: "session.turn", Data: string(data)})
+	})
+
+	if coordDB != nil {
+		// The doorbell a peer rings when it queues work for this agent. Plain
+		// HTTP behind the same rule as /api/status — a login session, or a
+		// direct loopback caller — because the /ws route it used to go through
+		// refuses unauthenticated sockets whenever dashboard auth is on, and it
+		// is on by default, so every cross-agent poke was a 401. Mounted even
+		// when this agent does not claim tasks (runner nil → Poke is a no-op),
+		// so a peer never gets a 404 for ringing.
+		srv.Handle("/api/tasks/poke", authMgr.RequireAuthExceptLocal(gateway.PokeHandler(runner.Poke)))
 	}
 
 	// Start Telegram bot polling in background

--- a/config.yaml
+++ b/config.yaml
@@ -159,8 +159,12 @@ claude:
     editing. The readable copy lives at ~/goterm-shared/NOTES.md and is
     regenerated on every write, so do not edit that file by hand.
 
-    Do not create tasks in a loop. If finishing a task suggests more work, say
-    so in the result and let a person decide.
+    Do not create tasks to continue your own work: when you are running a task
+    and it is not finished, record progress with `bomclaw task progress` and
+    return — the system calls you back with your notes and your conversation.
+    Create a task only for work a peer can do, and never from inside a task at
+    depth 5. If finishing a task suggests more work, say so in the result and
+    let a person decide.
 
 # Built-in Claude models (opus, sonnet, haiku) are always available.
 # Use models.default to override the default, or models.custom to add more.

--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { Task, TaskDetail } from './types'
-import { ago, taskStateStyle, truncate } from './format'
+import { ago, runLivenessStyle, taskStateStyle, truncate } from './format'
+import { useStore } from '../stores/store'
 
 type Call = (method: string, params?: any) => Promise<any>
 
@@ -8,11 +9,21 @@ type Call = (method: string, params?: any) => Promise<any>
 // waiting, in flight, and finished.
 const LANES: { key: string; label: string; states: string[] }[] = [
   { key: 'queued', label: 'Queued', states: ['submitted'] },
-  { key: 'active', label: 'In flight', states: ['working', 'input-required'] },
+  { key: 'active', label: 'In flight', states: ['working', 'input-required', 'blocked'] },
   { key: 'done', label: 'Finished', states: ['completed', 'failed', 'canceled', 'rejected'] },
 ]
 
+// FAIL_REASON says why the SYSTEM gave up, in words a person acts on.
+const FAIL_REASON: Record<string, string> = {
+  'exhausted': 'every attempt ended without a result',
+  'continuations-exhausted': 'ran out of continuations — `bomclaw task resume` to grant more',
+  'empty-exhausted': 'kept returning nothing',
+}
+
 function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
+  // A lapsed lease on a task that still has attempts WILL be reclaimed. One
+  // that has none is failed by the reaper and shows up as failed — the old
+  // "will be reclaimed" on an exhausted task was a lie.
   const leaseExpired = task.state === 'working' && new Date(task.lease_until).getTime() < Date.now()
   return (
     <button
@@ -36,9 +47,20 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
         <span className="font-mono">{task.claimed_by || task.assigned_to || 'any'}</span>
         <span className="ml-auto">{ago(task.created_at)}</span>
       </div>
-      {(task.attempts > 1 || leaseExpired) && (
+      {task.state === 'failed' && task.fail_reason && (
+        <div className="mt-1.5 text-[11px] text-red-400">{FAIL_REASON[task.fail_reason] ?? task.fail_reason}</div>
+      )}
+      {task.state === 'blocked' && (
+        <div className="mt-1.5 text-[11px] text-violet-300">waiting on {task.blocked_on || 'a person'}</div>
+      )}
+      {task.state !== 'failed' && (task.attempts > 1 || task.continuations > 0 || leaseExpired) && (
         <div className="mt-1.5 text-[11px] text-amber-400">
-          {leaseExpired ? 'lease expired — will be reclaimed' : `attempt ${task.attempts}/${task.max_attempts}`}
+          {leaseExpired
+            ? 'lease lapsed — will be reclaimed'
+            : [
+                task.continuations > 0 ? `run ${task.continuations + 1}` : null,
+                task.attempts > 1 ? `attempt ${task.attempts}/${task.max_attempts}` : null,
+              ].filter(Boolean).join(' · ')}
         </div>
       )}
     </button>
@@ -73,8 +95,22 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
     }
   }
 
+  const resume = async () => {
+    setBusy(true)
+    try {
+      await call('tasks.resume', { id, more: 5 })
+      onChanged()
+      onClose()
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const t = detail?.task
   const open = t && !['completed', 'failed', 'canceled', 'rejected'].includes(t.state)
+  const resumable = t && t.state === 'failed' && !!t.fail_reason
 
   return (
     <div className="fixed inset-0 z-40 flex justify-end bg-black/50" onClick={onClose}>
@@ -97,8 +133,20 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
               <div>
                 <div className="flex items-center gap-2">
                   <span className={`text-[10px] px-1.5 py-0.5 rounded ring-1 ${taskStateStyle(t.state)}`}>{t.state}</span>
-                  <span className="text-[11px] text-gray-500">attempt {t.attempts}/{t.max_attempts} · depth {t.depth}</span>
+                  <span className="text-[11px] text-gray-500">
+                    attempt {t.attempts}/{t.max_attempts} · run {t.continuations + 1}/{t.max_continuations} · depth {t.depth}
+                    {t.kind !== 'manual' && <> · {t.kind}</>}
+                  </span>
                 </div>
+                {t.fail_reason && (
+                  <div className="mt-1 text-xs text-red-300">{FAIL_REASON[t.fail_reason] ?? t.fail_reason}</div>
+                )}
+                {t.state === 'blocked' && (
+                  <div className="mt-1 text-xs text-violet-300">
+                    waiting on {t.blocked_on || 'a person'}
+                    {t.blocked_on === 'human' && <> — answer with <code className="text-gray-400">bomclaw task answer --id {t.id} --note "…"</code></>}
+                  </div>
+                )}
                 <h3 className="mt-2 text-base text-gray-100">{t.title}</h3>
                 {t.body && (
                   <pre className="mt-2 text-xs text-gray-300 bg-gray-900 rounded p-3 ring-1 ring-gray-800 whitespace-pre-wrap break-words">
@@ -106,6 +154,15 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
                   </pre>
                 )}
               </div>
+
+              {t.checkpoint && (
+                <div>
+                  <div className="text-[11px] uppercase tracking-wider text-gray-600 mb-1">Checkpoint · fed to the next run</div>
+                  <pre className="text-xs text-gray-300 bg-gray-900 rounded p-3 ring-1 ring-sky-500/20 whitespace-pre-wrap break-words">
+                    {t.checkpoint}
+                  </pre>
+                </div>
+              )}
 
               {t.result && (
                 <div>
@@ -122,6 +179,28 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
                 <div><dt className="text-gray-600">assigned to</dt><dd className="font-mono text-gray-300">{t.assigned_to || 'any'}</dd></div>
                 <div><dt className="text-gray-600">context</dt><dd className="font-mono text-gray-300 truncate">{t.context_id}</dd></div>
               </dl>
+
+              {detail!.runs?.length > 0 && (
+                <div>
+                  <div className="text-[11px] uppercase tracking-wider text-gray-600 mb-2">Runs</div>
+                  <ol className="space-y-1.5">
+                    {detail!.runs.map((r, i) => {
+                      const ended = r.ended_at ? new Date(r.ended_at).getTime() : Date.now()
+                      const secs = Math.max(0, Math.round((ended - new Date(r.started_at).getTime()) / 1000))
+                      const dur = secs >= 60 ? `${Math.round(secs / 60)}m` : `${secs}s`
+                      return (
+                        <li key={r.id} className="flex items-baseline gap-2 text-xs">
+                          <span className="text-gray-600 font-mono shrink-0 w-4">{i + 1}.</span>
+                          <span className={`px-1.5 rounded ring-1 shrink-0 ${runLivenessStyle(r.liveness)}`}>{r.liveness}</span>
+                          <span className="text-gray-500 shrink-0">{dur}</span>
+                          <span className="font-mono text-gray-400 shrink-0">{r.agent_id}</span>
+                          {r.note && <span className="text-gray-500 truncate">{r.note}</span>}
+                        </li>
+                      )
+                    })}
+                  </ol>
+                </div>
+              )}
 
               {detail!.events.length > 0 && (
                 <div>
@@ -142,15 +221,27 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
           )}
         </div>
 
-        {open && (
-          <div className="px-4 py-3 border-t border-gray-800">
-            <button
-              onClick={cancel}
-              disabled={busy}
-              className="px-3 py-1.5 text-sm rounded ring-1 ring-red-500/40 bg-red-500/10 text-red-300 hover:bg-red-500/20 disabled:opacity-50"
-            >
-              Cancel task
-            </button>
+        {(open || resumable) && (
+          <div className="px-4 py-3 border-t border-gray-800 flex gap-2">
+            {open && (
+              <button
+                onClick={cancel}
+                disabled={busy}
+                className="px-3 py-1.5 text-sm rounded ring-1 ring-red-500/40 bg-red-500/10 text-red-300 hover:bg-red-500/20 disabled:opacity-50"
+              >
+                Cancel task
+              </button>
+            )}
+            {resumable && (
+              <button
+                onClick={resume}
+                disabled={busy}
+                className="px-3 py-1.5 text-sm rounded ring-1 ring-sky-500/40 bg-sky-500/10 text-sky-300 hover:bg-sky-500/20 disabled:opacity-50"
+                title="Grant 5 more attempts/continuations and put it back in the queue"
+              >
+                Resume (+5)
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -180,6 +271,13 @@ export default function TaskBoard({ call, agents }: { call: Call; agents: string
     const id = setInterval(load, 5000)
     return () => clearInterval(id)
   }, [load])
+
+  // A task run starting or finishing anywhere is pushed as session.turn with
+  // kind "task"; reload at once instead of waiting for the poll.
+  const externalTurn = useStore(s => s.externalTurn)
+  useEffect(() => {
+    if (externalTurn?.kind === 'task') load()
+  }, [externalTurn, load])
 
   const create = async () => {
     if (!title.trim()) return

--- a/dashboard/src/admin/format.ts
+++ b/dashboard/src/admin/format.ts
@@ -57,6 +57,25 @@ export const TASK_STATE_STYLE: Record<string, string> = {
   canceled:         'bg-gray-500/15 text-gray-400 ring-gray-500/30',
   rejected:         'bg-orange-500/15 text-orange-300 ring-orange-500/30',
   'input-required': 'bg-violet-500/15 text-violet-300 ring-violet-500/30',
+  blocked:          'bg-violet-500/15 text-violet-300 ring-violet-500/30',
+}
+
+// Run liveness colours: green for done, amber for "call me back", violet for
+// waiting, red for broke, grey for the run itself being cut off.
+export const RUN_LIVENESS_STYLE: Record<string, string> = {
+  running:   'bg-amber-500/15 text-amber-300 ring-amber-500/30',
+  completed: 'bg-emerald-500/15 text-emerald-300 ring-emerald-500/30',
+  advanced:  'bg-sky-500/15 text-sky-300 ring-sky-500/30',
+  plan_only: 'bg-orange-500/15 text-orange-300 ring-orange-500/30',
+  empty:     'bg-orange-500/15 text-orange-300 ring-orange-500/30',
+  blocked:   'bg-violet-500/15 text-violet-300 ring-violet-500/30',
+  failed:    'bg-red-500/15 text-red-300 ring-red-500/30',
+  timed_out: 'bg-red-500/15 text-red-300 ring-red-500/30',
+  canceled:  'bg-gray-500/15 text-gray-400 ring-gray-500/30',
+}
+
+export function runLivenessStyle(l: string): string {
+  return RUN_LIVENESS_STYLE[l] ?? 'bg-gray-500/15 text-gray-400 ring-gray-500/30'
 }
 
 export function taskStateStyle(state: string): string {

--- a/dashboard/src/admin/types.ts
+++ b/dashboard/src/admin/types.ts
@@ -67,7 +67,25 @@ export interface Overview {
 
 export type TaskState =
   | 'submitted' | 'working' | 'completed'
-  | 'failed' | 'canceled' | 'rejected' | 'input-required'
+  | 'failed' | 'canceled' | 'rejected' | 'input-required' | 'blocked'
+
+// How ONE run of a task ended — a different vocabulary from TaskState on
+// purpose. A task is where the work stands; a run is one bounded attempt at it.
+export type RunLiveness =
+  | 'running' | 'completed' | 'advanced' | 'plan_only' | 'empty'
+  | 'blocked' | 'failed' | 'timed_out' | 'canceled'
+
+export interface TaskRun {
+  id: string
+  task_id: string
+  agent_id: string
+  attempt: number
+  liveness: RunLiveness
+  trace_id?: string
+  started_at: string
+  ended_at?: string
+  note?: string
+}
 
 export interface Task {
   id: string
@@ -87,6 +105,16 @@ export interface Task {
   depth: number
   created_at: string
   updated_at: string
+  // A task is many runs; these survive between them.
+  parent_id?: string
+  kind: 'manual' | 'scheduled' | 'heartbeat' | 'sub'
+  schedule_id?: string
+  checkpoint?: string
+  session_ref?: string
+  continuations: number
+  max_continuations: number
+  blocked_on?: 'children' | 'human' | ''
+  fail_reason?: 'exhausted' | 'continuations-exhausted' | 'empty-exhausted' | ''
 }
 
 export interface TaskEvent {
@@ -102,6 +130,7 @@ export interface TaskEvent {
 export interface TaskDetail {
   task: Task
   events: TaskEvent[]
+  runs: TaskRun[]
 }
 
 export interface Message {

--- a/dashboard/src/hooks/useGateway.ts
+++ b/dashboard/src/hooks/useGateway.ts
@@ -63,7 +63,9 @@ export function useGateway() {
           if (msg.event === 'session.turn') {
             try {
               const d = JSON.parse(msg.data)
-              useStore.getState().setExternalTurn({ sessionId: d.session_id, phase: d.phase, at: Date.now() })
+              useStore.getState().setExternalTurn({
+                sessionId: d.session_id, phase: d.phase, kind: d.kind, taskId: d.task_id, at: Date.now(),
+              })
             } catch {}
           }
           return

--- a/dashboard/src/stores/store.ts
+++ b/dashboard/src/stores/store.ts
@@ -80,6 +80,8 @@ interface Store {
 export type ExternalTurn = {
   sessionId: string
   phase: 'started' | 'finished'
+  kind?: 'chat' | 'task'   // absent = chat (older gateways)
+  taskId?: string
   at: number
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,6 +26,7 @@ All messages use the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) proto
 |---|---|---|
 | `/health` | GET | Health check, returns `{"status": "ok"}` |
 | `/ws` | WebSocket | JSON-RPC WebSocket endpoint |
+| `/api/tasks/poke` | POST | Doorbell: ask this agent to check the shared task queue now. Login session or direct loopback caller; peers on the same machine use it after queuing work |
 | `/*` | GET | Serves dashboard static files |
 
 ## JSON-RPC Methods

--- a/internal/coord/taskruns.go
+++ b/internal/coord/taskruns.go
@@ -140,6 +140,18 @@ func (db *DB) FinishRun(runID string, o RunOutcome) (*Task, error) {
 		return t, ErrTaskFinished
 	}
 
+	// The agent parked the task itself with `bomclaw task block` during this
+	// run: the task is already where it should be, only the run needs closing.
+	if t.State == TaskBlocked && t.ClaimedBy == run.AgentID && t.Attempts == run.Attempt {
+		if err := closeRun(RunBlocked, "blocked on "+t.BlockedOn); err != nil {
+			return nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return t, nil
+	}
+
 	// Fencing: still ours?
 	if t.ClaimedBy != run.AgentID || t.Attempts != run.Attempt || t.State != TaskWorking {
 		if err := closeRun(o.Liveness, "lease was lost; result discarded"); err != nil {

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -421,6 +421,45 @@ func (db *DB) SetSessionRef(taskID, agentID string, attempts int, ref SessionRef
 	return nil
 }
 
+// BlockTask parks a task the agent holds until a person or its children free
+// it. The agent types this from inside a run (`bomclaw task block`); the run
+// then ends and FinishRun records it as blocked without touching the task
+// again. Fenced like every other write from a holder.
+func (db *DB) BlockTask(taskID, agentID string, attempts int, on, note string) error {
+	switch on {
+	case BlockedOnChildren, BlockedOnHuman:
+	default:
+		return fmt.Errorf("coord: blocked_on must be %q or %q", BlockedOnChildren, BlockedOnHuman)
+	}
+	now := time.Now()
+	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, blocked_on = ?, lease_until = ?,
+			checkpoint = CASE WHEN ? != '' THEN ? ELSE checkpoint END, updated_at = ?
+		WHERE id = ? AND claimed_by = ? AND attempts = ? AND state = ?`,
+		TaskBlocked, on, ts(now), note, note, ts(now), taskID, agentID, attempts, TaskWorking)
+	if err != nil {
+		return fmt.Errorf("block task: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrLostLease
+	}
+	return db.appendEvent(taskID, agentID, TaskWorking, TaskBlocked, "blocked on "+on+": "+truncateNote(note))
+}
+
+// UnblockTask returns a blocked task to the queue — a person answering, or the
+// last child finishing. Not fenced: nobody holds a blocked task.
+func (db *DB) UnblockTask(taskID, byAgent, note string) error {
+	now := time.Now()
+	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, blocked_on = '', lease_until = ?, updated_at = ?
+		WHERE id = ? AND state = ?`, TaskSubmitted, ts(now), ts(now), taskID, TaskBlocked)
+	if err != nil {
+		return fmt.Errorf("unblock task: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("coord: task %s is not blocked", taskID)
+	}
+	return db.appendEvent(taskID, byAgent, TaskBlocked, TaskSubmitted, "unblocked: "+truncateNote(note))
+}
+
 // ReapExhausted moves tasks that have used every attempt into failed. Until
 // now they sat in `working` with an expired lease: unclaimable (ClaimTask
 // filters on attempts), yet counted as open and shown as "will be reclaimed".

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -126,10 +126,12 @@ type taskIDParams struct {
 	ID string `json:"id"`
 }
 
-// TaskDetail is a task together with its audit trail.
+// TaskDetail is a task together with its audit trail and its run ledger: one
+// row per claim, each saying how that bounded attempt ended.
 type TaskDetail struct {
 	Task   *coord.Task       `json:"task"`
 	Events []coord.TaskEvent `json:"events"`
+	Runs   []coord.TaskRun   `json:"runs"`
 }
 
 func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -148,7 +150,33 @@ func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(TaskDetail{Task: task, Events: events})
+	runs, err := deps.Coord.TaskRuns(p.ID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(TaskDetail{Task: task, Events: events, Runs: runs})
+}
+
+type taskResumeParams struct {
+	ID   string `json:"id"`
+	More int    `json:"more,omitempty"`
+}
+
+// handleTaskResume reopens a task the system gave up on. A person's decision,
+// from the dashboard, so it carries no fencing token.
+func handleTaskResume(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p taskResumeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if err := deps.Coord.ResumeTask(p.ID, deps.AgentID, p.More); err != nil {
+		return nil, err
+	}
+	go NotifyAgents(deps.Coord, "", "", "about resumed "+p.ID)
+	return json.Marshal(map[string]bool{"resumed": true})
 }
 
 type taskCreateParams struct {

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -162,6 +162,8 @@ func NewMethodHandler(deps Deps) MethodHandler {
 			return handleTaskCreate(deps, params)
 		case "tasks.cancel":
 			return handleTaskCancel(deps, params)
+		case "tasks.resume":
+			return handleTaskResume(deps, params)
 		case "messages.list":
 			return handleMessagesList(deps, params)
 		case "messages.send":

--- a/internal/gateway/notify.go
+++ b/internal/gateway/notify.go
@@ -4,47 +4,84 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
-
-	"github.com/gorilla/websocket"
 
 	"github.com/ngocp/goterm-control/internal/coord"
 )
 
-// PokeAgent tells the gateway at wsAddr to check the shared task queue now
+// PokeAgent tells the gateway behind wsAddr to check the shared task queue now
 // instead of waiting out its poll interval.
 //
 // This is a doorbell, not a delivery: the task itself is already committed to
-// the shared database. A failure here — peer down, or its dashboard auth
-// refusing an unauthenticated socket — costs latency and nothing else, because
-// the peer's own poll will find the work anyway. Callers should log it at most.
+// the shared database. A failure here — peer down, wrong address — costs
+// latency and nothing else, because the peer's own poll finds the work anyway.
+// Callers should log it at most.
+//
+// It goes over plain HTTP to /api/tasks/poke rather than the /ws socket. The
+// socket requires a dashboard login cookie whenever gateway.auth is on, which
+// is the shipped default, so every cross-agent poke was being refused with a
+// 401 and hand-offs always waited the full poll interval. The HTTP route sits
+// behind the same rule as /api/status: a login session, or a direct loopback
+// caller — and two agents on one machine are loopback to each other.
 func PokeAgent(wsAddr string) error {
-	if wsAddr == "" {
-		return fmt.Errorf("no address")
-	}
-	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
-	ws, _, err := dialer.Dial(wsAddr, nil)
+	target, err := PokeURL(wsAddr)
 	if err != nil {
-		return fmt.Errorf("dial %s: %w", wsAddr, err)
+		return err
 	}
-	defer ws.Close()
-
-	req := Request{ID: "poke", Method: "tasks.poke"}
-	if err := ws.WriteJSON(req); err != nil {
-		return fmt.Errorf("write: %w", err)
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Post(target, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		return fmt.Errorf("poke %s: %w", target, err)
 	}
-
-	// Read the ack so the peer has actually processed it before we hang up;
-	// without this the close can race the server's read.
-	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
-	var resp Response
-	if err := ws.ReadJSON(&resp); err != nil {
-		return fmt.Errorf("read: %w", err)
-	}
-	if resp.Error != nil {
-		return fmt.Errorf("peer: %s", resp.Error.Message)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("poke %s: HTTP %d", target, resp.StatusCode)
 	}
 	return nil
+}
+
+// PokeURL derives the doorbell endpoint from the address an agent registered
+// (ws://127.0.0.1:18789/ws → http://127.0.0.1:18789/api/tasks/poke). Agents
+// advertise their WebSocket address in the shared database; the HTTP route
+// lives on the same host and port.
+func PokeURL(wsAddr string) (string, error) {
+	if strings.TrimSpace(wsAddr) == "" {
+		return "", fmt.Errorf("no address")
+	}
+	u, err := url.Parse(wsAddr)
+	if err != nil || u.Host == "" {
+		return "", fmt.Errorf("bad agent address %q", wsAddr)
+	}
+	switch u.Scheme {
+	case "ws", "http":
+		u.Scheme = "http"
+	case "wss", "https":
+		u.Scheme = "https"
+	default:
+		return "", fmt.Errorf("bad agent address %q: scheme %s", wsAddr, u.Scheme)
+	}
+	u.Path, u.RawQuery, u.Fragment = "/api/tasks/poke", "", ""
+	return u.String(), nil
+}
+
+// PokeHandler is the HTTP side of the doorbell. poke is the local runner's
+// Poke; a nil-safe no-op when this agent does not claim tasks, so the route can
+// always be mounted and a peer never gets a 404 for ringing.
+func PokeHandler(poke func()) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"POST required"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if poke != nil {
+			poke()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(pokeResult)
+	}
 }
 
 // NotifyTaskCreated rings whoever could pick a new task up. A task addressed to
@@ -57,20 +94,28 @@ func NotifyTaskCreated(cdb *coord.DB, task *coord.Task) {
 	if cdb == nil || task == nil {
 		return
 	}
+	NotifyAgents(cdb, task.AssignedTo, task.CreatedBy, "about "+task.ID)
+}
+
+// NotifyAgents rings the agents that could act: only `only` when set, else
+// every online agent except `skip`. why is for the log line.
+func NotifyAgents(cdb *coord.DB, only, skip, why string) {
+	if cdb == nil {
+		return
+	}
 	agents, err := cdb.ListAgents()
 	if err != nil {
 		return
 	}
 	for _, a := range agents {
-		if !a.Online || a.ID == task.CreatedBy {
+		if !a.Online || a.ID == skip {
 			continue
 		}
-		if task.AssignedTo != "" && a.ID != task.AssignedTo {
+		if only != "" && a.ID != only {
 			continue
 		}
 		if err := PokeAgent(a.WSAddr); err != nil {
-			log.Printf("gateway: could not ring %s about %s (%v) — its poll will pick the task up",
-				a.ID, task.ID, err)
+			log.Printf("gateway: could not ring %s %s (%v) — its poll will pick the work up", a.ID, why, err)
 		}
 	}
 }

--- a/internal/gateway/notify_test.go
+++ b/internal/gateway/notify_test.go
@@ -1,0 +1,78 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPokeURLFromRegisteredAddress(t *testing.T) {
+	cases := map[string]string{
+		"ws://127.0.0.1:18789/ws":     "http://127.0.0.1:18789/api/tasks/poke",
+		"ws://127.0.0.1:18790/ws?x=1": "http://127.0.0.1:18790/api/tasks/poke",
+		"wss://bot.example.org/ws":    "https://bot.example.org/api/tasks/poke",
+		"http://127.0.0.1:18789":      "http://127.0.0.1:18789/api/tasks/poke",
+	}
+	for in, want := range cases {
+		got, err := PokeURL(in)
+		if err != nil || got != want {
+			t.Errorf("PokeURL(%q) = %q, %v; want %q", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"", "not a url", "ftp://x/ws"} {
+		if _, err := PokeURL(bad); err == nil {
+			t.Errorf("PokeURL(%q) should fail", bad)
+		}
+	}
+}
+
+// The doorbell must ring the local runner exactly once per POST, refuse other
+// methods, and stay mountable when this agent does not claim tasks at all.
+func TestPokeHandler(t *testing.T) {
+	rang := 0
+	h := PokeHandler(func() { rang++ })
+
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodPost, "/api/tasks/poke", strings.NewReader("{}")))
+	if rec.Code != http.StatusOK || rang != 1 || !strings.Contains(rec.Body.String(), `"poked":true`) {
+		t.Fatalf("POST: code=%d rang=%d body=%s", rec.Code, rang, rec.Body)
+	}
+
+	rec = httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/api/tasks/poke", nil))
+	if rec.Code != http.StatusMethodNotAllowed || rang != 1 {
+		t.Fatalf("GET should be refused without ringing: code=%d rang=%d", rec.Code, rang)
+	}
+
+	// No runner (auto_claim off): still 200, so a peer never sees a 404 for ringing.
+	rec = httptest.NewRecorder()
+	PokeHandler(nil)(rec, httptest.NewRequest(http.MethodPost, "/api/tasks/poke", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nil poke should still ack, got %d", rec.Code)
+	}
+}
+
+// End to end over a real listener: PokeAgent given the ws address an agent
+// registers must reach the HTTP handler.
+func TestPokeAgentReachesHandlerOverHTTP(t *testing.T) {
+	rang := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tasks/poke" {
+			http.NotFound(w, r)
+			return
+		}
+		PokeHandler(func() { rang <- struct{}{} })(w, r)
+	}))
+	defer srv.Close()
+
+	wsAddr := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	if err := PokeAgent(wsAddr); err != nil {
+		t.Fatalf("PokeAgent(%s): %v", wsAddr, err)
+	}
+	select {
+	case <-rang:
+	default:
+		t.Fatal("handler was not rung")
+	}
+}

--- a/internal/gateway/protocol.go
+++ b/internal/gateway/protocol.go
@@ -76,4 +76,10 @@ type RunInfo struct {
 	LastTool  string `json:"last_tool,omitempty"`
 	ToolCount int    `json:"tool_count"`
 	StartedAt string `json:"started_at"`
+
+	// Kind is "chat" for a conversation turn and "task" for a claimed task
+	// executing in the runner. Until task runs appeared here the tray's
+	// awake-while-running mode let the Mac sleep in the middle of one.
+	Kind   string `json:"kind,omitempty"`
+	TaskID string `json:"task_id,omitempty"`
 }

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -4,10 +4,19 @@
 // The loop is deliberately dumb: poll, claim, run, report. The database is the
 // source of truth — a missed doorbell only costs latency, never the task. That
 // is why the poll exists at all rather than relying on the peer to notify.
+//
+// A task is many runs. Each claim is one run, capped by Config.Timeout; how the
+// run ended (its liveness) is recorded on task_runs, and coord.FinishRun decides
+// what that means for the task — done, call me back, blocked, or failed. What
+// the agent wrote down (`bomclaw task progress`) and the CLI session it used
+// survive between runs, so the next run picks up where this one stopped instead
+// of restarting from the original prompt. See docs/design/scheduling-and-long-tasks.md §5.3.
 package taskrunner
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -32,7 +41,15 @@ type Config struct {
 	AgentID  string
 	Model    string
 	Interval time.Duration // how often to look for work; 0 disables polling
-	Timeout  time.Duration // hard cap on one task's execution
+	Timeout  time.Duration // hard cap on ONE run; the task itself has no cap
+}
+
+// Event announces a task run starting or finishing, so the gateway can push
+// it to open dashboards the way chat turns already are.
+type Event struct {
+	TaskID    string
+	SessionID string
+	Phase     string // "started" | "finished"
 }
 
 // Runner claims and executes tasks for one agent.
@@ -44,6 +61,14 @@ type Runner struct {
 	poke   chan struct{}
 	closed sync.Once
 	done   chan struct{}
+
+	// live holds the session of every run in flight, keyed by task id, so
+	// status consumers (tray, dashboard, `bomclaw status`) can see task runs
+	// alongside chat turns. Until they could, the tray's awake-while-running
+	// mode let the Mac sleep in the middle of a task.
+	live sync.Map
+
+	onEvent func(Event)
 }
 
 // New builds a Runner. A nil db or llm returns nil, which is a working no-op —
@@ -60,6 +85,34 @@ func New(db *coord.DB, llm chat.Client, rec *trace.Recorder, cfg Config) *Runner
 		poke: make(chan struct{}, 1),
 		done: make(chan struct{}),
 	}
+}
+
+// SetEventListener registers the single listener for run events. Delivery is
+// asynchronous: the listener does network writes and must never slow a run.
+func (r *Runner) SetEventListener(fn func(Event)) {
+	if r != nil {
+		r.onEvent = fn
+	}
+}
+
+func (r *Runner) emit(taskID, sessionID, phase string) {
+	if r.onEvent == nil {
+		return
+	}
+	go r.onEvent(Event{TaskID: taskID, SessionID: sessionID, Phase: phase})
+}
+
+// Live returns the sessions of runs in flight right now.
+func (r *Runner) Live() []*session.Session {
+	if r == nil {
+		return nil
+	}
+	var out []*session.Session
+	r.live.Range(func(_, v any) bool {
+		out = append(out, v.(*session.Session))
+		return true
+	})
+	return out
 }
 
 // Poke asks the runner to look for work right now instead of waiting out the
@@ -79,12 +132,13 @@ func (r *Runner) Start(ctx context.Context) {
 	if r == nil {
 		return
 	}
-	log.Printf("taskrunner: claiming tasks for %s every %s", r.cfg.AgentID, r.cfg.Interval)
+	log.Printf("taskrunner: claiming tasks for %s every %s (run cap %s)", r.cfg.AgentID, r.cfg.Interval, r.cfg.Timeout)
 	go func() {
 		defer close(r.done)
 		ticker := time.NewTicker(r.cfg.Interval)
 		defer ticker.Stop()
 		for {
+			r.sweep()
 			// Drain the queue before sleeping again: a peer may have left
 			// several tasks at once.
 			for r.claimAndRun(ctx) {
@@ -110,6 +164,22 @@ func (r *Runner) Wait() {
 	<-r.done
 }
 
+// sweep does the housekeeping the queue needs but no single run owns: fail
+// tasks that have used every attempt (they used to sit in `working` forever),
+// and open up tasks addressed to an agent that has stopped heartbeating.
+func (r *Runner) sweep() {
+	if ids, err := r.db.ReapExhausted(); err != nil {
+		log.Printf("taskrunner: reap: %v", err)
+	} else if len(ids) > 0 {
+		log.Printf("taskrunner: failed %d exhausted task(s): %v", len(ids), ids)
+	}
+	if ids, err := r.db.RelaxDeadAssignments(coord.StaleAfter); err != nil {
+		log.Printf("taskrunner: relax assignments: %v", err)
+	} else if len(ids) > 0 {
+		log.Printf("taskrunner: opened %d task(s) whose assignee is gone: %v", len(ids), ids)
+	}
+}
+
 // claimAndRun takes one task and executes it. It reports whether it found work,
 // so the caller can keep draining.
 func (r *Runner) claimAndRun(ctx context.Context) bool {
@@ -125,7 +195,7 @@ func (r *Runner) claimAndRun(ctx context.Context) bool {
 		return false
 	}
 
-	log.Printf("taskrunner: claimed %s (attempt %d): %s", task.ID, task.Attempts, task.Title)
+	log.Printf("taskrunner: claimed %s (attempt %d, run %d): %s", task.ID, task.Attempts, task.Continuations+1, task.Title)
 	r.execute(ctx, task)
 	return true
 }
@@ -138,28 +208,63 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	stopRenew := r.renewLease(runCtx, task.ID)
 	defer stopRenew()
 
+	// One session per task, kept across runs: the CLI stores the conversation
+	// under this id, so resuming it is what makes run 2 remember run 1.
+	sess := session.New(taskChatID)
+	sess.ID = "task_" + task.ID
+	resumed := false
+	if ref := coord.ParseSessionRef(task.SessionRef); ref.SessionID != "" {
+		// Only the same CLI can resume its own session; a ref from the other
+		// backend (after a provider switch) is simply not used.
+		if ref.Provider == r.llm.Name() {
+			sess.SetSessionID(ref.SessionID)
+			sess.SetProvider(ref.Provider)
+			if ref.Account != "" {
+				sess.SetAccount(ref.Account) // the credential pool honours the pin
+			}
+			resumed = true
+		}
+	}
+
 	span := r.rec.StartTrace("task", coord.RunTypeTask, trace.Meta{
-		SessionID: "task_" + task.ID,
+		SessionID: sess.ID,
 		Model:     r.cfg.Model,
 		Provider:  r.llm.Name(),
 	})
-	span.SetInputs(taskPrompt(task))
+	prompt := taskPrompt(task, r.cfg.Timeout, resumed)
+	span.SetInputs(prompt)
 	if tid := span.TraceID(); tid != "" {
 		if err := r.db.AttachTrace(task.ID, tid); err != nil {
 			log.Printf("taskrunner: attach trace: %v", err)
 		}
 	}
 
-	// A fresh, unregistered session per task: the peer's instruction must not
-	// inherit — or pollute — whatever the agent was chatting about.
-	sess := session.New(taskChatID)
-	sess.ID = "task_" + task.ID
+	run, err := r.db.StartRun(task.ID, r.cfg.AgentID, task.Attempts, span.TraceID())
+	if err != nil {
+		log.Printf("taskrunner: start run for %s: %v", task.ID, err)
+		return
+	}
+
+	// Visible while it runs: status, tray (awake), dashboard.
+	sess.MarkRunning(truncate(task.Title, 60))
+	r.live.Store(task.ID, sess)
+	r.emit(task.ID, sess.ID, "started")
+	defer func() {
+		sess.MarkIdle()
+		r.live.Delete(task.ID)
+		r.emit(task.ID, sess.ID, "finished")
+	}()
 
 	var reply strings.Builder
+	todoPending := false
 	call := span.Child(r.llm.Name(), coord.RunTypeLLM)
-	err := r.llm.SendMessage(runCtx, sess, r.cfg.Model, taskPrompt(task), "", chat.StreamCallbacks{
+	sendErr := r.llm.SendMessage(runCtx, sess, r.cfg.Model, prompt, "", chat.StreamCallbacks{
 		OnText: func(chunk string) { reply.WriteString(chunk) },
 		OnToolCall: func(name, input string) {
+			sess.NoteTool(name)
+			if name == "TodoWrite" && hasPendingTodos(input) {
+				todoPending = true
+			}
 			sp := call.Child(name, coord.RunTypeTool)
 			sp.SetInputs(input)
 			// Tool results are not paired here: the CLI backends report a
@@ -168,26 +273,125 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 		},
 	})
 	in, out := sess.Tokens()
-	call.EndWithTokens(reply.String(), err, in, out)
+	call.EndWithTokens(reply.String(), sendErr, in, out)
 
-	state, result := coord.TaskCompleted, reply.String()
+	// What did the agent do to the task while it ran? Its own commands
+	// (`task done`, `task progress`, `task block`) are the authoritative
+	// signals; everything else is inferred from how the run ended.
+	after, err := r.db.GetTask(task.ID)
 	if err != nil {
-		state = coord.TaskFailed
-		result = fmt.Sprintf("%s\n\nerror: %v", reply.String(), err)
+		log.Printf("taskrunner: reload %s: %v", task.ID, err)
+		after = nil
 	}
-	span.End(result, err)
+	outcome := classify(task, after, sendErr, runCtx.Err(), reply.String(), todoPending)
+	outcome.SessionRef = coord.SessionRef{
+		Provider: r.llm.Name(), SessionID: sess.GetSessionID(), Account: sess.GetAccount(),
+	}
 
-	if finishErr := r.db.FinishTask(task.ID, r.cfg.AgentID, state, result, task.Attempts); finishErr != nil {
-		// ErrLostLease means another agent took over and already answered;
-		// discarding this result is the correct outcome, not a failure.
-		log.Printf("taskrunner: finish %s: %v", task.ID, finishErr)
-		return
+	var spanErr error
+	if outcome.Liveness == coord.RunFailed || outcome.Liveness == coord.RunTimedOut {
+		spanErr = sendErr
+		if spanErr == nil {
+			spanErr = fmt.Errorf("%s", outcome.Liveness)
+		}
 	}
-	log.Printf("taskrunner: %s → %s", task.ID, state)
+	span.End(outcome.Result, spanErr)
+
+	final, finishErr := r.db.FinishRun(run.ID, outcome)
+	switch {
+	case errors.Is(finishErr, coord.ErrLostLease):
+		// Another agent took over and already answered; discarding this
+		// result is the correct outcome, not a failure.
+		log.Printf("taskrunner: %s run %s: %v", task.ID, outcome.Liveness, finishErr)
+	case errors.Is(finishErr, coord.ErrTaskFinished):
+		// The agent (or a person) moved the task to a terminal state during the
+		// run — `bomclaw task done` from inside it, say. The ledger has the run.
+		log.Printf("taskrunner: %s → %s (set during the run)", task.ID, final.State)
+	case finishErr != nil:
+		log.Printf("taskrunner: finish run %s: %v", run.ID, finishErr)
+	default:
+		msg := fmt.Sprintf("taskrunner: %s run %s → task %s", task.ID, outcome.Liveness, final.State)
+		if final.State == coord.TaskSubmitted {
+			msg += fmt.Sprintf(" (continuation %d/%d, pinned to %s)", final.Continuations, final.MaxContinuations, final.AssignedTo)
+		}
+		if final.FailReason != "" {
+			msg += " (" + final.FailReason + ")"
+		}
+		log.Print(msg)
+	}
+}
+
+// classify turns how the run ended into a RunOutcome. Order matters: the
+// agent's own explicit commands win over anything inferred; then the reasons
+// the runtime stopped it; then what the reply looks like.
+func classify(before, after *coord.Task, sendErr, ctxErr error, reply string, todoPending bool) coord.RunOutcome {
+	if after != nil {
+		switch after.State {
+		case coord.TaskCompleted:
+			return coord.RunOutcome{Liveness: coord.RunCompleted, Result: after.Result}
+		case coord.TaskFailed:
+			return coord.RunOutcome{Liveness: coord.RunFailed, Result: after.Result, Note: "agent gave up (task fail)"}
+		case coord.TaskBlocked:
+			return coord.RunOutcome{Liveness: coord.RunBlocked, BlockedOn: after.BlockedOn, Note: after.Checkpoint}
+		}
+	}
+	var checkpoint string
+	if after != nil && after.Checkpoint != before.Checkpoint {
+		checkpoint = after.Checkpoint
+	}
+	reply = strings.TrimSpace(reply)
+
+	switch {
+	case errors.Is(ctxErr, context.DeadlineExceeded) || errors.Is(sendErr, context.DeadlineExceeded):
+		return coord.RunOutcome{Liveness: coord.RunTimedOut, Checkpoint: checkpoint, Result: reply,
+			Note: "hit the run time cap"}
+	case errors.Is(ctxErr, context.Canceled) || errors.Is(sendErr, context.Canceled):
+		return coord.RunOutcome{Liveness: coord.RunCanceled, Checkpoint: checkpoint, Note: "run canceled"}
+	case sendErr != nil:
+		result := reply
+		if result != "" {
+			result += "\n\n"
+		}
+		result += "error: " + sendErr.Error()
+		return coord.RunOutcome{Liveness: coord.RunFailed, Checkpoint: checkpoint, Result: result, Note: sendErr.Error()}
+	case checkpoint != "":
+		// It wrote progress and returned: a long job asking to be called back.
+		return coord.RunOutcome{Liveness: coord.RunAdvanced, Checkpoint: checkpoint, Result: reply}
+	case reply == "":
+		return coord.RunOutcome{Liveness: coord.RunEmpty, Note: "no reply"}
+	case todoPending:
+		// A plan with unfinished items and no progress note: it described the
+		// work instead of doing it. Call it back rather than accept the plan
+		// as the deliverable.
+		return coord.RunOutcome{Liveness: coord.RunPlanOnly, Result: reply, Note: "TodoWrite left items pending"}
+	default:
+		// A plain reply with no commands: the reply IS the deliverable. This is
+		// the pre-P0 behaviour and what a short task still looks like.
+		return coord.RunOutcome{Liveness: coord.RunCompleted, Result: reply}
+	}
+}
+
+// hasPendingTodos reads a TodoWrite input and reports whether any item is not
+// completed. Tolerant of shape: anything unparseable is "no".
+func hasPendingTodos(inputJSON string) bool {
+	var in struct {
+		Todos []struct {
+			Status string `json:"status"`
+		} `json:"todos"`
+	}
+	if json.Unmarshal([]byte(inputJSON), &in) != nil {
+		return false
+	}
+	for _, t := range in.Todos {
+		if t.Status != "" && t.Status != "completed" {
+			return true
+		}
+	}
+	return false
 }
 
 // renewLease keeps the claim alive while the task runs, and returns a stop
-// function. If the lease is lost the renewal simply stops: FinishTask's fencing
+// function. If the lease is lost the renewal simply stops: FinishRun's fencing
 // check is what actually protects the other agent's result.
 func (r *Runner) renewLease(ctx context.Context, taskID string) func() {
 	stop := make(chan struct{})
@@ -211,22 +415,65 @@ func (r *Runner) renewLease(ctx context.Context, taskID string) func() {
 	return sync.OnceFunc(func() { close(stop) })
 }
 
-// taskPrompt turns a queued task into an instruction. The framing matters: the
-// agent must understand this came from a peer, not from the user it chats with,
-// and that its reply is the deliverable rather than conversation.
-func taskPrompt(t *coord.Task) string {
+// taskPrompt turns a queued task into an instruction for ONE run. The framing
+// matters: the agent must understand this came from a peer, not from the user
+// it chats with; that its reply is the deliverable rather than conversation;
+// that the run has a time budget and what to do about it; and, on a later run,
+// where the previous one stopped.
+func taskPrompt(t *coord.Task, budget time.Duration, resumed bool) string {
 	var b strings.Builder
-	b.WriteString("You have picked up a task from the shared queue.\n\n")
-	fmt.Fprintf(&b, "Task id: %s\nRequested by: %s\n\n", t.ID, t.CreatedBy)
+	if t.Continuations > 0 || resumed {
+		fmt.Fprintf(&b, "You are continuing a task from the shared queue (run %d).\n\n", t.Continuations+1)
+	} else {
+		b.WriteString("You have picked up a task from the shared queue.\n\n")
+	}
+	fmt.Fprintf(&b, "Task id: %s\nRequested by: %s\n", t.ID, t.CreatedBy)
+	if t.ParentID != "" {
+		fmt.Fprintf(&b, "Parent task: %s\n", t.ParentID)
+	}
+	fmt.Fprintf(&b, "Context: %s (depth %d of %d)\n\n", t.ContextID, t.Depth, coord.MaxDepth)
 	fmt.Fprintf(&b, "## %s\n", t.Title)
 	if t.Body != "" {
 		b.WriteString("\n")
 		b.WriteString(t.Body)
 		b.WriteString("\n")
 	}
-	b.WriteString("\nDo the work, then reply with the outcome. Your reply is recorded " +
-		"as the task result and is what the requesting agent will read, so state what " +
-		"you did and what you found — do not ask follow-up questions, there is nobody " +
-		"waiting to answer them.")
+	if t.Checkpoint != "" {
+		b.WriteString("\n## Where the previous run stopped\n\n")
+		b.WriteString(t.Checkpoint)
+		b.WriteString("\n")
+		if resumed {
+			b.WriteString("\nYour conversation from the previous run has been resumed, so you also " +
+				"remember what you did; the note above is the summary you left.\n")
+		} else {
+			b.WriteString("\nThe previous run's conversation is not available; the note above is all " +
+				"that carried over. Pick up from it.\n")
+		}
+	}
+
+	minutes := int(budget.Round(time.Minute) / time.Minute)
+	if minutes < 1 {
+		minutes = 1
+	}
+	fmt.Fprintf(&b, "\n## How this works\n\n"+
+		"You have about %d minutes for this run. The task itself is not limited: if you are not done "+
+		"when time is getting short, record where you are with\n\n"+
+		"    bomclaw task progress --id %s --note \"<what is done, what is left, anything the next run must know>\"\n\n"+
+		"and stop. The system will call you back with that note and your conversation. Do NOT loop on your "+
+		"own, and do NOT create a task to continue your own work — write progress and return.\n\n"+
+		"When the work is finished: `bomclaw task done --id %s --result \"<the deliverable>\"`. Your result is what "+
+		"the requesting agent reads, so state what you did and what you found. If you cannot proceed without "+
+		"a person: `bomclaw task block --id %s --on human --note \"<exactly what you need>\"` and stop.\n\n"+
+		"The final reply is the deliverable, not a plan — do not ask follow-up questions, there is nobody "+
+		"waiting to answer them; use `task block` instead.",
+		minutes, t.ID, t.ID, t.ID)
 	return b.String()
+}
+
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
 }

--- a/internal/taskrunner/runner_test.go
+++ b/internal/taskrunner/runner_test.go
@@ -16,11 +16,15 @@ import (
 
 // stubLLM records what it was asked and replies with a canned answer.
 type stubLLM struct {
-	mu      sync.Mutex
-	prompts []string
-	reply   string
-	err     error
-	delay   time.Duration
+	mu       sync.Mutex
+	prompts  []string
+	sessions []string // sess.GetSessionID() at call time — "" means a fresh session
+	reply    string
+	err      error
+	delay    time.Duration
+	// hook runs mid-call, standing in for the agent typing `bomclaw task …`
+	// or the CLI calling tools.
+	hook func(ctx context.Context, sess *session.Session, cb chat.StreamCallbacks)
 }
 
 func (s *stubLLM) Name() string { return "stub" }
@@ -29,9 +33,18 @@ func (s *stubLLM) SendMessage(ctx context.Context, sess *session.Session, model,
 	userText, memory string, cb chat.StreamCallbacks) error {
 	s.mu.Lock()
 	s.prompts = append(s.prompts, userText)
-	reply, err, delay := s.reply, s.err, s.delay
+	s.sessions = append(s.sessions, sess.GetSessionID())
+	reply, err, delay, hook := s.reply, s.err, s.delay, s.hook
 	s.mu.Unlock()
 
+	// The real CLIs announce the session id in their first stream event, so
+	// even a run that later times out knows which session it was in.
+	if sess.GetSessionID() == "" {
+		sess.SetSessionID("stub-session")
+	}
+	if hook != nil {
+		hook(ctx, sess, cb)
+	}
 	if delay > 0 {
 		select {
 		case <-time.After(delay):
@@ -42,9 +55,14 @@ func (s *stubLLM) SendMessage(ctx context.Context, sess *session.Session, model,
 	if cb.OnText != nil && reply != "" {
 		cb.OnText(reply)
 	}
-	sess.SetSessionID("stub-session")
 	sess.AddTokens(50, 7)
 	return err
+}
+
+func (s *stubLLM) seenSessions() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.sessions...)
 }
 
 func (s *stubLLM) seen() []string {
@@ -117,22 +135,40 @@ func TestRunnerClaimsAndCompletes(t *testing.T) {
 	}
 }
 
-func TestRunnerRecordsFailure(t *testing.T) {
+// A run that breaks is retried; only when every attempt has broken does the
+// task fail — and then with the reason, not stuck in `working`.
+func TestRunnerRetriesFailuresThenExhausts(t *testing.T) {
 	db := testDB(t)
 	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "Break"})
 
 	llm := &stubLLM{reply: "partial work", err: errors.New("codex error: 400")}
-	newRunner(db, llm).claimAndRun(context.Background())
+	r := newRunner(db, llm)
 
+	r.claimAndRun(context.Background())
 	task, _ := db.GetTask(created.ID)
-	if task.State != coord.TaskFailed {
-		t.Errorf("state = %q, want failed", task.State)
+	if task.State != coord.TaskSubmitted || task.Attempts != 1 {
+		t.Fatalf("after one broken run: state=%s attempts=%d, want submitted/1 (retry)", task.State, task.Attempts)
+	}
+
+	r.claimAndRun(context.Background())
+	r.claimAndRun(context.Background())
+	task, _ = db.GetTask(created.ID)
+	if task.State != coord.TaskFailed || task.FailReason != coord.FailExhausted {
+		t.Errorf("after three: state=%s reason=%q, want failed/exhausted", task.State, task.FailReason)
 	}
 	if !strings.Contains(task.Result, "codex error: 400") {
 		t.Errorf("result must carry the error, got %q", task.Result)
 	}
 	if !strings.Contains(task.Result, "partial work") {
 		t.Errorf("partial output must be kept, got %q", task.Result)
+	}
+	runs, _ := db.TaskRuns(created.ID)
+	if len(runs) != 3 || runs[0].Liveness != coord.RunFailed {
+		t.Errorf("ledger should show 3 failed runs, got %+v", runs)
+	}
+	// Nothing left to claim: no more `working` limbo.
+	if r.claimAndRun(context.Background()) {
+		t.Error("an exhausted task was claimed again")
 	}
 }
 
@@ -228,5 +264,265 @@ func TestNilRunnerIsSafe(t *testing.T) {
 	}
 	if New(testDB(t), &stubLLM{}, nil, Config{Interval: 0}) != nil {
 		t.Error("New must return nil when polling is disabled")
+	}
+}
+
+// The whole point of P0: a run that hits its cap having written progress is a
+// continuation. The task returns to the queue pinned to this agent, carrying
+// the checkpoint and the CLI session, and the next run resumes that session.
+func TestRunThatTimesOutWithProgressContinuesAndResumes(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "Summarise five sources"})
+
+	llm := &stubLLM{
+		reply: "working through source 3…",
+		delay: 2 * time.Second, // longer than the run cap below
+		hook: func(_ context.Context, _ *session.Session, _ chat.StreamCallbacks) {
+			// The agent writes progress before time runs out.
+			tk, _ := db.GetTask(created.ID)
+			_ = db.SetCheckpoint(created.ID, "a2", tk.Attempts, "sources 1-2 done, on 3")
+		},
+	}
+	r := New(db, llm, nil, Config{AgentID: "a2", Model: "m", Interval: 10 * time.Millisecond, Timeout: 150 * time.Millisecond})
+
+	r.claimAndRun(context.Background())
+
+	task, _ := db.GetTask(created.ID)
+	if task.State != coord.TaskSubmitted {
+		t.Fatalf("state = %s, want submitted (call me back)", task.State)
+	}
+	if task.Continuations != 1 || task.Attempts != 1 {
+		t.Errorf("continuations=%d attempts=%d — progress must not spend an attempt", task.Continuations, task.Attempts)
+	}
+	if task.AssignedTo != "a2" {
+		t.Errorf("assigned_to = %q, want a2 (the session lives in a2's config dir)", task.AssignedTo)
+	}
+	ref := coord.ParseSessionRef(task.SessionRef)
+	if ref.Provider != "stub" || ref.SessionID != "stub-session" {
+		t.Errorf("session ref = %+v, want stub/stub-session", ref)
+	}
+	runs, _ := db.TaskRuns(created.ID)
+	if len(runs) != 1 || runs[0].Liveness != coord.RunTimedOut {
+		t.Fatalf("ledger = %+v, want one timed_out run", runs)
+	}
+
+	// Run 2: quick, done. It must be handed the SAME session and told where run 1 stopped.
+	llm.mu.Lock()
+	llm.delay, llm.hook, llm.reply = 0, nil, "all five summarised"
+	llm.mu.Unlock()
+	r.claimAndRun(context.Background())
+
+	task, _ = db.GetTask(created.ID)
+	if task.State != coord.TaskCompleted || task.Result != "all five summarised" {
+		t.Fatalf("run 2: state=%s result=%q", task.State, task.Result)
+	}
+	sessions := llm.seenSessions()
+	if len(sessions) != 2 || sessions[0] != "" || sessions[1] != "stub-session" {
+		t.Errorf("sessions handed to the CLI = %v; run 2 must resume run 1's session", sessions)
+	}
+	p := llm.seen()[1]
+	for _, want := range []string{"continuing a task", "run 2", "sources 1-2 done, on 3", "has been resumed"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("run 2 prompt missing %q:\n%s", want, p)
+		}
+	}
+}
+
+// Without progress, a timeout is just a spent attempt — but the session is
+// still recorded, so the retry can resume it.
+func TestRunThatTimesOutSilentlySpendsAnAttempt(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "hang"})
+	llm := &stubLLM{delay: time.Second}
+	r := New(db, llm, nil, Config{AgentID: "a2", Model: "m", Interval: 10 * time.Millisecond, Timeout: 100 * time.Millisecond})
+
+	r.claimAndRun(context.Background())
+	task, _ := db.GetTask(created.ID)
+	if task.State != coord.TaskSubmitted || task.Attempts != 1 || task.Continuations != 0 {
+		t.Errorf("state=%s attempts=%d continuations=%d, want submitted/1/0", task.State, task.Attempts, task.Continuations)
+	}
+}
+
+// The agent's own `bomclaw task done` inside the run is the authoritative
+// completion, whatever the reply text looks like.
+func TestAgentMarkingDoneInsideTheRunCompletesIt(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "quick"})
+	llm := &stubLLM{
+		reply: "I'll get to that next.", // would otherwise read as plan-ish
+		hook: func(_ context.Context, _ *session.Session, _ chat.StreamCallbacks) {
+			tk, _ := db.GetTask(created.ID)
+			_ = db.FinishTask(created.ID, "a2", coord.TaskCompleted, "deliverable via task done", tk.Attempts)
+		},
+	}
+	newRunner(db, llm).claimAndRun(context.Background())
+
+	task, _ := db.GetTask(created.ID)
+	if task.State != coord.TaskCompleted || task.Result != "deliverable via task done" {
+		t.Fatalf("state=%s result=%q", task.State, task.Result)
+	}
+	runs, _ := db.TaskRuns(created.ID)
+	if len(runs) != 1 || runs[0].Liveness != coord.RunCompleted {
+		t.Errorf("ledger = %+v, want one completed run", runs)
+	}
+}
+
+// `bomclaw task block` inside the run parks the task; the run closes as blocked.
+func TestAgentBlockingInsideTheRun(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "needs a number"})
+	llm := &stubLLM{
+		reply: "I need the budget figure.",
+		hook: func(_ context.Context, _ *session.Session, _ chat.StreamCallbacks) {
+			tk, _ := db.GetTask(created.ID)
+			_ = db.BlockTask(created.ID, "a2", tk.Attempts, coord.BlockedOnHuman, "budget figure?")
+		},
+	}
+	newRunner(db, llm).claimAndRun(context.Background())
+
+	task, _ := db.GetTask(created.ID)
+	if task.State != coord.TaskBlocked || task.BlockedOn != coord.BlockedOnHuman {
+		t.Fatalf("state=%s blocked_on=%q", task.State, task.BlockedOn)
+	}
+	runs, _ := db.TaskRuns(created.ID)
+	if len(runs) != 1 || runs[0].Liveness != coord.RunBlocked {
+		t.Errorf("ledger = %+v, want one blocked run", runs)
+	}
+	// A person answers; the task is claimable again.
+	if err := db.UnblockTask(created.ID, "human", "it is 500"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ClaimTask("a2"); err != nil {
+		t.Errorf("unblocked task not claimable: %v", err)
+	}
+}
+
+// A reply that is a plan with unfinished TodoWrite items and no progress note
+// is not a deliverable; call the agent back.
+func TestPlanOnlyReplyIsContinuedNotAccepted(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "do the thing"})
+	llm := &stubLLM{
+		reply: "Here is my plan: 1) … 2) …",
+		hook: func(_ context.Context, _ *session.Session, cb chat.StreamCallbacks) {
+			cb.OnToolCall("TodoWrite", `{"todos":[{"content":"a","status":"completed"},{"content":"b","status":"pending"}]}`)
+		},
+	}
+	newRunner(db, llm).claimAndRun(context.Background())
+
+	task, _ := db.GetTask(created.ID)
+	if task.State != coord.TaskSubmitted || task.Continuations != 1 {
+		t.Fatalf("state=%s continuations=%d, want submitted/1", task.State, task.Continuations)
+	}
+	runs, _ := db.TaskRuns(created.ID)
+	if runs[0].Liveness != coord.RunPlanOnly {
+		t.Errorf("liveness = %s, want plan_only", runs[0].Liveness)
+	}
+}
+
+func TestEmptyReplyIsRecordedAsEmpty(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "say something"})
+	newRunner(db, &stubLLM{reply: ""}).claimAndRun(context.Background())
+	runs, _ := db.TaskRuns(created.ID)
+	if len(runs) != 1 || runs[0].Liveness != coord.RunEmpty {
+		t.Errorf("ledger = %+v, want one empty run", runs)
+	}
+}
+
+// While a run is in flight it is visible — this is what lets the tray hold the
+// Mac awake and the dashboard show it. Afterwards it is gone.
+func TestLiveRunsAreVisibleWhileRunning(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "visible work"})
+	release := make(chan struct{})
+	llm := &stubLLM{reply: "ok", hook: func(ctx context.Context, sess *session.Session, cb chat.StreamCallbacks) {
+		cb.OnToolCall("Bash", `{"command":"ls"}`)
+		<-release
+	}}
+	r := newRunner(db, llm)
+
+	var events []Event
+	var evMu sync.Mutex
+	r.SetEventListener(func(e Event) { evMu.Lock(); events = append(events, e); evMu.Unlock() })
+
+	done := make(chan struct{})
+	go func() { r.claimAndRun(context.Background()); close(done) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(r.Live()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	live := r.Live()
+	if len(live) != 1 {
+		t.Fatalf("live runs = %d, want 1", len(live))
+	}
+	info := live[0].RunInfo()
+	if !info.Running || info.CurrentTask != "visible work" || live[0].ID != "task_"+created.ID {
+		t.Errorf("live run info = %+v id=%s", info, live[0].ID)
+	}
+	if info.LastTool != "Bash" || info.ToolCount != 1 {
+		t.Errorf("tool activity not reflected: %+v", info)
+	}
+
+	close(release)
+	<-done
+	if len(r.Live()) != 0 {
+		t.Error("run still listed as live after it finished")
+	}
+	deadline = time.Now().Add(time.Second)
+	for {
+		evMu.Lock()
+		n := len(events)
+		evMu.Unlock()
+		if n == 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	evMu.Lock()
+	defer evMu.Unlock()
+	if len(events) != 2 || events[0].Phase != "started" || events[1].Phase != "finished" || events[0].TaskID != created.ID {
+		t.Errorf("events = %+v, want started then finished for %s", events, created.ID)
+	}
+}
+
+// The sweep is what turns "stuck in working forever" into a visible failure,
+// and frees tasks addressed to an agent that is gone.
+func TestSweepReapsAndRelaxes(t *testing.T) {
+	db := testDB(t)
+	// Exhausted: three claims that never reported back.
+	stuck, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "stuck"})
+	for i := 0; i < 3; i++ {
+		db.ClaimTask("a9")
+		db.Conn().Exec(`UPDATE tasks SET lease_until = ? WHERE id = ?`,
+			time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano), stuck.ID)
+	}
+	// Addressed to a dead agent.
+	db.RegisterAgent(coord.Agent{ID: "dead"})
+	db.Conn().Exec(`UPDATE agents SET last_seen_at = ? WHERE id = 'dead'`, time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano))
+	orphan, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", AssignedTo: "dead", Title: "orphan"})
+
+	newRunner(db, &stubLLM{}).sweep()
+
+	s1, _ := db.GetTask(stuck.ID)
+	if s1.State != coord.TaskFailed || s1.FailReason != coord.FailExhausted {
+		t.Errorf("stuck task: state=%s reason=%q", s1.State, s1.FailReason)
+	}
+	s2, _ := db.GetTask(orphan.ID)
+	if s2.AssignedTo != "" {
+		t.Errorf("orphan still assigned to %q", s2.AssignedTo)
+	}
+}
+
+func TestHasPendingTodos(t *testing.T) {
+	if !hasPendingTodos(`{"todos":[{"status":"completed"},{"status":"in_progress"}]}`) {
+		t.Error("in_progress is pending")
+	}
+	if hasPendingTodos(`{"todos":[{"status":"completed"}]}`) {
+		t.Error("all completed is not pending")
+	}
+	if hasPendingTodos(`not json`) || hasPendingTodos(`{}`) {
+		t.Error("garbage must not read as pending")
 	}
 }


### PR DESCRIPTION
**P0, part 2 of 2** — steps 5–10 of `docs/design/scheduling-and-long-tasks.md` §10, stacked on #88 (GitHub will retarget this to `main` when #88 merges).

After this, a task that needs 40 minutes gets there across three runs **with its context intact**, shows up everywhere a chat turn does, and its hand-offs reach the other agent in seconds instead of 60.

## Each claim is one run; the run resumes the last one's session

The runner opens a `task_runs` row per claim. When the task carries a `session_ref` from an earlier run by the **same CLI**, the CLI is handed that session id — and the credential-pool account it lived under is pinned — so the conversation *continues* rather than restarts. The prompt carries the agent's own checkpoint either way: the resumed session for what it did, the note for what it meant.

Proven in the test double: run 1 times out having written a checkpoint → task requeues pinned to the agent, `continuations=1`, `attempts=1` (progress does not spend an attempt), `session_ref=stub/stub-session`; run 2 is handed `stub-session`, its prompt says *"continuing a task (run 2) … has been resumed"*, and it completes.

## How a run ended is read from what happened, not from the prose

| Signal | Liveness | Why |
|---|---|---|
| agent typed `task done` / `task block` / `task fail` during the run | that, outright | the agent's own commands are authoritative |
| context deadline | `timed_out` | runtime fact |
| context cancel | `canceled` | a restart, not a failure — attempt refunded |
| CLI error | `failed` | retry; 3rd → `failed(exhausted)` |
| checkpoint changed | `advanced` | it wrote progress: call me back |
| empty reply | `empty` | 2nd in a row fails the task |
| TodoWrite left pending items | `plan_only` | a plan is not a deliverable — continue, don't accept |
| plain reply, nothing else | `completed`, reply = result | exactly what a short task looked like before |

**Failures retry now.** One broken run used to fail the task outright; it now spends an attempt and requeues. The one existing test asserting the old behaviour is replaced — deliberately — by one asserting three failures → `failed(exhausted)` and no more `working` limbo.

## Visible while it runs

Run sessions register in a live set the gateway folds into `StatusResult.Runs` with `Kind:"task"`, and start/finish are pushed as `session.turn` events with `kind:"task"`. That is what the tray's awake mode, `bomclaw status` and the dashboard read — **a task run absent from it was how the Mac came to sleep mid-task.**

## The doorbell rings again

`PokeAgent` moves from the `/ws` socket to `POST /api/tasks/poke`, derived from the address an agent registers (`ws://127.0.0.1:18789/ws → http://127.0.0.1:18789/api/tasks/poke`), mounted behind `RequireAuthExceptLocal` like `/api/status`.

Why: the socket refuses unauthenticated peers whenever dashboard auth is on — the shipped default — so **every cross-agent poke had been a 401** and hand-offs always waited the full 60 s poll. Mounted even when this agent does not claim tasks (nil runner → no-op), so ringing never 404s. Tested end to end over a real listener.

## Housekeeping in the loop

Each wake reaps exhausted tasks into `failed` and opens tasks addressed to an agent that has stopped heartbeating.

## Surfaces

- **CLI:** `task progress` (checkpoint), `task block --on human|children`, `task answer` (a person unblocking; the answer is appended under the agent's checkpoint so the next run reads both), `task resume --more N`, and `task show` now lists runs, checkpoint, continuations, and which session the next run will resume.
- **Dashboard:** runs with liveness, checkpoint, *why* a task failed in plain words, a **Resume (+5)** button on failed tasks, `blocked` lane, and immediate reload on pushed task events. The old "lease expired — will be reclaimed" is gone from tasks that will never be reclaimed.
- **System prompt:** the loop ban reworded around continuations — *write progress and return; never create a task to continue your own work.*

## Tests

- taskrunner: 11 new — timeout-with-progress → continue + resume; silent timeout spends an attempt; `task done` / `task block` inside the run; `plan_only`; `empty`; live visibility + events; sweep; TodoWrite parsing.
- gateway: `PokeURL` derivation, handler method/nil safety, `PokeAgent` → handler over a real HTTP listener.
- `go build ./... && go test ./...` green; `tsc --noEmit` and Vite build clean.

One stub fix worth noting: the test double set the CLI session id only *after* the reply, so a run that timed out had none — unlike the real CLIs, which announce it in their first stream event. The stub now does too.

## Deploying

Gateway binary + dashboard. The live `~/.bomclaw*/config.yaml` files carry their own system prompt and need the reworded loop paragraph applied by hand (they have diverged from the repo template — I will not copy over them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)