### PR TITLE
fix(bomtray): stop notifying that a healthy gateway is down

### DIFF
--- a/cmd/bomtray/main.go
+++ b/cmd/bomtray/main.go
@@ -53,6 +53,17 @@ type trayState struct {
 	awake   bool // a sleep-prevention hold is currently active
 }
 
+// downAfter is how many consecutive failed polls it takes to call an agent
+// down, and therefore to notify about it.
+//
+// One is not enough. The status request has a 2 second timeout against a
+// gateway that spawns CLI subprocesses heavy enough to starve it for that long,
+// so a single miss is routine — and it used to fire "… is DOWN" immediately,
+// followed by "… is back up" a few seconds later, over and over, about a
+// gateway that never stopped serving. Three misses is roughly ten seconds of
+// silence, which a gateway that is actually up does not produce.
+const downAfter = 3
+
 // defaultAgents is the standard local layout. Both are probed; whichever
 // answers is shown.
 var defaultAgents = []string{"http://127.0.0.1:18789", "http://127.0.0.1:18790"}
@@ -70,6 +81,7 @@ type agent struct {
 	mu        sync.Mutex
 	st        *gateway.StatusResult
 	up        bool
+	fails     int  // consecutive failed polls; down is declared at downAfter
 	seen      bool // has this address EVER answered? unseen agents stay hidden
 	upKnown   bool
 	wasUp     bool
@@ -332,13 +344,18 @@ func (a *app) poll() {
 			defer wg.Done()
 			st, err := fetchStatus(ag.url)
 			ag.mu.Lock()
-			ag.st, ag.up = st, err == nil
 			if err == nil {
-				ag.seen = true
+				ag.st, ag.fails, ag.seen = st, 0, true
 				if st.Workspace != "" {
 					ag.workspace = st.Workspace
 				}
+			} else {
+				ag.fails++
+				// The last good status is kept on purpose. It carries the
+				// agent's name, and a missed poll should not turn "BomClaw"
+				// back into an IP address in the menu and the notification.
 			}
+			ag.up = ag.fails < downAfter
 			ag.mu.Unlock()
 		}(ag)
 	}

--- a/cmd/bomtray/main_test.go
+++ b/cmd/bomtray/main_test.go
@@ -115,3 +115,46 @@ func TestTooltipWithNothingAnswering(t *testing.T) {
 		t.Errorf("tooltip = %q, want it to say no gateway is answering", got)
 	}
 }
+
+// A single missed poll must not declare an agent down. The status request has a
+// 2s timeout against a gateway that spawns CLI subprocesses, so one miss is
+// routine — and it used to fire "is DOWN" straight away, then "is back up"
+// seconds later, about a gateway with hours of uptime.
+func TestOneMissedPollDoesNotMeanDown(t *testing.T) {
+	ag := &agent{url: "http://127.0.0.1:18790"}
+	ag.st = &gateway.StatusResult{AgentID: "bomclaw", AgentName: "BomClaw"}
+	ag.seen, ag.up = true, true
+
+	for i := 1; i < downAfter; i++ {
+		ag.fails = i
+		ag.up = ag.fails < downAfter
+		if !ag.up {
+			t.Fatalf("declared down after only %d missed poll(s); downAfter is %d", i, downAfter)
+		}
+	}
+
+	ag.fails = downAfter
+	ag.up = ag.fails < downAfter
+	if ag.up {
+		t.Errorf("still up after %d consecutive misses", downAfter)
+	}
+}
+
+// A failed poll used to nil out the status, so the agent lost its name and the
+// notification said "127.0.0.1:18790 is DOWN" instead of "BomClaw is DOWN".
+func TestAFailedPollKeepsTheAgentName(t *testing.T) {
+	ag := &agent{url: "http://127.0.0.1:18790"}
+	ag.st = &gateway.StatusResult{AgentID: "bomclaw", AgentName: "BomClaw"}
+	ag.seen = true
+
+	// What poll() now does on error: count it, keep the last good status.
+	ag.fails++
+	ag.up = ag.fails < downAfter
+
+	if got := ag.name(); got != "BomClaw" {
+		t.Errorf("name after a failed poll = %q, want the last known name", got)
+	}
+	if ag.st == nil {
+		t.Error("the last good status must be kept — it is where the name comes from")
+	}
+}


### PR DESCRIPTION
The tray was firing "127.0.0.1:18790 is DOWN" toasts about a gateway with an hour and a half of continuous uptime and no restarts in its log. Both halves of the bug were on one line of poll():

	ag.st, ag.up = st, err == nil

A single failed poll declared the agent down, so the notification went out immediately and "is back up" followed a few seconds later — repeatedly. The status request has a 2 second timeout against a gateway that spawns claude CLI subprocesses heavy enough to starve it for that long, so missing one poll is routine rather than exceptional. Down now needs downAfter (3) consecutive misses, roughly ten seconds of silence.

The same line also nil'd the status on failure, which is why the toast named the agent "127.0.0.1:18790" rather than "BomClaw": name() reads AgentName from the last status, and there was none left. The last good status is now kept, so a down agent keeps its name in the menu, the tooltip and the notification.

Neither is Windows-specific — the same flap was possible on macOS, it just took a busier machine to see it.