### PR TITLE
fix(coord): close runs under contention — BEGIN IMMEDIATE, retry, reap orphans

### DIFF
--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -53,7 +53,16 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("coord: mkdir %s: %w", filepath.Dir(path), err)
 	}
 
-	conn, err := sql.Open("sqlite", storage.DSN(path))
+	// _txlock=immediate makes every Begin() a BEGIN IMMEDIATE. This file is
+	// written by several connections at once — two gateway processes, plus the
+	// trace recorder's async spans inside each — and a transaction that starts
+	// deferred (read first, write later) cannot upgrade to a write lock if
+	// another writer committed in between: SQLite returns SQLITE_BUSY at once,
+	// ignoring busy_timeout, because the snapshot it read is already stale.
+	// FinishRun is exactly that shape, and a span landing between its SELECT
+	// and its UPDATE lost a run's outcome in production. Taking the write lock
+	// up front turns that into an ordinary wait.
+	conn, err := sql.Open("sqlite", storage.DSN(path)+"&_txlock=immediate")
 	if err != nil {
 		return nil, fmt.Errorf("coord: open %s: %w", path, err)
 	}

--- a/internal/coord/taskruns.go
+++ b/internal/coord/taskruns.go
@@ -25,6 +25,7 @@ const (
 	RunFailed    = "failed"    // the run itself broke (CLI error, exception)
 	RunTimedOut  = "timed_out" // hit the per-run cap
 	RunCanceled  = "canceled"  // ctx cancelled: shutdown or a person stopping it
+	RunLost      = "lost"      // never closed: the process died, or the close failed; healed by ReapOrphanRuns
 )
 
 // TaskRun is one row of task_runs.
@@ -270,6 +271,39 @@ func (db *DB) FinishRun(runID string, o RunOutcome) (*Task, error) {
 	}
 	t.UpdatedAt = now
 	return t, nil
+}
+
+// ReapOrphanRuns closes runs still marked running whose claim is over: the
+// task has moved on (finished, requeued, reclaimed by someone else) or has been
+// unheld for longer than a lease, so no process can still be inside that run.
+// A gateway crash mid-run leaves exactly this behind; so did a FinishRun that
+// failed on a busy database. Marked lost, not failed — the outcome is unknown,
+// and the task's own state already says what happened to the work.
+func (db *DB) ReapOrphanRuns() ([]string, error) {
+	now := time.Now()
+	rows, err := db.conn.Query(`UPDATE task_runs SET liveness = ?, ended_at = ?,
+			note = 'run never closed; task moved on without it'
+		WHERE liveness = ?
+		  AND task_id IN (
+		    SELECT t.id FROM tasks t WHERE t.id = task_runs.task_id
+		      AND NOT (t.state = ? AND t.claimed_by = task_runs.agent_id
+		               AND t.attempts = task_runs.attempt AND t.lease_until > ?)
+		  )
+		RETURNING id`,
+		RunLost, ts(now), RunRunning, TaskWorking, ts(now))
+	if err != nil {
+		return nil, fmt.Errorf("reap orphan runs: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return ids, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 // TaskRuns lists a task's runs, oldest first.

--- a/internal/coord/taskruns_test.go
+++ b/internal/coord/taskruns_test.go
@@ -3,7 +3,10 @@ package coord
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -477,4 +480,127 @@ func TestMigrateV2DatabaseGainsV3Columns(t *testing.T) {
 		t.Fatalf("second open: %v", err)
 	}
 	db2.Close()
+}
+
+// The production failure: FinishRun begins a read-then-write transaction while
+// the trace recorder is inserting spans into the same file from another
+// connection. With a deferred BEGIN the upgrade to a write lock fails at once
+// with SQLITE_BUSY (stale snapshot), ignoring busy_timeout, and the run is
+// never closed. With BEGIN IMMEDIATE it waits its turn. This test hammers
+// exactly that interleaving; it fails without _txlock=immediate in coord.Open.
+func TestFinishRunSurvivesConcurrentSpanWrites(t *testing.T) {
+	db := testDB(t)
+	const tasks = 40
+
+	var ids []string
+	for i := 0; i < tasks; i++ {
+		tk := newTask(t, db)
+		ids = append(ids, tk.ID)
+	}
+
+	// A writer that never stops: what the trace recorder looks like.
+	stop := make(chan struct{})
+	var writerErrs int64
+	var wg sync.WaitGroup
+	for w := 0; w < 3; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				id := fmt.Sprintf("run-%d-%d", w, i)
+				if err := db.InsertRun(&Run{ID: id, TraceID: id, DottedOrder: id, AgentID: "a1",
+					Name: "span", RunType: RunTypeTool, Status: StatusPending, StartedAt: time.Now()}); err != nil {
+					atomic.AddInt64(&writerErrs, 1)
+				}
+				_ = db.EndRun(id, time.Now(), "", "", 0, 0)
+			}
+		}(w)
+	}
+
+	var busy int64
+	var finishWG sync.WaitGroup
+	for _, id := range ids {
+		finishWG.Add(1)
+		go func(taskID string) {
+			defer finishWG.Done()
+			tk, err := db.ClaimTask("a1")
+			if err != nil {
+				atomic.AddInt64(&busy, 1)
+				return
+			}
+			run, err := db.StartRun(tk.ID, "a1", tk.Attempts, "")
+			if err != nil {
+				atomic.AddInt64(&busy, 1)
+				return
+			}
+			if _, err := db.FinishRun(run.ID, RunOutcome{Liveness: RunCompleted, Result: "ok"}); err != nil {
+				t.Logf("FinishRun: %v", err)
+				atomic.AddInt64(&busy, 1)
+			}
+		}(id)
+	}
+	finishWG.Wait()
+	close(stop)
+	wg.Wait()
+
+	if busy != 0 {
+		t.Fatalf("%d of %d run closes failed under concurrent span writes — a run left 'running' forever", busy, tasks)
+	}
+	var open int
+	_ = db.conn.QueryRow(`SELECT count(*) FROM task_runs WHERE liveness = ?`, RunRunning).Scan(&open)
+	if open != 0 {
+		t.Fatalf("%d runs still 'running' after every FinishRun returned", open)
+	}
+}
+
+// A run left 'running' after the task moved on — a crash mid-run, or a close
+// that failed — is closed as lost on the next sweep. A run whose claim is
+// genuinely still live is left alone.
+func TestReapOrphanRuns(t *testing.T) {
+	db := testDB(t)
+
+	// (a) task finished by the agent's own `task done`, run never closed
+	t1 := newTask(t, db)
+	c1, _ := db.ClaimTask("a1")
+	r1, _ := db.StartRun(t1.ID, "a1", c1.Attempts, "")
+	_ = db.FinishTask(t1.ID, "a1", TaskCompleted, "done", c1.Attempts)
+
+	// (b) live run: task working, same holder, lease in the future
+	t2 := newTask(t, db)
+	c2, _ := db.ClaimTask("a1")
+	r2, _ := db.StartRun(t2.ID, "a1", c2.Attempts, "")
+
+	// (c) the holder died; lease lapsed; someone else reclaimed (attempt 2)
+	t3 := newTask(t, db)
+	c3, _ := db.ClaimTask("a1")
+	r3, _ := db.StartRun(t3.ID, "a1", c3.Attempts, "")
+	_, _ = db.conn.Exec(`UPDATE tasks SET lease_until = ? WHERE id = ?`, ts(time.Now().Add(-time.Minute)), t3.ID)
+	if _, err := db.ClaimTask("a2"); err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := db.ReapOrphanRuns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, id := range ids {
+		got[id] = true
+	}
+	if !got[r1.ID] || !got[r3.ID] || got[r2.ID] {
+		t.Fatalf("reaped %v; want r1 %s and r3 %s, not the live r2 %s", ids, r1.ID, r3.ID, r2.ID)
+	}
+	runs, _ := db.TaskRuns(t1.ID)
+	if runs[0].Liveness != RunLost || runs[0].EndedAt.IsZero() || runs[0].Note == "" {
+		t.Errorf("orphan should be lost with an end time and a note, got %+v", runs[0])
+	}
+	live, _ := db.TaskRuns(t2.ID)
+	if live[0].Liveness != RunRunning {
+		t.Errorf("live run was reaped: %+v", live[0])
+	}
 }

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -178,6 +178,43 @@ func (r *Runner) sweep() {
 	} else if len(ids) > 0 {
 		log.Printf("taskrunner: opened %d task(s) whose assignee is gone: %v", len(ids), ids)
 	}
+	if ids, err := r.db.ReapOrphanRuns(); err != nil {
+		log.Printf("taskrunner: reap orphan runs: %v", err)
+	} else if len(ids) > 0 {
+		log.Printf("taskrunner: closed %d orphan run(s) as lost: %v", len(ids), ids)
+	}
+}
+
+// withRetry runs a ledger write that must not be dropped on a transient
+// database error. The shared file has several writers; even with immediate
+// transactions a busy timeout can still fire under load, and losing the close
+// of a run leaves it "running" forever. Semantic outcomes (lease lost, task
+// finished, not found) are returned at once — retrying them is meaningless.
+func withRetry(what string, fn func() error) error {
+	delay := 100 * time.Millisecond
+	var err error
+	for i := 0; i < 6; i++ {
+		err = fn()
+		if err == nil || !isTransient(err) {
+			return err
+		}
+		log.Printf("taskrunner: %s: %v — retrying in %s", what, err, delay)
+		time.Sleep(delay)
+		if delay < 2*time.Second {
+			delay *= 2
+		}
+	}
+	return err
+}
+
+func isTransient(err error) bool {
+	switch {
+	case errors.Is(err, coord.ErrLostLease), errors.Is(err, coord.ErrTaskFinished), errors.Is(err, coord.ErrNotFound):
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") || strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "SQLITE_LOCKED")
 }
 
 // claimAndRun takes one task and executes it. It reports whether it found work,
@@ -239,8 +276,11 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 		}
 	}
 
-	run, err := r.db.StartRun(task.ID, r.cfg.AgentID, task.Attempts, span.TraceID())
-	if err != nil {
+	var run *coord.TaskRun
+	if err := withRetry("start run "+task.ID, func() (e error) {
+		run, e = r.db.StartRun(task.ID, r.cfg.AgentID, task.Attempts, span.TraceID())
+		return e
+	}); err != nil {
 		log.Printf("taskrunner: start run for %s: %v", task.ID, err)
 		return
 	}
@@ -297,7 +337,11 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	}
 	span.End(outcome.Result, spanErr)
 
-	final, finishErr := r.db.FinishRun(run.ID, outcome)
+	var final *coord.Task
+	finishErr := withRetry("finish run "+run.ID, func() (e error) {
+		final, e = r.db.FinishRun(run.ID, outcome)
+		return e
+	})
 	switch {
 	case errors.Is(finishErr, coord.ErrLostLease):
 		// Another agent took over and already answered; discarding this


### PR DESCRIPTION
Found on the **first live task** after deploying P0 (#88/#89):

```
20:42:24 taskrunner: finish run tr_5147…: database is locked (5) (SQLITE_BUSY)
```

The run row stayed `running` forever. The task completed only because the agent had typed `task done` itself.

## Root cause

`FinishRun` begins a transaction, **reads** the run + task, then **updates** both. `database/sql` issues a *deferred* `BEGIN`, so the transaction holds only a read snapshot until its first write. The shared coord file has other writers — the **trace recorder inserting spans from another connection in the same process**, and the second gateway. When one commits between the SELECT and the UPDATE, SQLite refuses the lock upgrade with `SQLITE_BUSY` **immediately, ignoring `busy_timeout`** — the snapshot is stale and waiting cannot make it fresh.

Reproduced deterministically — 40 `FinishRun`s racing 3 span writers:

```
without fix:  --- FAIL  17 of 40 run closes failed
              --- FAIL  11 of 40 run closes failed
              --- FAIL  14 of 40 run closes failed
with fix:     ok  (×3)
```

## Three layers

1. **`_txlock=immediate` on the coord DSN** — every `Begin()` takes the write lock up front, so `busy_timeout` applies. Coord only; the per-agent DB is untouched.
2. **Runner retries `StartRun`/`FinishRun`** on transient DB errors with backoff (100ms→2s, 6 tries). Semantic outcomes (`ErrLostLease`, `ErrTaskFinished`, `ErrNotFound`) return at once — retrying them is meaningless. Dropping the close of a run is the one thing this must never do.
3. **`ReapOrphanRuns`** in the sweep: a run still `running` whose claim is over (task finished / requeued / reclaimed / unheld past a lease) is closed as **`lost`**. A crash mid-run leaves exactly this; so did tonight's failure. Lost, not failed — the outcome is unknown and the task's own state already says what happened to the work. This also heals the row from tonight.

## Tests

`TestFinishRunSurvivesConcurrentSpanWrites` (fails without layer 1), `TestReapOrphanRuns` (finished-by-agent → lost; reclaimed-by-other → lost; genuinely live → untouched). `go build ./... && go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)