### PR TITLE
fix(coord): only reap runs old enough to be dead; let a late report replace "lost"

### DIFF
--- a/internal/coord/taskruns.go
+++ b/internal/coord/taskruns.go
@@ -109,9 +109,11 @@ func (db *DB) FinishRun(runID string, o RunOutcome) (*Task, error) {
 		}
 		return nil, fmt.Errorf("finish run: load run: %w", err)
 	}
-	if run.Liveness != RunRunning {
+	if run.Liveness != RunRunning && run.Liveness != RunLost {
 		return nil, fmt.Errorf("coord: run %s already ended as %s", runID, run.Liveness)
 	}
+	// RunLost is a sweep's guess that nobody would report in; the runner
+	// reporting in is the fact, and replaces it.
 
 	t, err := scanTask(tx.QueryRow(`SELECT `+taskCols+` FROM tasks WHERE id = ?`, run.TaskID))
 	if err != nil {
@@ -273,24 +275,33 @@ func (db *DB) FinishRun(runID string, o RunOutcome) (*Task, error) {
 	return t, nil
 }
 
-// ReapOrphanRuns closes runs still marked running whose claim is over: the
-// task has moved on (finished, requeued, reclaimed by someone else) or has been
-// unheld for longer than a lease, so no process can still be inside that run.
-// A gateway crash mid-run leaves exactly this behind; so did a FinishRun that
-// failed on a busy database. Marked lost, not failed — the outcome is unknown,
-// and the task's own state already says what happened to the work.
-func (db *DB) ReapOrphanRuns() ([]string, error) {
+// ReapOrphanRuns closes runs still marked running that no process can still be
+// inside: the claim is over (task finished, requeued, reclaimed by someone
+// else) AND the run started longer ago than olderThan. A gateway crash mid-run
+// leaves exactly this behind; so did a FinishRun that failed on a busy
+// database. Marked lost, not failed — the outcome is unknown, and the task's
+// own state already says what happened to the work.
+//
+// The age bound is not optional. The sweep runs in every gateway against the
+// shared table, and a peer cannot tell whether MY run is still in flight: the
+// agent typing `bomclaw task done` moves the task to completed while its CLI
+// is still shutting down, and for those few seconds "task moved on, run still
+// running" is the normal shape of a live run — a peer's sweep closed one as
+// lost in exactly that window. Callers pass the run cap plus a lease: nothing
+// live can be older than that.
+func (db *DB) ReapOrphanRuns(olderThan time.Duration) ([]string, error) {
 	now := time.Now()
 	rows, err := db.conn.Query(`UPDATE task_runs SET liveness = ?, ended_at = ?,
 			note = 'run never closed; task moved on without it'
 		WHERE liveness = ?
+		  AND started_at < ?
 		  AND task_id IN (
 		    SELECT t.id FROM tasks t WHERE t.id = task_runs.task_id
 		      AND NOT (t.state = ? AND t.claimed_by = task_runs.agent_id
 		               AND t.attempts = task_runs.attempt AND t.lease_until > ?)
 		  )
 		RETURNING id`,
-		RunLost, ts(now), RunRunning, TaskWorking, ts(now))
+		RunLost, ts(now), RunRunning, ts(now.Add(-olderThan)), TaskWorking, ts(now))
 	if err != nil {
 		return nil, fmt.Errorf("reap orphan runs: %w", err)
 	}

--- a/internal/coord/taskruns_test.go
+++ b/internal/coord/taskruns_test.go
@@ -584,7 +584,16 @@ func TestReapOrphanRuns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ids, err := db.ReapOrphanRuns()
+	// Young runs are never reaped, however their task looks: a peer's sweep
+	// cannot tell a live run whose agent just typed `task done` from a dead one.
+	if young, err := db.ReapOrphanRuns(time.Hour); err != nil {
+		t.Fatal(err)
+	} else if len(young) != 0 {
+		t.Fatalf("reaped %v though every run is seconds old — this is the race that closed a live run as lost", young)
+	}
+
+	// Past the age bound, the orphans go.
+	ids, err := db.ReapOrphanRuns(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -602,5 +611,32 @@ func TestReapOrphanRuns(t *testing.T) {
 	live, _ := db.TaskRuns(t2.ID)
 	if live[0].Liveness != RunRunning {
 		t.Errorf("live run was reaped: %+v", live[0])
+	}
+}
+
+// A run the sweep marked lost may still report in — the CLI was just slow to
+// exit. The runner's report is the fact and replaces the guess.
+func TestFinishRunOverwritesALostMarker(t *testing.T) {
+	db := testDB(t)
+	tk := newTask(t, db)
+	c, _ := db.ClaimTask("a1")
+	run, _ := db.StartRun(tk.ID, "a1", c.Attempts, "")
+	// The agent finished the task itself; a peer's sweep then closed the run.
+	_ = db.FinishTask(tk.ID, "a1", TaskCompleted, "done", c.Attempts)
+	if ids, _ := db.ReapOrphanRuns(0); len(ids) != 1 {
+		t.Fatalf("setup: expected the run to be reaped, got %v", ids)
+	}
+
+	_, err := db.FinishRun(run.ID, RunOutcome{Liveness: RunCompleted, Result: "done"})
+	if !errors.Is(err, ErrTaskFinished) {
+		t.Fatalf("expected ErrTaskFinished (task already completed by the agent), got %v", err)
+	}
+	runs, _ := db.TaskRuns(tk.ID)
+	if runs[0].Liveness != RunCompleted {
+		t.Errorf("run liveness = %s, want completed — the runner's report must replace the lost guess", runs[0].Liveness)
+	}
+	// But a run that genuinely ended cannot be reopened.
+	if _, err := db.FinishRun(run.ID, RunOutcome{Liveness: RunFailed}); err == nil {
+		t.Error("a completed run must not be re-closed")
 	}
 }

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -178,7 +178,9 @@ func (r *Runner) sweep() {
 	} else if len(ids) > 0 {
 		log.Printf("taskrunner: opened %d task(s) whose assignee is gone: %v", len(ids), ids)
 	}
-	if ids, err := r.db.ReapOrphanRuns(); err != nil {
+	// Nothing live can be older than one run cap plus one lease; anything
+	// still "running" past that has no process behind it.
+	if ids, err := r.db.ReapOrphanRuns(r.cfg.Timeout + coord.DefaultLease); err != nil {
 		log.Printf("taskrunner: reap orphan runs: %v", err)
 	} else if len(ids) > 0 {
 		log.Printf("taskrunner: closed %d orphan run(s) as lost: %v", len(ids), ids)


### PR DESCRIPTION
Seen on the **second** live task after #90:

```
20:49:59  agent types `bomclaw task done`          → task completed
20:50:00  peer gateway's sweep: closed 1 orphan run as lost   ← run still in flight
20:50:02  runner FinishRun: run already ended as lost          ← real report refused
```

## Root cause

`ReapOrphanRuns` treated *"task moved on, run still running"* as proof the process died. But that is exactly what **every live run looks like** for the few seconds between the agent's `task done` and its CLI exiting — and the sweep runs in **every** gateway against the shared table, so a peer cannot tell my live run from a crashed one.

## Fix

- `ReapOrphanRuns(olderThan)` — closes only runs older than the bound. The runner passes **one run cap + one lease**; nothing live can be older than that.
- `FinishRun` accepts a run marked `lost` and **overwrites** it. The marker was a sweep's guess that nobody would report in; the runner reporting in is the fact. A run that genuinely ended is still refused.

## Verified live

Smoke-3 (after #90, before this) closed correctly as `completed` — the BUSY fix holds; only the peer-sweep race remained. Tests: young orphans untouched whatever their task says; late `FinishRun` overwrites `lost`; completed run cannot be re-closed. `go build ./... && go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)