### PR TITLE
feat(scheduler): timed work from the shared database (P1a)

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/daemon"
 	"github.com/ngocp/goterm-control/internal/gateway"
 	"github.com/ngocp/goterm-control/internal/models"
+	"github.com/ngocp/goterm-control/internal/scheduler"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/storage"
 	"github.com/ngocp/goterm-control/internal/taskrunner"
@@ -106,6 +107,8 @@ func main() {
 		runStatus(os.Args[2:])
 	case "task":
 		runTask(os.Args[2:])
+	case "schedule":
+		runSchedule(os.Args[2:])
 	case "note":
 		runNote(os.Args[2:])
 	case "inbox":
@@ -153,6 +156,7 @@ Commands:
   accounts           Show the credential pool and which accounts are healthy
   agents             List agents registered in the shared database
   task               Create, claim and finish work shared between agents
+  schedule           Timed work: run a task or a command on a cron, interval or one-shot
   note               Record and search what the agents have learned
   inbox              Read messages other agents sent to this one
   msg                Send a message to another agent
@@ -368,6 +372,30 @@ func runGateway(args []string) {
 		log.Printf("taskrunner: disabled (tasks.auto_claim=false) — queued work waits for `bomclaw task claim`")
 	}
 
+	// Scheduler — fires timed work from the shared database. Off by default:
+	// it creates tasks and runs commands with nobody typing. Any number of
+	// gateways may run it; firing is a compare-and-set on the shared row.
+	var sched *scheduler.Scheduler
+	if coordDB != nil && cfg.Schedules.Enabled {
+		sched = scheduler.New(coordDB, scheduler.Config{
+			AgentID:        cfg.Agent.ID,
+			Tick:           time.Duration(cfg.Schedules.TickSeconds) * time.Second,
+			CommandTimeout: time.Duration(cfg.Schedules.CommandTimeoutSeconds) * time.Second,
+		})
+		// Results and alerts go to the owner's Telegram; the local runner is
+		// rung directly and peers over HTTP, exactly as for a hand-queued task.
+		sched.SetNotify(func(text string) { tgBot.Notify(text) })
+		sched.SetWake(func(t *coord.Task) {
+			if runner != nil {
+				runner.Poke()
+			}
+			gateway.NotifyTaskCreated(coordDB, t)
+		})
+		sched.Start(ctx)
+	} else if coordDB != nil {
+		log.Printf("scheduler: disabled (schedules.enabled=false) — `bomclaw schedule add` rows wait for a gateway that runs it")
+	}
+
 	deps := gateway.Deps{
 		Sessions:      sessions,
 		Resolver:      resolver,
@@ -384,6 +412,7 @@ func runGateway(args []string) {
 		ProviderName:  cfg.Provider,
 		Trace:         gwTrace,
 		PokeTasks:     runner.Poke,
+		PokeSchedules: sched.Poke,
 		NotesFile:     cfg.Coord.NotesFile,
 		Conversations: conversations,
 	}

--- a/cmd/bomclaw/schedulecmd.go
+++ b/cmd/bomclaw/schedulecmd.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/scheduler"
+)
+
+// `bomclaw schedule` writes straight to the shared database, like `task`. The
+// gateway's scheduler loop picks changes up on its next tick (30s by default),
+// so "add" and "run-now" say when to expect the firing rather than firing
+// themselves — a CLI process has no business running a model.
+
+func runSchedule(args []string) {
+	if len(args) == 0 {
+		scheduleUsage()
+		os.Exit(1)
+	}
+	sub, rest := args[0], args[1:]
+
+	switch sub {
+	case "add":
+		fs := flag.NewFlagSet("schedule add", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		name := fs.String("name", "", "Unique name (required)")
+		cronSpec := fs.String("cron", "", "5-field cron line, e.g. \"0 8 * * 1-5\" (or @daily)")
+		every := fs.String("every", "", "Interval, e.g. 10m, 1h30m (minimum 1m)")
+		at := fs.String("at", "", "One-shot time, e.g. 2026-09-07T09:00 (read in --tz)")
+		tz := fs.String("tz", "", "IANA zone for --cron/--at (default: this machine's, "+scheduler.LocalZone()+")")
+		agentTask := fs.String("agent-task", "", "Fire as a task for an agent: the task title")
+		body := fs.String("body", "", "Task body for --agent-task")
+		to := fs.String("to", "", "Assign the task to this agent (default: --owner, else any agent)")
+		quiet := fs.Bool("quiet", false, "Do not deliver the task's result to Telegram")
+		command := fs.String("command", "", "Fire as a shell command inside the gateway (no model)")
+		cwd := fs.String("cwd", "", "Working directory for --command")
+		timeoutS := fs.Int("timeout", 0, "Seconds a --command may run (default: gateway's schedules.command_timeout_seconds)")
+		owner := fs.String("owner", "", "Only this gateway fires it (default: whichever gateway sees it first)")
+		skipMissed := fs.Bool("skip-missed", false, "After downtime, re-arm instead of running the missed firing once")
+		fs.Parse(rest)
+
+		kind, spec, err := pickSpec(*cronSpec, *every, *at)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "schedule add: %v\n", err)
+			os.Exit(1)
+		}
+		if *tz == "" {
+			*tz = scheduler.LocalZone()
+		}
+		if (*agentTask == "") == (*command == "") {
+			fmt.Fprintln(os.Stderr, "schedule add: give exactly one of --agent-task or --command")
+			os.Exit(1)
+		}
+		now := time.Now()
+		next, err := scheduler.NextRun(kind, spec, *tz, now)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "schedule add: %v\n", err)
+			os.Exit(1)
+		}
+		if next.IsZero() {
+			fmt.Fprintf(os.Stderr, "schedule add: %s is already in the past\n", *at)
+			os.Exit(1)
+		}
+		n := coord.NewSchedule{
+			Name: *name, CreatedBy: orAny(*agent, "cli"), OwnerAgent: *owner,
+			Kind: kind, Spec: spec, TZ: *tz, SkipMissed: *skipMissed, NextRunAt: next,
+		}
+		if *agentTask != "" {
+			n.PayloadKind = coord.PayloadAgent
+			n.Payload = coord.AgentPayload{Title: *agentTask, Body: *body, To: *to, Quiet: *quiet}
+		} else {
+			n.PayloadKind = coord.PayloadCommand
+			n.Payload = coord.CommandPayload{Cmd: *command, Cwd: *cwd, TimeoutS: *timeoutS}
+		}
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		s, err := db.CreateSchedule(n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "schedule add: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s  %s\nfirst run %s (%s)\n", s.ID, s.Name, s.NextRunAt.Local().Format("2006-01-02 15:04:05 MST"), untilText(s.NextRunAt))
+		fmt.Println("(a gateway with schedules.enabled=true fires it; check with `bomclaw schedule list`)")
+
+	case "list":
+		fs := flag.NewFlagSet("schedule list", flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		all, err := db.ListSchedules()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "schedule list: %v\n", err)
+			os.Exit(1)
+		}
+		if len(all) == 0 {
+			fmt.Println("no schedules — add one with `bomclaw schedule add --name X --cron \"0 8 * * 1-5\" --agent-task \"...\"`")
+			return
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tWHEN\tNEXT\tLAST\tPAYLOAD\tOWNER")
+		for i := range all {
+			s := &all[i]
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				s.Name, scheduler.Describe(s), nextText(s), lastText(s), payloadText(s), orAny(s.OwnerAgent, "any"))
+		}
+		w.Flush()
+
+	case "show":
+		fs := flag.NewFlagSet("schedule show", flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		limit := fs.Int("runs", 10, "How many recent runs to show")
+		fs.Parse(rest)
+		s, db := findSchedule(fs, *dbPath, "schedule show")
+		defer db.Close()
+
+		fmt.Printf("%s  %s\n", s.ID, s.Name)
+		fmt.Printf("when:     %s\n", scheduler.Describe(s))
+		fmt.Printf("next:     %s\n", nextText(s))
+		fmt.Printf("last:     %s\n", lastText(s))
+		fmt.Printf("payload:  %s\n", payloadText(s))
+		fmt.Printf("owner:    %s   created by %s   skip_missed %v   system %v\n",
+			orAny(s.OwnerAgent, "any gateway"), s.CreatedBy, s.SkipMissed, s.System)
+		if s.ConsecutiveFailures > 0 {
+			fmt.Printf("failures: %d in a row (turns itself off at %d)\n", s.ConsecutiveFailures, coord.DisableAfterFailures)
+		}
+		runs, _ := db.ScheduleRuns(s.ID, *limit)
+		if len(runs) == 0 {
+			fmt.Println("\nno runs yet")
+			return
+		}
+		fmt.Println("\nruns:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		for _, r := range runs {
+			dur := ""
+			if !r.EndedAt.IsZero() {
+				dur = r.EndedAt.Sub(r.StartedAt).Round(time.Second).String()
+			}
+			detail := r.TaskID
+			if detail == "" {
+				detail = fmt.Sprintf("exit %d", r.ExitCode)
+			}
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n", r.StartedAt.Local().Format("01-02 15:04:05"), r.Status, dur, detail, firstLineOf(r.Output, 80))
+		}
+		w.Flush()
+
+	case "enable", "disable":
+		fs := flag.NewFlagSet("schedule "+sub, flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		fs.Parse(rest)
+		s, db := findSchedule(fs, *dbPath, "schedule "+sub)
+		defer db.Close()
+		if sub == "disable" {
+			if err := db.SetScheduleEnabled(s.ID, false, time.Time{}); err != nil {
+				fmt.Fprintf(os.Stderr, "schedule disable: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("%s disabled\n", s.Name)
+			return
+		}
+		next, err := scheduler.NextRun(s.Kind, s.Spec, s.TZ, time.Now())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "schedule enable: %v\n", err)
+			os.Exit(1)
+		}
+		if next.IsZero() {
+			fmt.Fprintf(os.Stderr, "schedule enable: %s is a one-shot whose time (%s) has passed; remove it and add a new one\n", s.Name, s.Spec)
+			os.Exit(1)
+		}
+		if err := db.SetScheduleEnabled(s.ID, true, next); err != nil {
+			fmt.Fprintf(os.Stderr, "schedule enable: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s enabled — next run %s (%s)\n", s.Name, next.Local().Format("2006-01-02 15:04:05 MST"), untilText(next))
+
+	case "remove", "rm":
+		fs := flag.NewFlagSet("schedule remove", flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		fs.Parse(rest)
+		s, db := findSchedule(fs, *dbPath, "schedule remove")
+		defer db.Close()
+		if err := db.DeleteSchedule(s.ID); err != nil {
+			if errors.Is(err, coord.ErrSystemSchedule) {
+				fmt.Fprintf(os.Stderr, "schedule remove: %s is owned by the gateway (heartbeat); turn it off in config.yaml instead\n", s.Name)
+			} else {
+				fmt.Fprintf(os.Stderr, "schedule remove: %v\n", err)
+			}
+			os.Exit(1)
+		}
+		fmt.Printf("%s removed\n", s.Name)
+
+	case "run-now", "run":
+		fs := flag.NewFlagSet("schedule run-now", flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		fs.Parse(rest)
+		s, db := findSchedule(fs, *dbPath, "schedule run-now")
+		defer db.Close()
+		if err := db.FireSchedule(s.ID, time.Now()); err != nil {
+			fmt.Fprintf(os.Stderr, "schedule run-now: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s will fire on the next scheduler tick (within ~30s); its regular cadence resumes from then\n", s.Name)
+
+	default:
+		fmt.Fprintf(os.Stderr, "unknown schedule command: %s\n\n", sub)
+		scheduleUsage()
+		os.Exit(1)
+	}
+}
+
+// findSchedule reads the positional id-or-name after the flags and loads it.
+func findSchedule(fs *flag.FlagSet, dbPath, what string) (*coord.Schedule, *coord.DB) {
+	if fs.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "%s: give the schedule's name or id\n", what)
+		os.Exit(1)
+	}
+	db := openCoord(dbPath)
+	s, err := db.FindSchedule(fs.Arg(0))
+	if err != nil {
+		db.Close()
+		fmt.Fprintf(os.Stderr, "%s: %v\n", what, err)
+		os.Exit(1)
+	}
+	return s, db
+}
+
+// pickSpec turns the three mutually exclusive time flags into kind+spec.
+func pickSpec(cronSpec, every, at string) (kind, spec string, err error) {
+	set := 0
+	for _, v := range []string{cronSpec, every, at} {
+		if v != "" {
+			set++
+		}
+	}
+	if set != 1 {
+		return "", "", fmt.Errorf("give exactly one of --cron, --every or --at")
+	}
+	switch {
+	case cronSpec != "":
+		return coord.ScheduleCron, cronSpec, nil
+	case every != "":
+		return coord.ScheduleEvery, every, nil
+	}
+	return coord.ScheduleAt, at, nil
+}
+
+func nextText(s *coord.Schedule) string {
+	switch {
+	case !s.Enabled && s.Done():
+		return "done"
+	case !s.Enabled:
+		return "disabled"
+	case s.Done():
+		return "never"
+	}
+	return fmt.Sprintf("%s (%s)", s.NextRunAt.Local().Format("01-02 15:04"), untilText(s.NextRunAt))
+}
+
+func lastText(s *coord.Schedule) string {
+	if s.LastRunAt.IsZero() {
+		return "-"
+	}
+	status := s.LastStatus
+	if s.ConsecutiveFailures > 1 {
+		status += fmt.Sprintf(" ×%d", s.ConsecutiveFailures)
+	}
+	return fmt.Sprintf("%s %s ago", status, age(s.LastRunAt))
+}
+
+func payloadText(s *coord.Schedule) string {
+	switch s.PayloadKind {
+	case coord.PayloadAgent:
+		var p coord.AgentPayload
+		_ = json.Unmarshal(s.Payload, &p)
+		out := "task: " + p.Title
+		if p.To != "" {
+			out += " → " + p.To
+		}
+		return out
+	case coord.PayloadCommand:
+		var p coord.CommandPayload
+		_ = json.Unmarshal(s.Payload, &p)
+		return "sh: " + firstLineOf(p.Cmd, 60)
+	}
+	return s.PayloadKind
+}
+
+// untilText says how far away a time is: "in 4h12m", "3m overdue".
+func untilText(t time.Time) string {
+	d := time.Until(t).Round(time.Minute)
+	if d < 0 {
+		return (-d).String() + " overdue"
+	}
+	if d < time.Minute {
+		return "in under a minute"
+	}
+	return "in " + d.String()
+}
+
+func firstLineOf(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i] + " …"
+	}
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}
+
+func scheduleUsage() {
+	fmt.Fprintln(os.Stderr, `Usage: bomclaw schedule <command> [flags]
+
+Timed work, fired by whichever gateway has schedules.enabled=true. A schedule
+never runs a model itself: --agent-task creates an ordinary task at the
+appointed time (any agent claims it; the result is sent to Telegram);
+--command runs a shell command inside the gateway.
+
+Commands:
+  add       --name X (--cron "0 8 * * 1-5" | --every 10m | --at 2026-09-07T09:00) [--tz Asia/Ho_Chi_Minh]
+            (--agent-task "title" [--body ...] [--to agent] [--quiet] | --command "df -h" [--cwd dir] [--timeout 60])
+            [--owner agent] [--skip-missed]
+  list                    every schedule with its next and last run
+  show <name|id>          details and recent runs
+  enable <name|id>        turn on (next run computed from now; failure streak reset)
+  disable <name|id>       turn off; keeps the row and history
+  remove <name|id>        delete it and its runs
+  run-now <name|id>       fire on the next tick, then resume the cadence
+
+After consecutive failures a schedule retries sooner (30s, 1m, 5m, 15m, 1h),
+tells you on Telegram at the 2nd failure, and turns itself off at the 10th.
+Missed while every gateway was down: runs once on startup (or re-arms with
+--skip-missed). Cron: when both day-of-month and day-of-week are set, standard
+cron fires when EITHER matches.`)
+}

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,17 @@ tasks:
   poll_interval_seconds: 60
   timeout_minutes: 15
 
+# Timed work (docs/design/scheduling-and-long-tasks.md §5.5). `bomclaw schedule
+# add` writes rows to the shared database; a gateway with this on fires them.
+# OFF by default: a schedule creates tasks or runs shell commands with nobody
+# typing. Safe to turn on in every gateway — firing is a compare-and-set on
+# the row, so two loops never fire one schedule twice; a schedule with
+# --owner only fires in that gateway.
+schedules:
+  enabled: false
+  tick_seconds: 30              # how often to look for due schedules
+  command_timeout_seconds: 60   # cap on a --command payload (its --timeout overrides)
+
 # Credential pool. Leave `pool` empty (the default) and the agent runs on the
 # ambient login, exactly as before this existed.
 #

--- a/docs/design/scheduling-and-long-tasks.md
+++ b/docs/design/scheduling-and-long-tasks.md
@@ -384,11 +384,24 @@ Restart gateway ở bất kỳ bước nào: lease hết → claim lại → `--
 | Giai đoạn | Nội dung | Điều kiện hoàn thành |
 |---|---|---|
 | ~~**P0 — Nền cho "dài" và "nhìn thấy"**~~ ✅ | `task_runs` + liveness; `checkpoint`/`session_ref`/`continuations` + `--resume`; `progress`/`done` lệnh; dead-letter thật; task run vào `Runs` + `TurnEvent`; sửa chuông sang HTTP loopback; nới `assigned_to` khi agent chết | Một task 40 phút xong qua 3 run **giữ ngữ cảnh**; tray giữ Mac thức suốt; hết attempts → `failed` thật trên TaskBoard; poke chéo agent < 2s dưới auth bật. **Xong (PR #88–#91).** Đo thật: task claim sau 9s qua chuông HTTP; run đóng đúng; Runs API hiện `kind:task`. Hai bug chỉ lộ khi chạy thật: `SQLITE_BUSY` khi FinishRun đọc-rồi-ghi trong khi trace recorder ghi span (→ `_txlock=immediate` + retry, #90) và sweep của gateway kia gặt run còn sống ngay sau `task done` (→ reap theo tuổi, FinishRun ghi đè `lost`, #91) |
-| **P1 — Lịch & heartbeat** | `schedules`/`schedule_runs`; vòng quét CAS; `agent`+`command`; catch-up; backoff + auto-disable + báo Telegram; `bomclaw schedule`; heartbeat + scratch + skip rules; tab Schedules | `0 8 * * 1-5` chạy đúng giờ đúng TZ, đúng một lần khi hai gateway; máy tắt qua giờ → bù một lần; heartbeat scratch rỗng → 0 API call |
+| **P1 — Lịch & heartbeat** | **P1a ✅ lịch**: `schedules`/`schedule_runs` (schema v4, kèm `agents.scratch` cho P1b); vòng quét CAS 30s; `agent`→task `kind=scheduled` (run `pending` tới khi task kết thúc, gateway nào thấy trước thì settle — cũng CAS), `command`→sh trong gateway, output cắt 8KB giữ đầu+cuối; catch-up một lần / `--skip-missed`; bậc thang 30s→1m→5m→15m→1h, báo Telegram lần 2 (cooldown 1h), tự tắt lần 10; kết quả task theo lịch **gửi Telegram** cho chủ (`--quiet` để không); `bomclaw schedule add|list|show|enable|disable|remove|run-now`; RPC `schedules.*`; config `schedules.enabled` mặc định false. **P1b** heartbeat + scratch + skip rules; **P1c** tab Schedules — chưa | `0 8 * * 1-5` chạy đúng giờ đúng TZ, đúng một lần khi hai gateway (test `TestTwoGatewaysFireOnce`, `TestClaimScheduleIsExclusiveAcrossHandles`); máy tắt qua giờ → bù một lần (`TestMissedScheduleCatchesUpOnce`); heartbeat scratch rỗng → 0 API call |
 | **P2 — Cha–con** | `parent_id`, `task sub/block`, children-done → cha thức, prompt gom kết quả con, `max_open_children`, TaskBoard vẽ cây, wake `comment` + auto-read inbox | Luồng A (§7) chạy thật với hai agent; `MaxDepth` từ chối ở depth 6 trên đường thật |
 | **P3 — Song song trong một agent** | taskrunner claim nhiều task đồng thời (giới hạn `tasks.concurrency`), vẫn một lane cho chat | Task dài không chặn task ngắn xếp sau |
 
 P0 trước P1 vì lịch sinh ra task — task chưa "dài được, thấy được" thì lịch chỉ nhân bản vấn đề theo giờ. P2 sau P1 vì cha–con cần `task_runs` (P0) và cần chuông chạy (P0) để cha thức đúng lúc.
+
+---
+
+## 9b. Ghi chú triển khai P1a (khác/thêm so với §5.5)
+
+- **Kết quả task theo lịch được gửi Telegram** cho `security.allowed_user_ids` khi task `completed` (payload `quiet: true` để chỉ ghi). §5.5 không nói; lý do: một "tóm tắt inbox 08:00" không ai đọc là một lần gọi model vô ích. Đường gửi: `bot.Bot.Notify` — không có hội thoại để trả lời vào, nên người nhận là danh sách tin cậy trong config, không phải "ai nhắn gần nhất"; không có allow-list thì chỉ ghi log.
+- **"Lỗi" của payload `agent`**: hàng `schedule_runs` sinh ra ở trạng thái `pending` mang `task_id`; mỗi tick, gateway nào cũng quét pending, task `completed` → `ok`, `failed|canceled|rejected` → `failed`. Việc đóng là CAS trên `status` (`pending→…`) nên hai gateway không đếm lỗi hai lần.
+- **Thời điểm kế tiếp** tính từ *lúc claim* (`every` = now+d, `cron` = Next(now) trong TZ, `at` = `Never`). `ScheduleSucceeded` không đụng `next_run_at` (có thể đã claim lần mới); `ScheduleFailed` ghi đè `next_run_at = now + Backoff(n)` — bậc thang **đè** nhịp riêng của lịch, job hằng ngày lỗi sẽ thử lại trong giờ, không đợi mai.
+- **Missed** = trễ hơn `2×tick` (60s) — trễ một tick là bình thường, không phải downtime.
+- **Spec không parse được** (TZ bị gỡ, lỗi dữ liệu) → tự `enabled=0` + báo, thay vì log lỗi mỗi 30s mãi.
+- Parser cron: `robfig/cron/v3` chuẩn 5 trường + descriptor (`@daily`, `@every 1h`); DOM và DOW cùng đặt → **OR** (ghi trong `schedule --help`).
+- `schedule run-now` chỉ đẩy `next_run_at = now`; gateway bắt ở tick kế (≤30s). RPC `schedules.run` có thêm poke vòng quét cục bộ nên từ dashboard là ngay.
+- Chưa có: heartbeat (P1b), tab Schedules (P1c), purge `schedule_runs` theo tuổi (hàng nhỏ; thêm khi cần).
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/robfig/cron/v3 v3.0.1
 	golang.org/x/crypto v0.53.0
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -44,6 +44,27 @@ type Bot struct {
 // through the same path as Telegram messages (see Handler.RunTurn).
 func (b *Bot) Handler() *Handler { return b.handler }
 
+// Notify sends a message the gateway composed on its own initiative — a
+// schedule's result, a failure alert — to the people the config trusts. There
+// is no conversation to answer into, so the recipients are
+// security.allowed_user_ids (a private Telegram chat id equals the user id),
+// not whoever wrote last. With no allow-list there is nobody to tell; the line
+// goes to the log instead of to every stranger who ever messaged the bot.
+func (b *Bot) Notify(text string) {
+	if b == nil || b.handler == nil {
+		log.Printf("notify (no bot): %s", text)
+		return
+	}
+	ids := b.cfg.Security.AllowedUserIDs
+	if len(ids) == 0 {
+		log.Printf("notify (no allowed_user_ids to deliver to): %s", text)
+		return
+	}
+	for _, id := range ids {
+		b.handler.sendText(id, text)
+	}
+}
+
 // New creates and initialises the bot. db and sessions are shared with the
 // gateway so label renames and turn counters are visible to the dashboard
 // immediately (two managers on one SQLite file would clobber each other).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	// Tasks controls whether this agent picks up work its peers queued.
 	Tasks TasksConfig `yaml:"tasks"`
 
+	// Schedules controls the scheduler loop that fires timed work from the
+	// shared database. Off until enabled, like everything that spends tokens
+	// or runs commands without a person typing.
+	Schedules SchedulesConfig `yaml:"schedules"`
+
 	Telegram TelegramConfig `yaml:"telegram"`
 	Claude   ClaudeConfig   `yaml:"claude"`
 	Models   ModelsConfig   `yaml:"models"`
@@ -71,6 +76,15 @@ type TasksConfig struct {
 	AutoClaim           bool `yaml:"auto_claim"`
 	PollIntervalSeconds int  `yaml:"poll_interval_seconds"` // default 60
 	TimeoutMinutes      int  `yaml:"timeout_minutes"`       // default 15
+}
+
+// SchedulesConfig tunes the scheduler (docs/design/scheduling-and-long-tasks.md
+// §5.5). Every gateway on the machine may run it: firing is a compare-and-set
+// on the shared row, so two loops never fire one schedule twice.
+type SchedulesConfig struct {
+	Enabled               bool `yaml:"enabled"`
+	TickSeconds           int  `yaml:"tick_seconds"`            // default 30
+	CommandTimeoutSeconds int  `yaml:"command_timeout_seconds"` // default 60; a payload's timeout_s overrides
 }
 
 // GatewayConfig holds gateway HTTP server settings.
@@ -262,6 +276,12 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Tasks.TimeoutMinutes == 0 {
 		cfg.Tasks.TimeoutMinutes = 15
+	}
+	if cfg.Schedules.TickSeconds == 0 {
+		cfg.Schedules.TickSeconds = 30
+	}
+	if cfg.Schedules.CommandTimeoutSeconds == 0 {
+		cfg.Schedules.CommandTimeoutSeconds = 60
 	}
 	if cfg.Telegram.Timeout == 0 {
 		cfg.Telegram.Timeout = 60

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -26,7 +26,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 3
+const schemaVersion = 4
 
 // DB is the shared coordination database.
 type DB struct {
@@ -99,7 +99,8 @@ var ddl = []string{
 		ws_addr      TEXT NOT NULL DEFAULT '',  -- how a peer reaches it
 		workspace    TEXT NOT NULL DEFAULT '',
 		started_at   TEXT NOT NULL,
-		last_seen_at TEXT NOT NULL              -- heartbeat; stale ⇒ presumed dead
+		last_seen_at TEXT NOT NULL,             -- heartbeat; stale ⇒ presumed dead
+		scratch      TEXT NOT NULL DEFAULT ''   -- v4: what the agent's heartbeat should look at
 	) STRICT`,
 
 	// --- traces (LangSmith run tree) ----------------------------------------
@@ -181,6 +182,51 @@ var ddl = []string{
 	) STRICT`,
 	`CREATE INDEX IF NOT EXISTS idx_task_runs_task ON task_runs(task_id, started_at)`,
 
+	// --- schedules: automations decide WHEN, tasks record WHAT happened -----
+	// A schedule never runs a model itself. When it is due, an `agent` payload
+	// materialises one ordinary task row (kind='scheduled') that goes through
+	// claim/lease/fencing like any other; a `command` payload runs a shell
+	// command inside the gateway. next_run_at is the only "clock": firing is
+	// a compare-and-set on it, so two gateways that both see a due schedule
+	// produce exactly one run without a lock or a leader.
+	`CREATE TABLE IF NOT EXISTS schedules (
+		id                   TEXT PRIMARY KEY,          -- 'sch_' || uuid
+		name                 TEXT NOT NULL UNIQUE,
+		created_by           TEXT NOT NULL,
+		owner_agent          TEXT NOT NULL DEFAULT '',  -- '' = any gateway may fire it
+		kind                 TEXT NOT NULL,             -- at | every | cron
+		spec                 TEXT NOT NULL,             -- RFC3339 | duration | 5-field cron
+		tz                   TEXT NOT NULL,             -- IANA zone, always explicit
+		payload_kind         TEXT NOT NULL,             -- agent | command
+		payload              TEXT NOT NULL,             -- JSON
+		enabled              INTEGER NOT NULL DEFAULT 1,
+		system               INTEGER NOT NULL DEFAULT 0, -- 1 = owned by the gateway (heartbeat)
+		skip_missed          INTEGER NOT NULL DEFAULT 0, -- 1 = re-arm after downtime instead of catching up
+		next_run_at          TEXT NOT NULL,
+		last_run_at          TEXT NOT NULL DEFAULT '',
+		last_status          TEXT NOT NULL DEFAULT '',  -- ok | failed | skipped
+		consecutive_failures INTEGER NOT NULL DEFAULT 0,
+		created_at           TEXT NOT NULL,
+		updated_at           TEXT NOT NULL
+	) STRICT`,
+	`CREATE INDEX IF NOT EXISTS idx_schedules_due ON schedules(enabled, next_run_at)`,
+
+	// One row per firing. For an agent payload the row is 'pending' until the
+	// task it created reaches a terminal state; whichever gateway notices
+	// settles it (again by compare-and-set on status).
+	`CREATE TABLE IF NOT EXISTS schedule_runs (
+		id          TEXT PRIMARY KEY,               -- 'sr_' || uuid
+		schedule_id TEXT NOT NULL,
+		task_id     TEXT NOT NULL DEFAULT '',       -- when payload_kind = agent
+		started_at  TEXT NOT NULL,
+		ended_at    TEXT NOT NULL DEFAULT '',
+		status      TEXT NOT NULL,                  -- pending | ok | failed | skipped
+		exit_code   INTEGER NOT NULL DEFAULT 0,
+		output      TEXT NOT NULL DEFAULT ''        -- command output, cut to 8KB
+	) STRICT`,
+	`CREATE INDEX IF NOT EXISTS idx_schedule_runs ON schedule_runs(schedule_id, started_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS idx_schedule_runs_pending ON schedule_runs(status, task_id)`,
+
 	`CREATE TABLE IF NOT EXISTS task_events (
 		id         INTEGER PRIMARY KEY AUTOINCREMENT,
 		task_id    TEXT NOT NULL,
@@ -256,6 +302,11 @@ var v3Columns = []struct{ name, decl string }{
 	{"fail_reason", "TEXT NOT NULL DEFAULT ''"},
 }
 
+// v4Columns: the heartbeat scratchpad on agents. Same guard as v3Columns.
+var v4Columns = []struct{ table, name, decl string }{
+	{"agents", "scratch", "TEXT NOT NULL DEFAULT ''"},
+}
+
 // v3Indexes reference columns that v3Columns adds, so on a database created by
 // the previous version they can only be built after those columns exist — a
 // fresh database gets them from the CREATE TABLE and the ALTERs are no-ops,
@@ -272,6 +323,11 @@ func (db *DB) migrate() error {
 	}
 	for _, c := range v3Columns {
 		if err := db.ensureColumn("tasks", c.name, c.decl); err != nil {
+			return err
+		}
+	}
+	for _, c := range v4Columns {
+		if err := db.ensureColumn(c.table, c.name, c.decl); err != nil {
 			return err
 		}
 	}
@@ -318,10 +374,19 @@ func firstLine(s string) string {
 	return s
 }
 
-// ts formats a timestamp the way every column in this schema stores it.
-// RFC3339 with nanoseconds sorts lexicographically, which the dotted_order
-// scheme and every "ORDER BY started_at" depend on.
-func ts(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
+// ts formats a timestamp the way every column in this schema stores it. The
+// dotted_order scheme, every "ORDER BY started_at", every "lease_until <= now"
+// and the scheduler's "next_run_at <= now" compare these as strings, so the
+// format must sort like the instants do.
+//
+// time.RFC3339Nano does NOT: it trims trailing zeros from the fraction, so
+// "…00.1Z" sorts after "…00.10000001Z" ('Z' > '0') although it is earlier.
+// That made a task finished at .1 look unclaimable at .10000001 — a flake in
+// tests, a 10-minute lease wait in production. Nine fixed digits keep the
+// string order equal to the time order; parseTS still reads either form.
+func ts(t time.Time) string { return t.UTC().Format(tsLayout) }
+
+const tsLayout = "2006-01-02T15:04:05.000000000Z07:00"
 
 // parseTS is the inverse of ts, tolerant of the plain RFC3339 rows that
 // hand-written or older data may contain.

--- a/internal/coord/schedules.go
+++ b/internal/coord/schedules.go
@@ -1,0 +1,578 @@
+package coord
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Schedule kinds: how the next firing is computed from the spec.
+const (
+	ScheduleAt    = "at"    // spec is one RFC3339 instant; fires once
+	ScheduleEvery = "every" // spec is a Go duration; fires that long after each firing
+	ScheduleCron  = "cron"  // spec is a 5-field cron line (or @daily-style descriptor)
+)
+
+// Payload kinds: what a firing does. Neither runs a model in the scheduler.
+const (
+	PayloadAgent   = "agent"   // materialise one task row; the task runner does the rest
+	PayloadCommand = "command" // run a shell command inside the gateway
+)
+
+// Schedule run statuses.
+const (
+	ScheduleRunPending = "pending" // an agent task was created and has not finished
+	ScheduleRunOK      = "ok"
+	ScheduleRunFailed  = "failed"
+	ScheduleRunSkipped = "skipped" // due while the gateway was down and skip_missed was set
+)
+
+// Never is the next_run_at of a schedule with no future firing — a one-shot
+// that has fired. It sorts after every real timestamp, so the due query never
+// returns it, and the column stays NOT NULL.
+const Never = "9999-12-31T00:00:00Z"
+
+// Failure ladder (OpenClaw's): after consecutive failures a schedule retries
+// sooner than its own cadence, then gives up. A person is told at
+// AlertAfterFailures; the schedule turns itself off at DisableAfterFailures.
+const (
+	AlertAfterFailures   = 2
+	DisableAfterFailures = 10
+)
+
+// MaxScheduleOutput is how much of a command's output one run keeps.
+const MaxScheduleOutput = 8 * 1024
+
+// ErrSystemSchedule means the row is owned by the gateway (a heartbeat) and
+// cannot be removed from the CLI; it goes away when its config does.
+var ErrSystemSchedule = errors.New("coord: system schedule — change it in config, not here")
+
+// Schedule is one automation: it decides WHEN; schedule_runs and tasks record
+// WHAT happened.
+type Schedule struct {
+	ID                  string          `json:"id"`
+	Name                string          `json:"name"`
+	CreatedBy           string          `json:"created_by"`
+	OwnerAgent          string          `json:"owner_agent,omitempty"` // "" = any gateway fires it
+	Kind                string          `json:"kind"`
+	Spec                string          `json:"spec"`
+	TZ                  string          `json:"tz"`
+	PayloadKind         string          `json:"payload_kind"`
+	Payload             json.RawMessage `json:"payload"`
+	Enabled             bool            `json:"enabled"`
+	System              bool            `json:"system"`
+	SkipMissed          bool            `json:"skip_missed"`
+	NextRunAt           time.Time       `json:"next_run_at"`
+	LastRunAt           time.Time       `json:"last_run_at,omitempty"`
+	LastStatus          string          `json:"last_status,omitempty"`
+	ConsecutiveFailures int             `json:"consecutive_failures"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at"`
+
+	// nextRaw is next_run_at exactly as stored. ClaimSchedule compares on it,
+	// so a row written with a different timestamp precision still matches.
+	nextRaw string
+}
+
+// NextRaw is the stored next_run_at, the token ClaimSchedule needs.
+func (s *Schedule) NextRaw() string { return s.nextRaw }
+
+// Done reports a one-shot that has fired (next_run_at = Never).
+func (s *Schedule) Done() bool { return s.nextRaw == Never }
+
+// AgentPayload is what an `agent` schedule turns into a task.
+type AgentPayload struct {
+	Title string `json:"title"`
+	Body  string `json:"body,omitempty"`
+	To    string `json:"to,omitempty"`    // assign to this agent; "" = owner_agent, or anyone
+	Quiet bool   `json:"quiet,omitempty"` // do not deliver the result to the owner's chat
+}
+
+// CommandPayload is what a `command` schedule runs.
+type CommandPayload struct {
+	Cmd      string `json:"cmd"`
+	Cwd      string `json:"cwd,omitempty"`
+	TimeoutS int    `json:"timeout_s,omitempty"`
+}
+
+// ScheduleRun is one firing.
+type ScheduleRun struct {
+	ID         string    `json:"id"`
+	ScheduleID string    `json:"schedule_id"`
+	TaskID     string    `json:"task_id,omitempty"`
+	StartedAt  time.Time `json:"started_at"`
+	EndedAt    time.Time `json:"ended_at,omitempty"`
+	Status     string    `json:"status"`
+	ExitCode   int       `json:"exit_code"`
+	Output     string    `json:"output,omitempty"`
+}
+
+// NewSchedule is what it takes to create one. NextRunAt is computed by the
+// caller (internal/scheduler knows the calendar; this package only stores it).
+type NewSchedule struct {
+	Name        string
+	CreatedBy   string
+	OwnerAgent  string
+	Kind        string
+	Spec        string
+	TZ          string
+	PayloadKind string
+	Payload     any // AgentPayload, CommandPayload, or a json.RawMessage
+	SkipMissed  bool
+	System      bool
+	NextRunAt   time.Time
+}
+
+// CreateSchedule stores a schedule. It validates shape, not calendar: the spec
+// must already have produced NextRunAt.
+func (db *DB) CreateSchedule(n NewSchedule) (*Schedule, error) {
+	n.Name = strings.TrimSpace(n.Name)
+	if n.Name == "" {
+		return nil, fmt.Errorf("coord: schedule name is required")
+	}
+	switch n.Kind {
+	case ScheduleAt, ScheduleEvery, ScheduleCron:
+	default:
+		return nil, fmt.Errorf("coord: schedule kind %q must be at, every or cron", n.Kind)
+	}
+	if strings.TrimSpace(n.Spec) == "" {
+		return nil, fmt.Errorf("coord: schedule spec is required")
+	}
+	if strings.TrimSpace(n.TZ) == "" {
+		return nil, fmt.Errorf("coord: schedule tz is required (an IANA zone such as Asia/Ho_Chi_Minh)")
+	}
+	if n.NextRunAt.IsZero() {
+		return nil, fmt.Errorf("coord: schedule has no first run time")
+	}
+	payload, err := encodePayload(n.PayloadKind, n.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	s := &Schedule{
+		ID:          "sch_" + uuid.NewString(),
+		Name:        n.Name,
+		CreatedBy:   n.CreatedBy,
+		OwnerAgent:  n.OwnerAgent,
+		Kind:        n.Kind,
+		Spec:        strings.TrimSpace(n.Spec),
+		TZ:          n.TZ,
+		PayloadKind: n.PayloadKind,
+		Payload:     payload,
+		Enabled:     true,
+		System:      n.System,
+		SkipMissed:  n.SkipMissed,
+		NextRunAt:   n.NextRunAt,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		nextRaw:     ts(n.NextRunAt),
+	}
+	_, err = db.conn.Exec(`INSERT INTO schedules
+		(id, name, created_by, owner_agent, kind, spec, tz, payload_kind, payload,
+		 enabled, system, skip_missed, next_run_at, last_run_at, last_status,
+		 consecutive_failures, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, '', '', 0, ?, ?)`,
+		s.ID, s.Name, s.CreatedBy, s.OwnerAgent, s.Kind, s.Spec, s.TZ, s.PayloadKind, string(s.Payload),
+		b2i(s.System), b2i(s.SkipMissed), s.nextRaw, ts(now), ts(now))
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE") {
+			return nil, fmt.Errorf("coord: a schedule named %q already exists", s.Name)
+		}
+		return nil, fmt.Errorf("create schedule: %w", err)
+	}
+	return s, nil
+}
+
+// encodePayload checks that a payload has what its kind needs and returns it
+// as stored JSON. A schedule that cannot fire is a bug found at 08:00, so the
+// required fields are checked here rather than then.
+func encodePayload(kind string, payload any) (json.RawMessage, error) {
+	var raw []byte
+	switch p := payload.(type) {
+	case nil:
+		return nil, fmt.Errorf("coord: schedule payload is required")
+	case json.RawMessage:
+		raw = p
+	case []byte:
+		raw = p
+	case string:
+		raw = []byte(p)
+	default:
+		var err error
+		if raw, err = json.Marshal(p); err != nil {
+			return nil, fmt.Errorf("coord: encode payload: %w", err)
+		}
+	}
+	switch kind {
+	case PayloadAgent:
+		var p AgentPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("coord: agent payload: %w", err)
+		}
+		if strings.TrimSpace(p.Title) == "" {
+			return nil, fmt.Errorf("coord: agent payload needs a title")
+		}
+	case PayloadCommand:
+		var p CommandPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("coord: command payload: %w", err)
+		}
+		if strings.TrimSpace(p.Cmd) == "" {
+			return nil, fmt.Errorf("coord: command payload needs cmd")
+		}
+	default:
+		return nil, fmt.Errorf("coord: payload kind %q must be agent or command", kind)
+	}
+	return json.RawMessage(raw), nil
+}
+
+const scheduleCols = `id, name, created_by, owner_agent, kind, spec, tz, payload_kind, payload,
+	enabled, system, skip_missed, next_run_at, last_run_at, last_status,
+	consecutive_failures, created_at, updated_at`
+
+// GetSchedule fetches by id.
+func (db *DB) GetSchedule(id string) (*Schedule, error) {
+	s, err := scanSchedule(db.conn.QueryRow(`SELECT `+scheduleCols+` FROM schedules WHERE id = ?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("coord: no schedule %s", id)
+	}
+	return s, err
+}
+
+// FindSchedule accepts an id or a name — the CLI takes either.
+func (db *DB) FindSchedule(idOrName string) (*Schedule, error) {
+	s, err := scanSchedule(db.conn.QueryRow(
+		`SELECT `+scheduleCols+` FROM schedules WHERE id = ? OR name = ? LIMIT 1`, idOrName, idOrName))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("coord: no schedule %q", idOrName)
+	}
+	return s, err
+}
+
+// ListSchedules returns every schedule, soonest first; disabled ones last.
+func (db *DB) ListSchedules() ([]Schedule, error) {
+	rows, err := db.conn.Query(`SELECT ` + scheduleCols + ` FROM schedules
+		ORDER BY enabled DESC, next_run_at, name`)
+	if err != nil {
+		return nil, fmt.Errorf("list schedules: %w", err)
+	}
+	defer rows.Close()
+	out := []Schedule{}
+	for rows.Next() {
+		s, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *s)
+	}
+	return out, rows.Err()
+}
+
+// DueSchedules returns the enabled schedules whose time has come. The caller
+// must still win ClaimSchedule before acting on any of them.
+func (db *DB) DueSchedules(now time.Time) ([]Schedule, error) {
+	rows, err := db.conn.Query(`SELECT `+scheduleCols+` FROM schedules
+		WHERE enabled = 1 AND next_run_at <= ? ORDER BY next_run_at`, ts(now))
+	if err != nil {
+		return nil, fmt.Errorf("due schedules: %w", err)
+	}
+	defer rows.Close()
+	out := []Schedule{}
+	for rows.Next() {
+		s, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *s)
+	}
+	return out, rows.Err()
+}
+
+// ClaimSchedule is the compare-and-set that makes firing exclusive: it moves
+// next_run_at from the value this caller saw (seenNext) to next, and reports
+// whether this caller was the one to do it. Two gateways that both found the
+// schedule due both call this; the UPDATE matches for exactly one of them.
+//
+// next is what the caller computed from NOW, not from the old mark — that is
+// what turns eight hours of downtime into one catch-up run instead of eight.
+// A zero next stores Never (a one-shot that has fired).
+func (db *DB) ClaimSchedule(id, seenNext string, now, next time.Time) (bool, error) {
+	nextRaw := Never
+	if !next.IsZero() {
+		nextRaw = ts(next)
+	}
+	res, err := db.conn.Exec(`UPDATE schedules
+		SET next_run_at = ?, last_run_at = ?, updated_at = ?
+		WHERE id = ? AND enabled = 1 AND next_run_at = ?`,
+		nextRaw, ts(now), ts(now), id, seenNext)
+	if err != nil {
+		return false, fmt.Errorf("claim schedule %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+
+// SetScheduleEnabled turns a schedule on or off. Re-enabling takes a fresh
+// next_run_at from the caller so a schedule paused for a week does not fire the
+// moment it is switched back on; the failure count resets with it.
+func (db *DB) SetScheduleEnabled(id string, enabled bool, next time.Time) error {
+	now := ts(time.Now())
+	var res sql.Result
+	var err error
+	if enabled {
+		if next.IsZero() {
+			return fmt.Errorf("coord: enabling a schedule needs its next run time")
+		}
+		res, err = db.conn.Exec(`UPDATE schedules
+			SET enabled = 1, next_run_at = ?, consecutive_failures = 0, updated_at = ?
+			WHERE id = ?`, ts(next), now, id)
+	} else {
+		res, err = db.conn.Exec(`UPDATE schedules SET enabled = 0, updated_at = ? WHERE id = ?`, now, id)
+	}
+	if err != nil {
+		return fmt.Errorf("set schedule %s enabled=%v: %w", id, enabled, err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("coord: no schedule %s", id)
+	}
+	return nil
+}
+
+// DeleteSchedule removes a schedule and its run history. System rows refuse.
+func (db *DB) DeleteSchedule(id string) error {
+	var system int
+	err := db.conn.QueryRow(`SELECT system FROM schedules WHERE id = ?`, id).Scan(&system)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("coord: no schedule %s", id)
+	}
+	if err != nil {
+		return fmt.Errorf("delete schedule %s: %w", id, err)
+	}
+	if system == 1 {
+		return ErrSystemSchedule
+	}
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`DELETE FROM schedule_runs WHERE schedule_id = ?`, id); err != nil {
+		return fmt.Errorf("delete schedule runs %s: %w", id, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM schedules WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete schedule %s: %w", id, err)
+	}
+	return tx.Commit()
+}
+
+// FireSchedule moves a schedule's clock to now so the next tick fires it. It
+// does not enable a disabled schedule: the due query ignores those, and
+// silently re-enabling something a person switched off would be a surprise.
+func (db *DB) FireSchedule(id string, now time.Time) error {
+	s, err := db.GetSchedule(id)
+	if err != nil {
+		return err
+	}
+	if !s.Enabled {
+		return fmt.Errorf("coord: schedule %s is disabled — enable it first", s.Name)
+	}
+	_, err = db.conn.Exec(`UPDATE schedules SET next_run_at = ?, updated_at = ? WHERE id = ?`,
+		ts(now), ts(now), id)
+	if err != nil {
+		return fmt.Errorf("fire schedule %s: %w", id, err)
+	}
+	return nil
+}
+
+// ScheduleSucceeded records a good firing: the failure streak ends. status is
+// ScheduleRunOK or ScheduleRunSkipped. A one-shot is switched off here — not at
+// claim time — so a one-shot that failed keeps retrying up the ladder.
+func (db *DB) ScheduleSucceeded(id, status string, now time.Time) error {
+	_, err := db.conn.Exec(`UPDATE schedules
+		SET consecutive_failures = 0, last_status = ?, updated_at = ?,
+		    enabled = CASE WHEN kind = 'at' THEN 0 ELSE enabled END
+		WHERE id = ?`, status, ts(now), id)
+	if err != nil {
+		return fmt.Errorf("schedule %s succeeded: %w", id, err)
+	}
+	return nil
+}
+
+// ScheduleFailed records a bad firing and applies the ladder: the streak grows,
+// the next run moves to now+Backoff(streak), and at DisableAfterFailures the
+// schedule switches itself off. It returns the updated row and whether this
+// call is the one that disabled it, so the caller can tell a person once.
+func (db *DB) ScheduleFailed(id string, now time.Time) (*Schedule, bool, error) {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return nil, false, err
+	}
+	defer tx.Rollback()
+
+	var failures, enabled int
+	if err := tx.QueryRow(`SELECT consecutive_failures, enabled FROM schedules WHERE id = ?`, id).
+		Scan(&failures, &enabled); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("coord: no schedule %s", id)
+		}
+		return nil, false, fmt.Errorf("schedule %s failed: %w", id, err)
+	}
+	failures++
+	disable := failures >= DisableAfterFailures
+	newEnabled := enabled
+	if disable {
+		newEnabled = 0
+	}
+	if _, err := tx.Exec(`UPDATE schedules
+		SET consecutive_failures = ?, last_status = ?, next_run_at = ?, enabled = ?, updated_at = ?
+		WHERE id = ?`,
+		failures, ScheduleRunFailed, ts(now.Add(Backoff(failures))), newEnabled, ts(now), id); err != nil {
+		return nil, false, fmt.Errorf("schedule %s failed: %w", id, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, err
+	}
+	s, err := db.GetSchedule(id)
+	if err != nil {
+		return nil, false, err
+	}
+	return s, disable && enabled == 1, nil
+}
+
+// Backoff is the retry ladder: how long after the n-th consecutive failure the
+// next attempt waits. It overrides the schedule's own cadence — a daily job
+// that fails retries within the hour, not tomorrow — and tops out at an hour.
+func Backoff(n int) time.Duration {
+	ladder := []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute, 15 * time.Minute, time.Hour}
+	if n < 1 {
+		n = 1
+	}
+	if n > len(ladder) {
+		n = len(ladder)
+	}
+	return ladder[n-1]
+}
+
+// RecordScheduleRun writes one firing. Output is cut to MaxScheduleOutput.
+func (db *DB) RecordScheduleRun(r ScheduleRun) (*ScheduleRun, error) {
+	if r.ID == "" {
+		r.ID = "sr_" + uuid.NewString()
+	}
+	if r.StartedAt.IsZero() {
+		r.StartedAt = time.Now()
+	}
+	if r.Status == "" {
+		return nil, fmt.Errorf("coord: schedule run needs a status")
+	}
+	r.Output = cutOutput(r.Output, MaxScheduleOutput)
+	ended := ""
+	if !r.EndedAt.IsZero() {
+		ended = ts(r.EndedAt)
+	}
+	_, err := db.conn.Exec(`INSERT INTO schedule_runs
+		(id, schedule_id, task_id, started_at, ended_at, status, exit_code, output)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.ScheduleID, r.TaskID, ts(r.StartedAt), ended, r.Status, r.ExitCode, r.Output)
+	if err != nil {
+		return nil, fmt.Errorf("record schedule run: %w", err)
+	}
+	return &r, nil
+}
+
+// SettleScheduleRun closes a pending (task-backed) run. It is a compare-and-set
+// on status: whichever gateway's tick notices the task has finished settles the
+// run, and only the one that flips pending→status applies the outcome to the
+// schedule, so a failure is never counted twice.
+func (db *DB) SettleScheduleRun(runID, status, output string, now time.Time) (bool, error) {
+	res, err := db.conn.Exec(`UPDATE schedule_runs SET status = ?, ended_at = ?, output = ?
+		WHERE id = ? AND status = ?`,
+		status, ts(now), cutOutput(output, MaxScheduleOutput), runID, ScheduleRunPending)
+	if err != nil {
+		return false, fmt.Errorf("settle schedule run %s: %w", runID, err)
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+
+// PendingScheduleRuns lists runs still waiting on their task.
+func (db *DB) PendingScheduleRuns() ([]ScheduleRun, error) {
+	rows, err := db.conn.Query(`SELECT id, schedule_id, task_id, started_at, ended_at, status, exit_code, output
+		FROM schedule_runs WHERE status = ? AND task_id != '' ORDER BY started_at`, ScheduleRunPending)
+	if err != nil {
+		return nil, fmt.Errorf("pending schedule runs: %w", err)
+	}
+	defer rows.Close()
+	return scanScheduleRuns(rows)
+}
+
+// ScheduleRuns lists a schedule's firings, newest first.
+func (db *DB) ScheduleRuns(scheduleID string, limit int) ([]ScheduleRun, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := db.conn.Query(`SELECT id, schedule_id, task_id, started_at, ended_at, status, exit_code, output
+		FROM schedule_runs WHERE schedule_id = ? ORDER BY started_at DESC LIMIT ?`, scheduleID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("schedule runs: %w", err)
+	}
+	defer rows.Close()
+	return scanScheduleRuns(rows)
+}
+
+func scanScheduleRuns(rows *sql.Rows) ([]ScheduleRun, error) {
+	out := []ScheduleRun{}
+	for rows.Next() {
+		var r ScheduleRun
+		var started, ended string
+		if err := rows.Scan(&r.ID, &r.ScheduleID, &r.TaskID, &started, &ended, &r.Status, &r.ExitCode, &r.Output); err != nil {
+			return nil, fmt.Errorf("scan schedule run: %w", err)
+		}
+		r.StartedAt, r.EndedAt = parseTS(started), parseTS(ended)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func scanSchedule(s scanner) (*Schedule, error) {
+	var sc Schedule
+	var payload, next, last, created, updated string
+	var enabled, system, skip int
+	if err := s.Scan(&sc.ID, &sc.Name, &sc.CreatedBy, &sc.OwnerAgent, &sc.Kind, &sc.Spec, &sc.TZ,
+		&sc.PayloadKind, &payload, &enabled, &system, &skip, &next, &last, &sc.LastStatus,
+		&sc.ConsecutiveFailures, &created, &updated); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("scan schedule: %w", err)
+	}
+	sc.Payload = json.RawMessage(payload)
+	sc.Enabled, sc.System, sc.SkipMissed = enabled == 1, system == 1, skip == 1
+	sc.nextRaw = next
+	sc.NextRunAt = parseTS(next)
+	sc.LastRunAt = parseTS(last)
+	sc.CreatedAt, sc.UpdatedAt = parseTS(created), parseTS(updated)
+	return &sc, nil
+}
+
+// cutOutput keeps the head and the tail of a long output: a `df -h` wants its
+// first lines, a failing build its last ones.
+func cutOutput(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	half := max / 2
+	return s[:half] + fmt.Sprintf("\n…[%d bytes cut]…\n", len(s)-2*half) + s[len(s)-half:]
+}
+
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/coord/schedules_test.go
+++ b/internal/coord/schedules_test.go
@@ -1,0 +1,354 @@
+package coord
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/storage"
+)
+
+func newSchedule(t *testing.T, db *DB, name string, next time.Time) *Schedule {
+	t.Helper()
+	s, err := db.CreateSchedule(NewSchedule{
+		Name: name, CreatedBy: "test", Kind: ScheduleEvery, Spec: "10m", TZ: "UTC",
+		PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "true"}, NextRunAt: next,
+	})
+	if err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+	return s
+}
+
+func TestCreateScheduleValidatesShape(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	cases := []struct {
+		name string
+		n    NewSchedule
+		want string
+	}{
+		{"no name", NewSchedule{Kind: ScheduleEvery, Spec: "1m", TZ: "UTC", PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "x"}, NextRunAt: now}, "name is required"},
+		{"bad kind", NewSchedule{Name: "a", Kind: "weekly", Spec: "1m", TZ: "UTC", PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "x"}, NextRunAt: now}, "must be at, every or cron"},
+		{"no tz", NewSchedule{Name: "a", Kind: ScheduleEvery, Spec: "1m", PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "x"}, NextRunAt: now}, "tz is required"},
+		{"no next", NewSchedule{Name: "a", Kind: ScheduleEvery, Spec: "1m", TZ: "UTC", PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "x"}}, "no first run time"},
+		{"agent without title", NewSchedule{Name: "a", Kind: ScheduleEvery, Spec: "1m", TZ: "UTC", PayloadKind: PayloadAgent, Payload: AgentPayload{}, NextRunAt: now}, "needs a title"},
+		{"command without cmd", NewSchedule{Name: "a", Kind: ScheduleEvery, Spec: "1m", TZ: "UTC", PayloadKind: PayloadCommand, Payload: CommandPayload{}, NextRunAt: now}, "needs cmd"},
+		{"bad payload kind", NewSchedule{Name: "a", Kind: ScheduleEvery, Spec: "1m", TZ: "UTC", PayloadKind: "webhook", Payload: `{}`, NextRunAt: now}, "must be agent or command"},
+	}
+	for _, c := range cases {
+		_, err := db.CreateSchedule(c.n)
+		if err == nil || !strings.Contains(err.Error(), c.want) {
+			t.Errorf("%s: got %v, want error containing %q", c.name, err, c.want)
+		}
+	}
+	newSchedule(t, db, "dup", now)
+	if _, err := db.CreateSchedule(NewSchedule{Name: "dup", CreatedBy: "t", Kind: ScheduleEvery, Spec: "1m", TZ: "UTC",
+		PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "x"}, NextRunAt: now}); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("duplicate name: got %v", err)
+	}
+}
+
+// The heart of P1: two gateways hold two handles to one file, both see the
+// schedule due, both try to claim it — exactly one wins.
+func TestClaimScheduleIsExclusiveAcrossHandles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coord.db")
+	a, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	b, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	now := time.Now()
+	s := newSchedule(t, a, "shared", now.Add(-time.Minute))
+
+	dueA, _ := a.DueSchedules(now)
+	dueB, _ := b.DueSchedules(now)
+	if len(dueA) != 1 || len(dueB) != 1 {
+		t.Fatalf("both handles should see one due schedule, got %d and %d", len(dueA), len(dueB))
+	}
+	next := now.Add(10 * time.Minute)
+	wonA, err := a.ClaimSchedule(s.ID, dueA[0].NextRaw(), now, next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wonB, err := b.ClaimSchedule(s.ID, dueB[0].NextRaw(), now, next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wonA == wonB {
+		t.Fatalf("exactly one claim must win: a=%v b=%v", wonA, wonB)
+	}
+	got, _ := a.GetSchedule(s.ID)
+	if !got.NextRunAt.Equal(next) || got.LastRunAt.IsZero() {
+		t.Errorf("winner should have moved the clock: next=%v last=%v", got.NextRunAt, got.LastRunAt)
+	}
+	if due, _ := b.DueSchedules(now); len(due) != 0 {
+		t.Errorf("claimed schedule must no longer be due, got %d", len(due))
+	}
+}
+
+func TestClaimScheduleRefusesDisabledAndStaleToken(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	s := newSchedule(t, db, "s", now.Add(-time.Second))
+	if won, _ := db.ClaimSchedule(s.ID, "2000-01-01T00:00:00Z", now, now.Add(time.Hour)); won {
+		t.Error("a stale token must not claim")
+	}
+	if err := db.SetScheduleEnabled(s.ID, false, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if won, _ := db.ClaimSchedule(s.ID, s.NextRaw(), now, now.Add(time.Hour)); won {
+		t.Error("a disabled schedule must not claim")
+	}
+}
+
+// A one-shot: claim stores Never, success switches it off, failure keeps it
+// retrying up the ladder.
+func TestOneShotLifecycle(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	s, err := db.CreateSchedule(NewSchedule{Name: "once", CreatedBy: "t", Kind: ScheduleAt, Spec: "x", TZ: "UTC",
+		PayloadKind: PayloadCommand, Payload: CommandPayload{Cmd: "true"}, NextRunAt: now.Add(-time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if won, _ := db.ClaimSchedule(s.ID, s.NextRaw(), now, time.Time{}); !won {
+		t.Fatal("claim should win")
+	}
+	got, _ := db.GetSchedule(s.ID)
+	if !got.Done() || !got.Enabled {
+		t.Fatalf("after claim: done=%v enabled=%v, want done and still enabled", got.Done(), got.Enabled)
+	}
+	// Failure: retried at now+30s, still enabled.
+	updated, disabled, err := db.ScheduleFailed(s.ID, now)
+	if err != nil || disabled {
+		t.Fatalf("first failure: err=%v disabled=%v", err, disabled)
+	}
+	if !updated.Enabled || updated.ConsecutiveFailures != 1 || updated.NextRunAt.Sub(now) != 30*time.Second {
+		t.Errorf("after one failure: enabled=%v failures=%d next-in=%s", updated.Enabled, updated.ConsecutiveFailures, updated.NextRunAt.Sub(now))
+	}
+	// Success: off for good.
+	if err := db.ScheduleSucceeded(s.ID, ScheduleRunOK, now); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = db.GetSchedule(s.ID)
+	if got.Enabled || got.ConsecutiveFailures != 0 || got.LastStatus != ScheduleRunOK {
+		t.Errorf("after success: enabled=%v failures=%d status=%s", got.Enabled, got.ConsecutiveFailures, got.LastStatus)
+	}
+}
+
+func TestFailureLadderAndAutoDisable(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	s := newSchedule(t, db, "flaky", now)
+
+	wantBackoff := []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute, 15 * time.Minute, time.Hour, time.Hour}
+	for i, want := range wantBackoff {
+		updated, disabled, err := db.ScheduleFailed(s.ID, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if disabled {
+			t.Fatalf("failure %d must not disable", i+1)
+		}
+		if got := updated.NextRunAt.Sub(now); got != want {
+			t.Errorf("failure %d: next in %s, want %s", i+1, got, want)
+		}
+		if updated.ConsecutiveFailures != i+1 {
+			t.Errorf("failure %d: count %d", i+1, updated.ConsecutiveFailures)
+		}
+	}
+	// Recovery resets the streak.
+	if err := db.ScheduleSucceeded(s.ID, ScheduleRunOK, now); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.GetSchedule(s.ID); got.ConsecutiveFailures != 0 || !got.Enabled {
+		t.Fatalf("success should reset: %+v", got)
+	}
+	// Ten in a row switches it off; the disable is reported exactly once.
+	var disabledAt int
+	for i := 1; i <= DisableAfterFailures+1; i++ {
+		updated, disabled, err := db.ScheduleFailed(s.ID, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if disabled {
+			if disabledAt != 0 {
+				t.Fatalf("disable reported twice (at %d and %d)", disabledAt, i)
+			}
+			disabledAt = i
+		}
+		if i >= DisableAfterFailures && updated.Enabled {
+			t.Errorf("failure %d: still enabled", i)
+		}
+		if i < DisableAfterFailures && !updated.Enabled {
+			t.Errorf("failure %d: disabled too early", i)
+		}
+	}
+	if disabledAt != DisableAfterFailures {
+		t.Errorf("disable reported at failure %d, want %d", disabledAt, DisableAfterFailures)
+	}
+}
+
+func TestEnableTakesFreshClockAndResetsStreak(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	s := newSchedule(t, db, "paused", now.Add(-time.Hour))
+	for i := 0; i < 3; i++ {
+		db.ScheduleFailed(s.ID, now)
+	}
+	db.SetScheduleEnabled(s.ID, false, time.Time{})
+	if err := db.SetScheduleEnabled(s.ID, true, time.Time{}); err == nil {
+		t.Error("enabling without a next time must be refused")
+	}
+	next := now.Add(time.Hour)
+	if err := db.SetScheduleEnabled(s.ID, true, next); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := db.GetSchedule(s.ID)
+	if !got.Enabled || got.ConsecutiveFailures != 0 || !got.NextRunAt.Equal(next) {
+		t.Errorf("after enable: %+v", got)
+	}
+}
+
+func TestSettleScheduleRunIsCompareAndSet(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	s := newSchedule(t, db, "agentic", now)
+	run, err := db.RecordScheduleRun(ScheduleRun{ScheduleID: s.ID, TaskID: "t_1", StartedAt: now, Status: ScheduleRunPending})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := db.PendingScheduleRuns()
+	if len(pending) != 1 || pending[0].ID != run.ID {
+		t.Fatalf("pending: %+v", pending)
+	}
+	won1, _ := db.SettleScheduleRun(run.ID, ScheduleRunOK, "done", now)
+	won2, _ := db.SettleScheduleRun(run.ID, ScheduleRunFailed, "again", now)
+	if !won1 || won2 {
+		t.Fatalf("first settle wins, second loses: %v %v", won1, won2)
+	}
+	runs, _ := db.ScheduleRuns(s.ID, 10)
+	if len(runs) != 1 || runs[0].Status != ScheduleRunOK || runs[0].Output != "done" || runs[0].EndedAt.IsZero() {
+		t.Errorf("settled run: %+v", runs[0])
+	}
+	if pending, _ := db.PendingScheduleRuns(); len(pending) != 0 {
+		t.Errorf("nothing should be pending, got %d", len(pending))
+	}
+}
+
+func TestRecordScheduleRunCutsOutputKeepingHeadAndTail(t *testing.T) {
+	db := testDB(t)
+	s := newSchedule(t, db, "chatty", time.Now())
+	big := strings.Repeat("H", 6000) + strings.Repeat("T", 6000)
+	run, err := db.RecordScheduleRun(ScheduleRun{ScheduleID: s.ID, Status: ScheduleRunOK, Output: big})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(run.Output) > MaxScheduleOutput+64 {
+		t.Errorf("output not cut: %d bytes", len(run.Output))
+	}
+	if !strings.HasPrefix(run.Output, "HHHH") || !strings.HasSuffix(run.Output, "TTTT") || !strings.Contains(run.Output, "bytes cut") {
+		t.Errorf("cut should keep head and tail with a marker")
+	}
+}
+
+func TestDeleteScheduleRefusesSystemRows(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	sys, err := db.CreateSchedule(NewSchedule{Name: "heartbeat:x", CreatedBy: "gateway", Kind: ScheduleEvery, Spec: "30m", TZ: "UTC",
+		PayloadKind: PayloadAgent, Payload: AgentPayload{Title: "hb"}, System: true, NextRunAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DeleteSchedule(sys.ID); err != ErrSystemSchedule {
+		t.Errorf("system delete: got %v", err)
+	}
+	user := newSchedule(t, db, "mine", now)
+	db.RecordScheduleRun(ScheduleRun{ScheduleID: user.ID, Status: ScheduleRunOK})
+	if err := db.DeleteSchedule(user.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.GetSchedule(user.ID); err == nil {
+		t.Error("deleted schedule still readable")
+	}
+	if runs, _ := db.ScheduleRuns(user.ID, 10); len(runs) != 0 {
+		t.Error("runs should go with the schedule")
+	}
+	if found, err := db.FindSchedule("heartbeat:x"); err != nil || found.ID != sys.ID {
+		t.Errorf("find by name: %v %v", found, err)
+	}
+}
+
+func TestFireScheduleMovesClockOnlyWhenEnabled(t *testing.T) {
+	db := testDB(t)
+	now := time.Now()
+	s := newSchedule(t, db, "later", now.Add(time.Hour))
+	if due, _ := db.DueSchedules(now); len(due) != 0 {
+		t.Fatal("should not be due yet")
+	}
+	if err := db.FireSchedule(s.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if due, _ := db.DueSchedules(now); len(due) != 1 {
+		t.Fatal("run-now should make it due")
+	}
+	db.SetScheduleEnabled(s.ID, false, time.Time{})
+	if err := db.FireSchedule(s.ID, now); err == nil {
+		t.Error("run-now on a disabled schedule must be refused")
+	}
+}
+
+// A v3 database (P0) must gain the schedule tables and agents.scratch.
+func TestMigrateV3DatabaseGainsSchedules(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coord.db")
+	raw, err := sql.Open("sqlite", storage.DSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, stmt := range []string{
+		`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL) STRICT`,
+		`INSERT INTO meta VALUES ('schema_version', '3')`,
+		`CREATE TABLE agents (
+			id TEXT PRIMARY KEY, display_name TEXT NOT NULL DEFAULT '', provider TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '', ws_addr TEXT NOT NULL DEFAULT '', workspace TEXT NOT NULL DEFAULT '',
+			started_at TEXT NOT NULL, last_seen_at TEXT NOT NULL
+		) STRICT`,
+		`INSERT INTO agents (id, started_at, last_seen_at) VALUES ('bomclaw', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`,
+	} {
+		if _, err := raw.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	raw.Close()
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open v3 db: %v", err)
+	}
+	defer db.Close()
+	var version string
+	db.conn.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&version)
+	if version != "4" {
+		t.Errorf("schema_version %s, want 4", version)
+	}
+	var n int
+	db.conn.QueryRow(`SELECT count(*) FROM pragma_table_info('agents') WHERE name='scratch'`).Scan(&n)
+	if n != 1 {
+		t.Error("agents.scratch missing after migration")
+	}
+	if _, err := db.ListSchedules(); err != nil {
+		t.Errorf("schedules table: %v", err)
+	}
+	if agents, err := db.ListAgents(); err != nil || len(agents) != 1 {
+		t.Errorf("existing agents survive: %v %d", err, len(agents))
+	}
+}

--- a/internal/coord/taskruns_test.go
+++ b/internal/coord/taskruns_test.go
@@ -471,8 +471,8 @@ func TestMigrateV2DatabaseGainsV3Columns(t *testing.T) {
 	}
 	var ver string
 	_ = db.conn.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&ver)
-	if ver != "3" {
-		t.Errorf("schema_version = %s, want 3", ver)
+	if ver != fmt.Sprint(schemaVersion) {
+		t.Errorf("schema_version = %s, want %d", ver, schemaVersion)
 	}
 	// Re-opening (a second gateway) must not trip on the columns already existing.
 	db2, err := Open(path)

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -51,6 +51,11 @@ type Deps struct {
 	// Nil when this agent does not claim tasks.
 	PokeTasks func()
 
+	// PokeSchedules asks the local scheduler loop to tick now (after a
+	// "run now"). Nil when schedules are disabled on this gateway; the row is
+	// still updated and another gateway's tick fires it.
+	PokeSchedules func()
+
 	// NotesFile is the markdown rendering of shared notes, rewritten whenever
 	// a note is added so agents can read it with their file tools.
 	NotesFile string
@@ -172,6 +177,18 @@ func NewMethodHandler(deps Deps) MethodHandler {
 			return handleNotesList(deps, params)
 		case "notes.add":
 			return handleNoteAdd(deps, params)
+		case "schedules.list":
+			return handleSchedulesList(deps)
+		case "schedules.get":
+			return handleScheduleGet(deps, params)
+		case "schedules.create":
+			return handleScheduleCreate(deps, params)
+		case "schedules.toggle":
+			return handleScheduleToggle(deps, params)
+		case "schedules.delete":
+			return handleScheduleDelete(deps, params)
+		case "schedules.run":
+			return handleScheduleRun(deps, params)
 		case "tasks.poke":
 			if deps.PokeTasks != nil {
 				deps.PokeTasks()

--- a/internal/gateway/schedules.go
+++ b/internal/gateway/schedules.go
@@ -1,0 +1,182 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/scheduler"
+)
+
+// The schedules.* methods are the dashboard's view of `bomclaw schedule`. They
+// write the same rows; the gateway's scheduler loop (any gateway's) does the
+// firing on its next tick.
+
+// ScheduleView is a schedule plus its recent runs, for the detail panel.
+type ScheduleView struct {
+	Schedule *coord.Schedule     `json:"schedule"`
+	Runs     []coord.ScheduleRun `json:"runs"`
+	When     string              `json:"when"` // human rendering of kind+spec+tz
+}
+
+func handleSchedulesList(deps Deps) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	all, err := deps.Coord.ListSchedules()
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		coord.Schedule
+		When string `json:"when"`
+	}
+	out := make([]row, 0, len(all))
+	for i := range all {
+		out = append(out, row{Schedule: all[i], When: scheduler.Describe(&all[i])})
+	}
+	return json.Marshal(out)
+}
+
+type scheduleIDParams struct {
+	ID    string `json:"id"` // id or name
+	Limit int    `json:"limit,omitempty"`
+}
+
+func handleScheduleGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p scheduleIDParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	s, err := deps.Coord.FindSchedule(p.ID)
+	if err != nil {
+		return nil, err
+	}
+	runs, err := deps.Coord.ScheduleRuns(s.ID, p.Limit)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(ScheduleView{Schedule: s, Runs: runs, When: scheduler.Describe(s)})
+}
+
+type scheduleCreateParams struct {
+	Name        string          `json:"name"`
+	Kind        string          `json:"kind"` // at | every | cron
+	Spec        string          `json:"spec"`
+	TZ          string          `json:"tz,omitempty"` // default: the machine's zone
+	PayloadKind string          `json:"payload_kind"` // agent | command
+	Payload     json.RawMessage `json:"payload"`
+	OwnerAgent  string          `json:"owner_agent,omitempty"`
+	SkipMissed  bool            `json:"skip_missed,omitempty"`
+}
+
+func handleScheduleCreate(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p scheduleCreateParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if p.TZ == "" {
+		p.TZ = scheduler.LocalZone()
+	}
+	next, err := scheduler.NextRun(p.Kind, p.Spec, p.TZ, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	if next.IsZero() {
+		return nil, fmt.Errorf("%s is already in the past", p.Spec)
+	}
+	s, err := deps.Coord.CreateSchedule(coord.NewSchedule{
+		Name: p.Name, CreatedBy: deps.AgentID, OwnerAgent: p.OwnerAgent,
+		Kind: p.Kind, Spec: p.Spec, TZ: p.TZ,
+		PayloadKind: p.PayloadKind, Payload: p.Payload,
+		SkipMissed: p.SkipMissed, NextRunAt: next,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(s)
+}
+
+type scheduleToggleParams struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+}
+
+func handleScheduleToggle(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p scheduleToggleParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	s, err := deps.Coord.FindSchedule(p.ID)
+	if err != nil {
+		return nil, err
+	}
+	var next time.Time
+	if p.Enabled {
+		if next, err = scheduler.NextRun(s.Kind, s.Spec, s.TZ, time.Now()); err != nil {
+			return nil, err
+		}
+		if next.IsZero() {
+			return nil, fmt.Errorf("%s is a one-shot whose time has passed", s.Name)
+		}
+	}
+	if err := deps.Coord.SetScheduleEnabled(s.ID, p.Enabled, next); err != nil {
+		return nil, err
+	}
+	s, err = deps.Coord.GetSchedule(s.ID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(s)
+}
+
+func handleScheduleDelete(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p scheduleIDParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	s, err := deps.Coord.FindSchedule(p.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := deps.Coord.DeleteSchedule(s.ID); err != nil {
+		return nil, err
+	}
+	return json.Marshal(map[string]bool{"deleted": true})
+}
+
+// handleScheduleRun moves the clock to now and pokes the local loop, so a
+// "run now" from the dashboard fires within a second rather than a tick.
+func handleScheduleRun(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p scheduleIDParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	s, err := deps.Coord.FindSchedule(p.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := deps.Coord.FireSchedule(s.ID, time.Now()); err != nil {
+		return nil, err
+	}
+	if deps.PokeSchedules != nil {
+		deps.PokeSchedules()
+	}
+	return json.Marshal(map[string]bool{"fired": true})
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,468 @@
+// Package scheduler fires schedules from the shared coordination database.
+//
+// It follows the rule the design calls "automations decide when, tasks record
+// what happened": the scheduler itself never runs a model. When a schedule is
+// due it either materialises one ordinary task row (payload `agent`) — which
+// then goes through claim, lease, fencing and the run cap exactly like a task
+// a peer queued — or runs a shell command in-process (payload `command`).
+//
+// Every gateway on the machine runs one of these against the same database.
+// Firing is a compare-and-set on schedules.next_run_at (coord.ClaimSchedule),
+// so two gateways that both see a due schedule produce one run. No lock, no
+// leader, and a gateway that is down simply does not fire — the other does.
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// Config tunes the loop. Zero values take the defaults noted.
+type Config struct {
+	AgentID        string
+	Tick           time.Duration // how often to look for due schedules; default 30s
+	CommandTimeout time.Duration // cap on a command payload without timeout_s; default 60s
+	AlertCooldown  time.Duration // min gap between failure alerts for one schedule; default 1h
+	// MissedAfter is how late a due schedule may be before it counts as missed
+	// (the gateway was down). A missed schedule with skip_missed set re-arms
+	// instead of running. Default 2×Tick, so a schedule found on the very next
+	// tick is never "missed".
+	MissedAfter time.Duration
+}
+
+func (c *Config) defaults() {
+	if c.Tick <= 0 {
+		c.Tick = 30 * time.Second
+	}
+	if c.CommandTimeout <= 0 {
+		c.CommandTimeout = time.Minute
+	}
+	if c.AlertCooldown <= 0 {
+		c.AlertCooldown = time.Hour
+	}
+	if c.MissedAfter <= 0 {
+		c.MissedAfter = 2 * c.Tick
+	}
+}
+
+// Scheduler is the loop. Create with New, wire SetNotify/SetWake, then Start.
+type Scheduler struct {
+	db  *coord.DB
+	cfg Config
+
+	notify    func(text string)   // deliver a line to the owner (Telegram); nil = log only
+	wake      func(t *coord.Task) // ring the runner(s) for a task just created
+	now       func() time.Time    // test seam
+	poke      chan struct{}       // Poke → run a tick now
+	fires     sync.WaitGroup      // in-flight firings and the loop itself
+	mu        sync.Mutex          // guards lastAlert
+	lastAlert map[string]time.Time
+}
+
+// New builds a scheduler. It does nothing until Start.
+func New(db *coord.DB, cfg Config) *Scheduler {
+	cfg.defaults()
+	return &Scheduler{
+		db:        db,
+		cfg:       cfg,
+		now:       time.Now,
+		poke:      make(chan struct{}, 1),
+		lastAlert: map[string]time.Time{},
+	}
+}
+
+// SetNotify installs the delivery path for results and alerts.
+func (s *Scheduler) SetNotify(fn func(text string)) { s.notify = fn }
+
+// SetWake installs the doorbell rung after an agent task is materialised.
+func (s *Scheduler) SetWake(fn func(t *coord.Task)) { s.wake = fn }
+
+// Poke asks for a tick now (a `schedule run-now` from the CLI, for example).
+func (s *Scheduler) Poke() {
+	if s == nil {
+		return // schedules disabled on this gateway; the row still changed
+	}
+	select {
+	case s.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Start runs the loop until ctx ends. The first tick is immediate: after a
+// restart, whatever came due while the gateway was down runs (once) right away.
+func (s *Scheduler) Start(ctx context.Context) {
+	log.Printf("scheduler: firing schedules as %s every %s", s.cfg.AgentID, s.cfg.Tick)
+	s.fires.Add(1)
+	go func() {
+		defer s.fires.Done()
+		t := time.NewTicker(s.cfg.Tick)
+		defer t.Stop()
+		s.Tick(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			case <-s.poke:
+			}
+			s.Tick(ctx)
+		}
+	}()
+}
+
+// Wait blocks until the loop has stopped and every in-flight firing has ended.
+func (s *Scheduler) Wait() { s.fires.Wait() }
+
+// Tick is one pass: fire what is due, then settle agent runs whose task has
+// finished. Firings run in their own goroutines so a slow command does not
+// hold the next tick; Wait joins them. Exported so tests can drive the clock.
+func (s *Scheduler) Tick(ctx context.Context) {
+	now := s.now()
+	due, err := s.db.DueSchedules(now)
+	if err != nil {
+		log.Printf("scheduler: %v", err)
+	}
+	for i := range due {
+		sc := due[i]
+		if sc.OwnerAgent != "" && sc.OwnerAgent != s.cfg.AgentID {
+			continue
+		}
+		next, err := NextRun(sc.Kind, sc.Spec, sc.TZ, now)
+		if err != nil {
+			// A spec that no longer parses cannot be scheduled. Disable it
+			// rather than log the same error every 30 seconds forever.
+			log.Printf("scheduler: %s: %v — disabling", sc.Name, err)
+			_ = s.db.SetScheduleEnabled(sc.ID, false, time.Time{})
+			s.alert(&sc, fmt.Sprintf("⛔ schedule %s disabled: %v", sc.Name, err), true)
+			continue
+		}
+		won, err := s.db.ClaimSchedule(sc.ID, sc.NextRaw(), now, next)
+		if err != nil {
+			log.Printf("scheduler: %v", err)
+			continue
+		}
+		if !won {
+			continue // the other gateway has it
+		}
+		missed := now.Sub(sc.NextRunAt) > s.cfg.MissedAfter
+		s.fires.Add(1)
+		go func() {
+			defer s.fires.Done()
+			s.fire(ctx, &sc, now, missed)
+		}()
+	}
+	s.settle(ctx, now)
+}
+
+// fire is one firing of a schedule this gateway won.
+func (s *Scheduler) fire(ctx context.Context, sc *coord.Schedule, now time.Time, missed bool) {
+	if missed && sc.SkipMissed {
+		log.Printf("scheduler: %s was due %s ago while no gateway ran; skip_missed — re-armed for %s",
+			sc.Name, now.Sub(sc.NextRunAt).Round(time.Second), nextOf(s.db, sc.ID))
+		_, _ = s.db.RecordScheduleRun(coord.ScheduleRun{
+			ScheduleID: sc.ID, StartedAt: now, EndedAt: now, Status: coord.ScheduleRunSkipped,
+			Output: fmt.Sprintf("due %s, found %s; skip_missed", sc.NextRunAt.Format(time.RFC3339), now.Format(time.RFC3339)),
+		})
+		_ = s.db.ScheduleSucceeded(sc.ID, coord.ScheduleRunSkipped, now)
+		return
+	}
+	if missed {
+		log.Printf("scheduler: %s was due %s ago while no gateway ran — catching up once",
+			sc.Name, now.Sub(sc.NextRunAt).Round(time.Second))
+	}
+	switch sc.PayloadKind {
+	case coord.PayloadAgent:
+		s.fireAgent(sc, now)
+	case coord.PayloadCommand:
+		s.fireCommand(ctx, sc, now)
+	default:
+		s.failed(sc, now, fmt.Sprintf("unknown payload kind %q", sc.PayloadKind))
+	}
+}
+
+// fireAgent materialises the task. The schedule run stays pending until the
+// task reaches a terminal state; settle() closes it.
+func (s *Scheduler) fireAgent(sc *coord.Schedule, now time.Time) {
+	var p coord.AgentPayload
+	if err := json.Unmarshal(sc.Payload, &p); err != nil {
+		s.failed(sc, now, "agent payload: "+err.Error())
+		return
+	}
+	to := p.To
+	if to == "" {
+		to = sc.OwnerAgent
+	}
+	task, err := s.db.CreateTask(coord.NewTask{
+		CreatedBy:  "schedule:" + sc.Name,
+		AssignedTo: to,
+		Title:      p.Title,
+		Body:       agentBody(sc, &p),
+		Kind:       coord.KindScheduled,
+		ScheduleID: sc.ID,
+	})
+	if err != nil {
+		s.failed(sc, now, "create task: "+err.Error())
+		return
+	}
+	if _, err := s.db.RecordScheduleRun(coord.ScheduleRun{
+		ScheduleID: sc.ID, TaskID: task.ID, StartedAt: now, Status: coord.ScheduleRunPending,
+	}); err != nil {
+		log.Printf("scheduler: %s: %v", sc.Name, err)
+	}
+	log.Printf("scheduler: %s → task %s (%s)", sc.Name, task.ID, orAny(to, "any agent"))
+	if s.wake != nil {
+		s.wake(task)
+	}
+}
+
+// agentBody is the task body a scheduled agent task carries: the payload body
+// plus a line saying where it came from, so the agent does not go looking for
+// a requester to report to.
+func agentBody(sc *coord.Schedule, p *coord.AgentPayload) string {
+	var b strings.Builder
+	if p.Body != "" {
+		b.WriteString(p.Body)
+		b.WriteString("\n\n")
+	}
+	fmt.Fprintf(&b, "(Created by schedule %q — %s. Nobody is waiting in a chat: "+
+		"finish with `bomclaw task done --result ...` and your result is delivered to the owner", sc.Name, Describe(sc))
+	if p.Quiet {
+		b.WriteString(" — or rather recorded, this schedule is quiet")
+	}
+	b.WriteString(".)")
+	return b.String()
+}
+
+// fireCommand runs the shell command with a timeout and records the outcome.
+func (s *Scheduler) fireCommand(ctx context.Context, sc *coord.Schedule, now time.Time) {
+	var p coord.CommandPayload
+	if err := json.Unmarshal(sc.Payload, &p); err != nil {
+		s.failed(sc, now, "command payload: "+err.Error())
+		return
+	}
+	timeout := s.cfg.CommandTimeout
+	if p.TimeoutS > 0 {
+		timeout = time.Duration(p.TimeoutS) * time.Second
+	}
+	out, code, err := runCommand(ctx, sc, &p, timeout)
+	ended := s.now()
+	status := coord.ScheduleRunOK
+	if err != nil || code != 0 {
+		status = coord.ScheduleRunFailed
+		if err != nil {
+			out = strings.TrimRight(out, "\n") + "\n[" + err.Error() + "]"
+		}
+	}
+	if _, rerr := s.db.RecordScheduleRun(coord.ScheduleRun{
+		ScheduleID: sc.ID, StartedAt: now, EndedAt: ended, Status: status, ExitCode: code, Output: out,
+	}); rerr != nil {
+		log.Printf("scheduler: %s: %v", sc.Name, rerr)
+	}
+	if status == coord.ScheduleRunOK {
+		log.Printf("scheduler: %s ok in %s", sc.Name, ended.Sub(now).Round(time.Millisecond))
+		_ = s.db.ScheduleSucceeded(sc.ID, coord.ScheduleRunOK, ended)
+		return
+	}
+	s.applyFailure(sc, ended, fmt.Sprintf("exit %d", code), out)
+}
+
+// runCommand executes `sh -c cmd` in its own process group so a timeout kills
+// what the command spawned, not just the shell.
+func runCommand(ctx context.Context, sc *coord.Schedule, p *coord.CommandPayload, timeout time.Duration) (string, int, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", p.Cmd)
+	if p.Cwd != "" {
+		cmd.Dir = expandHome(p.Cwd)
+	}
+	cmd.Env = append(os.Environ(), "BOMCLAW_SCHEDULE="+sc.Name, "BOMCLAW_SCHEDULE_ID="+sc.ID)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var exit *exec.ExitError
+		switch {
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			return string(out), -1, fmt.Errorf("timed out after %s", timeout)
+		case errors.As(err, &exit):
+			code = exit.ExitCode()
+			err = nil
+		default:
+			return string(out), -1, err
+		}
+	}
+	return string(out), code, err
+}
+
+// settle closes pending agent runs whose task has reached a terminal state.
+// Any gateway may do it; the compare-and-set in SettleScheduleRun makes sure
+// only one applies the outcome.
+func (s *Scheduler) settle(ctx context.Context, now time.Time) {
+	pending, err := s.db.PendingScheduleRuns()
+	if err != nil {
+		log.Printf("scheduler: %v", err)
+		return
+	}
+	for _, run := range pending {
+		if ctx.Err() != nil {
+			return
+		}
+		task, err := s.db.GetTask(run.TaskID)
+		if err != nil {
+			// The task row is gone; nothing will ever finish it.
+			if won, _ := s.db.SettleScheduleRun(run.ID, coord.ScheduleRunFailed, "task missing: "+err.Error(), now); won {
+				if sc, gerr := s.db.GetSchedule(run.ScheduleID); gerr == nil {
+					s.applyFailure(sc, now, "task missing", "")
+				}
+			}
+			continue
+		}
+		var status string
+		switch task.State {
+		case coord.TaskCompleted:
+			status = coord.ScheduleRunOK
+		case coord.TaskFailed, coord.TaskCanceled, coord.TaskRejected:
+			status = coord.ScheduleRunFailed
+		default:
+			continue // still working, blocked, or waiting to be claimed
+		}
+		won, err := s.db.SettleScheduleRun(run.ID, status, task.Result, now)
+		if err != nil {
+			log.Printf("scheduler: %v", err)
+			continue
+		}
+		if !won {
+			continue
+		}
+		sc, err := s.db.GetSchedule(run.ScheduleID)
+		if err != nil {
+			continue // schedule deleted under a live run; the run is closed, that is enough
+		}
+		if status == coord.ScheduleRunOK {
+			_ = s.db.ScheduleSucceeded(sc.ID, coord.ScheduleRunOK, now)
+			s.deliver(sc, task)
+			continue
+		}
+		reason := task.State
+		if task.FailReason != "" {
+			reason += " (" + task.FailReason + ")"
+		}
+		s.applyFailure(sc, now, "task "+reason, task.Result)
+	}
+}
+
+// deliver sends a finished agent task's result to the owner unless the payload
+// asked for quiet. The result IS the point of a scheduled task; a report nobody
+// reads is a wasted model call.
+func (s *Scheduler) deliver(sc *coord.Schedule, task *coord.Task) {
+	var p coord.AgentPayload
+	_ = json.Unmarshal(sc.Payload, &p)
+	if p.Quiet || s.notify == nil {
+		return
+	}
+	result := strings.TrimSpace(task.Result)
+	if result == "" {
+		result = "(finished without a result)"
+	}
+	s.notify(fmt.Sprintf("📅 %s\n\n%s", sc.Name, truncate(result, 3500)))
+}
+
+// failed records a firing that never got off the ground (bad payload, task
+// creation refused) and applies the ladder.
+func (s *Scheduler) failed(sc *coord.Schedule, now time.Time, why string) {
+	_, _ = s.db.RecordScheduleRun(coord.ScheduleRun{
+		ScheduleID: sc.ID, StartedAt: now, EndedAt: now, Status: coord.ScheduleRunFailed, ExitCode: -1, Output: why,
+	})
+	s.applyFailure(sc, now, why, "")
+}
+
+// applyFailure climbs the ladder and tells the owner when the design says to:
+// at AlertAfterFailures with a cooldown, and always when the schedule turns
+// itself off.
+func (s *Scheduler) applyFailure(sc *coord.Schedule, now time.Time, why, output string) {
+	updated, disabled, err := s.db.ScheduleFailed(sc.ID, now)
+	if err != nil {
+		log.Printf("scheduler: %s failed (%s) and the failure could not be recorded: %v", sc.Name, why, err)
+		return
+	}
+	log.Printf("scheduler: %s failed (%s) — %d in a row, next try %s", sc.Name, why,
+		updated.ConsecutiveFailures, updated.NextRunAt.Local().Format("15:04:05"))
+	tail := strings.TrimSpace(output)
+	if tail != "" {
+		tail = "\n\n" + truncate(tail, 1200)
+	}
+	if disabled {
+		s.alert(updated, fmt.Sprintf("⛔ schedule %s disabled after %d consecutive failures (last: %s). "+
+			"Fix it, then `bomclaw schedule enable %s`.%s", sc.Name, updated.ConsecutiveFailures, why, sc.Name, tail), true)
+		return
+	}
+	if updated.ConsecutiveFailures >= coord.AlertAfterFailures {
+		s.alert(updated, fmt.Sprintf("⚠️ schedule %s has failed %d times in a row (last: %s). Retrying at %s; it turns itself off at %d.%s",
+			sc.Name, updated.ConsecutiveFailures, why, updated.NextRunAt.Local().Format("15:04"), coord.DisableAfterFailures, tail), false)
+	}
+}
+
+// alert delivers a failure line, at most once per cooldown per schedule unless
+// force (the disable notice always goes out).
+func (s *Scheduler) alert(sc *coord.Schedule, text string, force bool) {
+	if s.notify == nil {
+		log.Printf("scheduler: %s", text)
+		return
+	}
+	now := s.now()
+	s.mu.Lock()
+	last, seen := s.lastAlert[sc.ID]
+	if !force && seen && now.Sub(last) < s.cfg.AlertCooldown {
+		s.mu.Unlock()
+		return
+	}
+	s.lastAlert[sc.ID] = now
+	s.mu.Unlock()
+	s.notify(text)
+}
+
+func nextOf(db *coord.DB, id string) string {
+	sc, err := db.GetSchedule(id)
+	if err != nil || sc.Done() {
+		return "never"
+	}
+	return sc.NextRunAt.Local().Format(time.RFC3339)
+}
+
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+func orAny(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,405 @@
+package scheduler
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+func openDB(t *testing.T) *coord.DB {
+	t.Helper()
+	db, err := coord.Open(filepath.Join(t.TempDir(), "coord.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// fixed pins the scheduler's clock so "due" and "missed" are deterministic.
+func fixed(s *Scheduler, at time.Time) { s.now = func() time.Time { return at } }
+
+type notes struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (n *notes) add(s string) { n.mu.Lock(); n.lines = append(n.lines, s); n.mu.Unlock() }
+func (n *notes) all() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]string(nil), n.lines...)
+}
+
+func TestNextRun(t *testing.T) {
+	hcm, _ := time.LoadLocation("Asia/Ho_Chi_Minh")
+	// Friday 2026-09-11 09:00 Ho Chi Minh time.
+	from := time.Date(2026, 9, 11, 9, 0, 0, 0, hcm)
+
+	next, err := NextRun(coord.ScheduleCron, "0 8 * * 1-5", "Asia/Ho_Chi_Minh", from)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 9, 14, 8, 0, 0, 0, hcm) // Monday 08:00 local
+	if !next.Equal(want) {
+		t.Errorf("weekday cron from Friday 09:00: got %s, want %s", next.In(hcm), want)
+	}
+	// Same cron read in UTC is a different instant: 08:00 UTC = 15:00 HCM.
+	utcNext, _ := NextRun(coord.ScheduleCron, "0 8 * * 1-5", "UTC", from)
+	if utcNext.Equal(next) {
+		t.Error("tz must change the instant")
+	}
+	if _, err := NextRun(coord.ScheduleCron, "0 8 * *", "UTC", from); err == nil {
+		t.Error("4-field cron must be rejected")
+	}
+	if next, _ := NextRun(coord.ScheduleCron, "@daily", "UTC", from); next.IsZero() {
+		t.Error("descriptors should parse")
+	}
+
+	if next, err := NextRun(coord.ScheduleEvery, "10m", "UTC", from); err != nil || !next.Equal(from.Add(10*time.Minute)) {
+		t.Errorf("every 10m: %v %v", next, err)
+	}
+	if _, err := NextRun(coord.ScheduleEvery, "10s", "UTC", from); err == nil {
+		t.Error("every under 1m must be rejected")
+	}
+	if _, err := NextRun(coord.ScheduleEvery, "soon", "UTC", from); err == nil {
+		t.Error("non-duration must be rejected")
+	}
+
+	at, err := NextRun(coord.ScheduleAt, "2026-09-12T07:30", "Asia/Ho_Chi_Minh", from)
+	if err != nil || !at.Equal(time.Date(2026, 9, 12, 7, 30, 0, 0, hcm)) {
+		t.Errorf("at local: %v %v", at, err)
+	}
+	if past, err := NextRun(coord.ScheduleAt, "2026-09-10T07:30", "Asia/Ho_Chi_Minh", from); err != nil || !past.IsZero() {
+		t.Errorf("at in the past must be zero/never: %v %v", past, err)
+	}
+	if _, err := NextRun(coord.ScheduleEvery, "10m", "Mars/Olympus", from); err == nil {
+		t.Error("bad tz must be rejected")
+	}
+	if LocalZone() == "" {
+		t.Error("LocalZone must always name something")
+	}
+}
+
+func TestCommandScheduleRunsAndRecordsOutput(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, err := db.CreateSchedule(coord.NewSchedule{Name: "echo", CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "10m", TZ: "UTC",
+		PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "echo hello $BOMCLAW_SCHEDULE"}, NextRunAt: now.Add(-time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := New(db, Config{AgentID: "a1"})
+	fixed(s, now)
+	s.Tick(context.Background())
+	s.Wait()
+
+	runs, _ := db.ScheduleRuns(sc.ID, 10)
+	if len(runs) != 1 || runs[0].Status != coord.ScheduleRunOK || strings.TrimSpace(runs[0].Output) != "hello echo" {
+		t.Fatalf("runs: %+v", runs)
+	}
+	got, _ := db.GetSchedule(sc.ID)
+	if got.LastStatus != coord.ScheduleRunOK || !got.NextRunAt.Equal(now.Add(10*time.Minute)) {
+		t.Errorf("after ok run: status=%s next=%s", got.LastStatus, got.NextRunAt)
+	}
+	// Not due again until then.
+	s.Tick(context.Background())
+	s.Wait()
+	if runs, _ := db.ScheduleRuns(sc.ID, 10); len(runs) != 1 {
+		t.Errorf("fired again before its time: %d runs", len(runs))
+	}
+}
+
+func TestCommandFailureClimbsLadderAndAlerts(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, _ := db.CreateSchedule(coord.NewSchedule{Name: "broken", CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "10m", TZ: "UTC",
+		PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "echo boom >&2; exit 3"}, NextRunAt: now.Add(-time.Second)})
+	var n notes
+	s := New(db, Config{AgentID: "a1"})
+	s.SetNotify(n.add)
+
+	clock := now
+	fixed(s, clock)
+	s.Tick(context.Background())
+	s.Wait()
+	got, _ := db.GetSchedule(sc.ID)
+	if got.ConsecutiveFailures != 1 || got.NextRunAt.Sub(clock) != 30*time.Second {
+		t.Fatalf("first failure: failures=%d next-in=%s", got.ConsecutiveFailures, got.NextRunAt.Sub(clock))
+	}
+	if len(n.all()) != 0 {
+		t.Fatalf("one failure must not alert: %v", n.all())
+	}
+	runs, _ := db.ScheduleRuns(sc.ID, 10)
+	if runs[0].ExitCode != 3 || !strings.Contains(runs[0].Output, "boom") {
+		t.Errorf("run: %+v", runs[0])
+	}
+
+	// Second failure: due after the 30s backoff; alerts once.
+	clock = clock.Add(31 * time.Second)
+	fixed(s, clock)
+	s.Tick(context.Background())
+	s.Wait()
+	if lines := n.all(); len(lines) != 1 || !strings.Contains(lines[0], "failed 2 times") {
+		t.Fatalf("second failure should alert once: %v", lines)
+	}
+	// Third failure within the cooldown: no second alert.
+	clock = clock.Add(2 * time.Minute)
+	fixed(s, clock)
+	s.Tick(context.Background())
+	s.Wait()
+	if len(n.all()) != 1 {
+		t.Fatalf("alert cooldown not honoured: %v", n.all())
+	}
+	// Drive to auto-disable; the disable notice bypasses the cooldown.
+	for i := 0; i < coord.DisableAfterFailures; i++ {
+		clock = clock.Add(2 * time.Hour)
+		fixed(s, clock)
+		s.Tick(context.Background())
+		s.Wait()
+	}
+	got, _ = db.GetSchedule(sc.ID)
+	if got.Enabled {
+		t.Fatalf("should be auto-disabled after %d failures, have %d", coord.DisableAfterFailures, got.ConsecutiveFailures)
+	}
+	var sawDisable int
+	for _, l := range n.all() {
+		if strings.Contains(l, "disabled after") {
+			sawDisable++
+		}
+	}
+	if sawDisable != 1 {
+		t.Errorf("disable notice should go out exactly once, got %d in %v", sawDisable, n.all())
+	}
+}
+
+func TestCommandTimeoutFails(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, _ := db.CreateSchedule(coord.NewSchedule{Name: "slow", CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "10m", TZ: "UTC",
+		PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "sleep 5", TimeoutS: 1}, NextRunAt: now.Add(-time.Second)})
+	s := New(db, Config{AgentID: "a1"})
+	fixed(s, now)
+	start := time.Now()
+	s.Tick(context.Background())
+	s.Wait()
+	if time.Since(start) > 3*time.Second {
+		t.Fatalf("timeout not enforced: took %s", time.Since(start))
+	}
+	runs, _ := db.ScheduleRuns(sc.ID, 10)
+	if len(runs) != 1 || runs[0].Status != coord.ScheduleRunFailed || !strings.Contains(runs[0].Output, "timed out") {
+		t.Errorf("runs: %+v", runs)
+	}
+}
+
+// Eight hours of downtime over an hourly schedule: one catch-up run, and the
+// next run is computed from now, not from the missed mark.
+func TestMissedScheduleCatchesUpOnce(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, _ := db.CreateSchedule(coord.NewSchedule{Name: "hourly", CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "1h", TZ: "UTC",
+		PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "true"}, NextRunAt: now.Add(-8 * time.Hour)})
+	s := New(db, Config{AgentID: "a1"})
+	fixed(s, now)
+	s.Tick(context.Background())
+	s.Wait()
+	s.Tick(context.Background())
+	s.Wait()
+	runs, _ := db.ScheduleRuns(sc.ID, 10)
+	if len(runs) != 1 || runs[0].Status != coord.ScheduleRunOK {
+		t.Fatalf("want exactly one catch-up run, got %+v", runs)
+	}
+	got, _ := db.GetSchedule(sc.ID)
+	if !got.NextRunAt.Equal(now.Add(time.Hour)) {
+		t.Errorf("next must be now+1h, got %s", got.NextRunAt.Sub(now))
+	}
+}
+
+func TestMissedScheduleWithSkipMissedReArms(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, _ := db.CreateSchedule(coord.NewSchedule{Name: "skippy", CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "1h", TZ: "UTC",
+		PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "echo RAN"}, SkipMissed: true, NextRunAt: now.Add(-8 * time.Hour)})
+	s := New(db, Config{AgentID: "a1"})
+	fixed(s, now)
+	s.Tick(context.Background())
+	s.Wait()
+	runs, _ := db.ScheduleRuns(sc.ID, 10)
+	if len(runs) != 1 || runs[0].Status != coord.ScheduleRunSkipped || strings.Contains(runs[0].Output, "RAN") {
+		t.Fatalf("want one skipped run and no execution, got %+v", runs)
+	}
+	got, _ := db.GetSchedule(sc.ID)
+	if !got.NextRunAt.Equal(now.Add(time.Hour)) || got.LastStatus != coord.ScheduleRunSkipped {
+		t.Errorf("re-armed: next-in=%s status=%s", got.NextRunAt.Sub(now), got.LastStatus)
+	}
+	// A schedule found one tick late is NOT missed: it runs.
+	late, _ := db.CreateSchedule(coord.NewSchedule{Name: "ontime", CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "1h", TZ: "UTC",
+		PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "echo RAN"}, SkipMissed: true, NextRunAt: now.Add(-40 * time.Second)})
+	s.Tick(context.Background())
+	s.Wait()
+	runs, _ = db.ScheduleRuns(late.ID, 10)
+	if len(runs) != 1 || runs[0].Status != coord.ScheduleRunOK {
+		t.Errorf("40s late with tick 30s is on time, want a real run: %+v", runs)
+	}
+}
+
+func TestAgentScheduleMaterialisesTaskAndSettles(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, _ := db.CreateSchedule(coord.NewSchedule{Name: "briefing", CreatedBy: "me", OwnerAgent: "a1", Kind: coord.ScheduleCron,
+		Spec: "0 8 * * *", TZ: "UTC", PayloadKind: coord.PayloadAgent,
+		Payload: coord.AgentPayload{Title: "Morning briefing", Body: "Summarise the inbox."}, NextRunAt: now.Add(-time.Second)})
+	var n notes
+	var woke []*coord.Task
+	s := New(db, Config{AgentID: "a1"})
+	s.SetNotify(n.add)
+	s.SetWake(func(t *coord.Task) { woke = append(woke, t) })
+	fixed(s, now)
+
+	// The other gateway must leave an owned schedule alone.
+	other := New(db, Config{AgentID: "a2"})
+	fixed(other, now)
+	other.Tick(context.Background())
+	other.Wait()
+	if tasks, _ := db.ListTasks(coord.TaskFilter{}); len(tasks) != 0 {
+		t.Fatal("a2 fired a schedule owned by a1")
+	}
+
+	s.Tick(context.Background())
+	s.Wait()
+	tasks, _ := db.ListTasks(coord.TaskFilter{})
+	if len(tasks) != 1 {
+		t.Fatalf("want one task, got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.Kind != coord.KindScheduled || task.ScheduleID != sc.ID || task.AssignedTo != "a1" || task.CreatedBy != "schedule:briefing" {
+		t.Errorf("task: kind=%s schedule=%s to=%s by=%s", task.Kind, task.ScheduleID, task.AssignedTo, task.CreatedBy)
+	}
+	if !strings.Contains(task.Body, "Summarise the inbox.") || !strings.Contains(task.Body, "schedule \"briefing\"") {
+		t.Errorf("body: %q", task.Body)
+	}
+	if len(woke) != 1 || woke[0].ID != task.ID {
+		t.Errorf("wake should ring once for the task")
+	}
+	runs, _ := db.ScheduleRuns(sc.ID, 10)
+	if len(runs) != 1 || runs[0].Status != coord.ScheduleRunPending || runs[0].TaskID != task.ID {
+		t.Fatalf("run should be pending on the task: %+v", runs)
+	}
+
+	// Still working: another tick changes nothing.
+	s.Tick(context.Background())
+	s.Wait()
+	if runs, _ := db.ScheduleRuns(sc.ID, 10); len(runs) != 1 || runs[0].Status != coord.ScheduleRunPending {
+		t.Fatalf("pending run touched too early: %+v", runs)
+	}
+
+	// The agent finishes it; the next tick settles the run and delivers.
+	claimed, err := db.ClaimTask("a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _ := db.StartRun(claimed.ID, "a1", claimed.Attempts, "")
+	if _, err := db.FinishRun(run.ID, coord.RunOutcome{Liveness: coord.RunCompleted, Result: "3 mails, none urgent"}); err != nil {
+		t.Fatal(err)
+	}
+	s.Tick(context.Background())
+	s.Wait()
+	runs, _ = db.ScheduleRuns(sc.ID, 10)
+	if runs[0].Status != coord.ScheduleRunOK || !strings.Contains(runs[0].Output, "3 mails") {
+		t.Errorf("settled: %+v", runs[0])
+	}
+	got, _ := db.GetSchedule(sc.ID)
+	if got.LastStatus != coord.ScheduleRunOK {
+		t.Errorf("schedule status %s", got.LastStatus)
+	}
+	lines := n.all()
+	if len(lines) != 1 || !strings.Contains(lines[0], "briefing") || !strings.Contains(lines[0], "3 mails, none urgent") {
+		t.Errorf("result should be delivered once: %v", lines)
+	}
+}
+
+func TestAgentScheduleTaskFailureCountsAndQuietStaysQuiet(t *testing.T) {
+	db := openDB(t)
+	now := time.Now()
+	sc, _ := db.CreateSchedule(coord.NewSchedule{Name: "quiet", CreatedBy: "me", Kind: coord.ScheduleEvery, Spec: "1h", TZ: "UTC",
+		PayloadKind: coord.PayloadAgent, Payload: coord.AgentPayload{Title: "Tidy", Quiet: true}, NextRunAt: now.Add(-time.Second)})
+	var n notes
+	s := New(db, Config{AgentID: "a1"})
+	s.SetNotify(n.add)
+	fixed(s, now)
+	s.Tick(context.Background())
+	s.Wait()
+	tasks, _ := db.ListTasks(coord.TaskFilter{})
+	if len(tasks) != 1 {
+		t.Fatal("no task")
+	}
+	// Canceled counts as a failure for the schedule.
+	if err := db.CancelTask(tasks[0].ID, "me"); err != nil {
+		t.Fatal(err)
+	}
+	s.Tick(context.Background())
+	s.Wait()
+	got, _ := db.GetSchedule(sc.ID)
+	if got.ConsecutiveFailures != 1 || got.LastStatus != coord.ScheduleRunFailed {
+		t.Errorf("task cancel should count as a failure: failures=%d status=%s", got.ConsecutiveFailures, got.LastStatus)
+	}
+	if len(n.all()) != 0 {
+		t.Errorf("one failure, quiet payload: nothing should be sent, got %v", n.all())
+	}
+	// A completed quiet task delivers nothing either.
+	sc2, _ := db.CreateSchedule(coord.NewSchedule{Name: "quiet2", CreatedBy: "me", Kind: coord.ScheduleEvery, Spec: "1h", TZ: "UTC",
+		PayloadKind: coord.PayloadAgent, Payload: coord.AgentPayload{Title: "Tidy2", Quiet: true}, NextRunAt: now.Add(-time.Second)})
+	s.Tick(context.Background())
+	s.Wait()
+	claimed, _ := db.ClaimTask("a1")
+	run, _ := db.StartRun(claimed.ID, "a1", claimed.Attempts, "")
+	db.FinishRun(run.ID, coord.RunOutcome{Liveness: coord.RunCompleted, Result: "done"})
+	s.Tick(context.Background())
+	s.Wait()
+	if runs, _ := db.ScheduleRuns(sc2.ID, 5); runs[0].Status != coord.ScheduleRunOK {
+		t.Errorf("quiet run should settle ok: %+v", runs[0])
+	}
+	if len(n.all()) != 0 {
+		t.Errorf("quiet must not deliver: %v", n.all())
+	}
+}
+
+// Two schedulers on two handles, both ticking at the same instant, produce
+// exactly one run per due schedule.
+func TestTwoGatewaysFireOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coord.db")
+	a, _ := coord.Open(path)
+	defer a.Close()
+	b, _ := coord.Open(path)
+	defer b.Close()
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		a.CreateSchedule(coord.NewSchedule{Name: "s" + string(rune('a'+i)), CreatedBy: "t", Kind: coord.ScheduleEvery, Spec: "10m", TZ: "UTC",
+			PayloadKind: coord.PayloadCommand, Payload: coord.CommandPayload{Cmd: "true"}, NextRunAt: now.Add(-time.Second)})
+	}
+	sa, sb := New(a, Config{AgentID: "a1"}), New(b, Config{AgentID: "a2"})
+	fixed(sa, now)
+	fixed(sb, now)
+	var wg sync.WaitGroup
+	for _, s := range []*Scheduler{sa, sb} {
+		wg.Add(1)
+		go func(s *Scheduler) {
+			defer wg.Done()
+			s.Tick(context.Background())
+			s.Wait()
+		}(s)
+	}
+	wg.Wait()
+	all, _ := a.ListSchedules()
+	for _, sc := range all {
+		runs, _ := a.ScheduleRuns(sc.ID, 10)
+		if len(runs) != 1 {
+			t.Errorf("%s: %d runs, want 1", sc.Name, len(runs))
+		}
+	}
+}

--- a/internal/scheduler/spec.go
+++ b/internal/scheduler/spec.go
@@ -1,0 +1,125 @@
+package scheduler
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// cronParser is the standard 5-field parser plus descriptors (@daily, @every
+// 1h). Only the parser is used; the calendar lives in the database
+// (schedules.next_run_at), not in a process — that is what lets two gateways
+// share one set of schedules.
+//
+// Standard-cron trap worth knowing: when BOTH day-of-month and day-of-week are
+// restricted ("0 8 1 * 1"), a run happens when EITHER matches, not both.
+var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+// atLayouts are the forms `--at` accepts, tried in order, in the schedule's zone.
+var atLayouts = []string{
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+	"2006-01-02T15:04",
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
+}
+
+// NextRun computes the first firing at or after `from` for a spec. A zero
+// result with a nil error means "never again" — an `at` whose time has passed.
+//
+// `every` counts from `from`, so an every-10m schedule that fires late does not
+// try to catch up on a fixed grid; `cron` and `at` are absolute in tz.
+func NextRun(kind, spec, tz string, from time.Time) (time.Time, error) {
+	loc, err := LoadZone(tz)
+	if err != nil {
+		return time.Time{}, err
+	}
+	spec = strings.TrimSpace(spec)
+	switch kind {
+	case coord.ScheduleEvery:
+		d, err := time.ParseDuration(spec)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("every: %q is not a duration (try 10m, 1h30m): %w", spec, err)
+		}
+		if d < time.Minute {
+			return time.Time{}, fmt.Errorf("every: %s is under the 1m minimum", d)
+		}
+		return from.Add(d), nil
+	case coord.ScheduleCron:
+		sched, err := cronParser.Parse(spec)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("cron: %q: %w", spec, err)
+		}
+		return sched.Next(from.In(loc)), nil
+	case coord.ScheduleAt:
+		at, err := ParseAt(spec, loc)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !at.After(from) {
+			return time.Time{}, nil
+		}
+		return at, nil
+	}
+	return time.Time{}, fmt.Errorf("schedule kind %q must be at, every or cron", kind)
+}
+
+// ParseAt reads a one-shot time. Forms without a zone are read in loc.
+func ParseAt(spec string, loc *time.Location) (time.Time, error) {
+	spec = strings.TrimSpace(spec)
+	for _, layout := range atLayouts {
+		if t, err := time.ParseInLocation(layout, spec, loc); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("at: %q is not a time (use 2026-09-07T09:00 or RFC3339)", spec)
+}
+
+// LoadZone resolves an IANA zone name. "" and "local" mean the machine's zone.
+func LoadZone(tz string) (*time.Location, error) {
+	switch strings.ToLower(strings.TrimSpace(tz)) {
+	case "", "local":
+		return time.LoadLocation(LocalZone())
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, fmt.Errorf("tz: %q is not an IANA zone (try Asia/Ho_Chi_Minh): %w", tz, err)
+	}
+	return loc, nil
+}
+
+// LocalZone names the machine's zone the way a schedule row must store it: an
+// IANA name, never "Local". $TZ wins; otherwise the /etc/localtime symlink
+// (macOS points it at /var/db/timezone/zoneinfo/<Area>/<City>); else UTC.
+func LocalZone() string {
+	if tz := strings.TrimSpace(os.Getenv("TZ")); tz != "" {
+		if _, err := time.LoadLocation(tz); err == nil {
+			return tz
+		}
+	}
+	if target, err := os.Readlink("/etc/localtime"); err == nil {
+		if i := strings.Index(target, "zoneinfo/"); i >= 0 {
+			name := target[i+len("zoneinfo/"):]
+			if _, err := time.LoadLocation(name); err == nil {
+				return name
+			}
+		}
+	}
+	return "UTC"
+}
+
+// Describe renders a spec for lists: "every 10m", "cron 0 8 * * 1-5 (Asia/Ho_Chi_Minh)".
+func Describe(s *coord.Schedule) string {
+	switch s.Kind {
+	case coord.ScheduleEvery:
+		return "every " + s.Spec
+	case coord.ScheduleAt:
+		return "at " + s.Spec + " (" + s.TZ + ")"
+	}
+	return "cron " + s.Spec + " (" + s.TZ + ")"
+}


### PR DESCRIPTION
## P1a — Lịch (design §5.5, §6, §9b)

**Nguyên tắc**: lịch quyết định *khi nào*; `tasks`/`schedule_runs` ghi *chuyện gì đã xảy ra*. Scheduler không chạy model.

### Gì mới
- **Schema v4**: `schedules`, `schedule_runs`, `agents.scratch` (sẵn cho P1b heartbeat). Migration `IF NOT EXISTS` + `ensureColumn`, test mở DB v3 thật.
- **`internal/scheduler`**: tick 30s; **CAS trên `next_run_at`** → hai gateway cùng thấy đến giờ, đúng một cái bắn (`TestTwoGatewaysFireOnce`, `TestClaimScheduleIsExclusiveAcrossHandles`).
  - payload `agent` → tạo task `kind=scheduled` → đi đường claim/lease/fencing như task thường; run `pending` tới khi task kết thúc, gateway nào thấy trước settle (cũng CAS) → không đếm lỗi hai lần.
  - payload `command` → `sh -c` trong gateway, process group riêng, timeout, output cắt 8KB giữ đầu+cuối.
  - **Catch-up một lần** sau downtime (next tính từ *bây giờ*, không phải mốc cũ) hoặc `--skip-missed` re-arm.
  - **Bậc thang** 30s→1m→5m→15m→1h; báo Telegram ở lần lỗi thứ 2 (cooldown 1h); **tự tắt** ở lần 10 (báo đúng một lần).
  - Kết quả task theo lịch **gửi Telegram** cho `security.allowed_user_ids` khi `completed` (`--quiet` để không) — xem §9b vì sao.
- **CLI** `bomclaw schedule add|list|show|enable|disable|remove|run-now`; **RPC** `schedules.*` (sẵn cho tab dashboard P1c).
- **Config** `schedules.enabled` mặc định **false** (nguyên tắc 12). Bật ở cả hai gateway là an toàn.
- `bot.Bot.Notify` — tin nhắn gateway tự khởi xướng gửi tới allow-list, không phải "ai nhắn gần nhất".

### Sửa bug có sẵn (lộ ra khi chạy full test)
`coord.ts()` dùng `RFC3339Nano` → cắt số 0 cuối → `"…00.1Z"` **xếp sau** `"…00.10000001Z"` khi so chuỗi. Task xong lúc `.1` không claim được lúc `.10000001` → test P0 fail ngẫu nhiên; production: chờ hết lease. Đổi sang 9 chữ số cố định; `parseTS` đọc được cả hai dạng. Coord chạy 6 lần liên tiếp xanh.

### Test
`go test ./...` xanh. Scheduler: cron+TZ (`0 8 * * 1-5` từ thứ Sáu 09:00 HCM → thứ Hai 08:00), every/at, command ok/fail/timeout, ladder+alert+cooldown+auto-disable, catch-up once, skip_missed, agent → task → settle → deliver, quiet, owner_agent, hai gateway.

### Sau merge (chưa bật gì cả)
1. Deploy như thường (`/deploy`). Migration v4 tự chạy, không đụng dữ liệu cũ.
2. Bật khi muốn: `schedules: {enabled: true}` trong `~/.bomclaw/config.yaml` (và/hoặc `~/.bomclaw2`), restart.
3. Thử: `bomclaw schedule add --name disk --every 10m --command "df -h /"` → `bomclaw schedule show disk` sau vài phút.
4. System prompt live (mục "Working with the other agents") nên thêm một câu: *việc lặp → `bomclaw schedule add`, không tự tạo task lặp*. Sửa tay, không copy config.yaml repo.

Tiếp: **P1b heartbeat** (schedule hệ thống + scratch + skip rules + `NO_REPLY`), **P1c** tab Schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
