### PR TITLE
feat(coord): report a delegated task's outcome back to the owner

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/daemon"
 	"github.com/ngocp/goterm-control/internal/gateway"
 	"github.com/ngocp/goterm-control/internal/models"
+	"github.com/ngocp/goterm-control/internal/reporter"
 	"github.com/ngocp/goterm-control/internal/scheduler"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/storage"
@@ -385,6 +386,21 @@ func runGateway(args []string) {
 		runner.Start(ctx)
 	} else if coordDB != nil {
 		log.Printf("taskrunner: disabled (tasks.auto_claim=false) — queued work waits for `bomclaw task claim`")
+	}
+
+	// Reporter — tells the owner what came of tasks this agent handed to a
+	// peer. Not gated on auto_claim or schedules.enabled, and that is the whole
+	// point: a gateway delegates because it does *not* run the work itself, so
+	// it is exactly the gateway whose runner and scheduler are switched off.
+	// Any number of gateways may run it; the compare-and-set on tasks
+	// .reported_at means only one delivers.
+	var report *reporter.Reporter
+	if coordDB != nil {
+		report = reporter.New(coordDB, reporter.Config{AgentID: cfg.Agent.ID})
+		if tgBot != nil {
+			report.SetNotify(func(text string) { tgBot.Notify(text) })
+		}
+		report.Start(ctx)
 	}
 
 	// Scheduler — fires timed work from the shared database. Off by default:

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -26,7 +26,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 // DB is the shared coordination database.
 type DB struct {
@@ -160,7 +160,10 @@ var ddl = []string{
 		continuations     INTEGER NOT NULL DEFAULT 0, -- runs that ended "not done yet" (≠ attempts, which are failures)
 		max_continuations INTEGER NOT NULL DEFAULT 20,
 		blocked_on        TEXT NOT NULL DEFAULT '',   -- '' | children | human
-		fail_reason       TEXT NOT NULL DEFAULT ''    -- exhausted | continuations-exhausted | empty-exhausted
+		fail_reason       TEXT NOT NULL DEFAULT '',   -- exhausted | continuations-exhausted | empty-exhausted
+		-- v5: set once the task's outcome has been reported to whoever asked for
+		-- it. Empty on a terminal task means a report is still owed.
+		reported_at       TEXT NOT NULL DEFAULT ''
 	) STRICT`,
 	`CREATE INDEX IF NOT EXISTS idx_tasks_claimable ON tasks(state, lease_until, priority DESC, created_at)`,
 	`CREATE INDEX IF NOT EXISTS idx_tasks_context   ON tasks(context_id)`,
@@ -311,6 +314,13 @@ var v4Columns = []struct{ table, name, decl string }{
 // the previous version they can only be built after those columns exist — a
 // fresh database gets them from the CREATE TABLE and the ALTERs are no-ops,
 // but an upgraded one would fail with "no such column" if these sat in ddl.
+// v5Columns adds the reporting marker to tasks. Same guarded-ALTER treatment as
+// v3Columns: CREATE TABLE IF NOT EXISTS leaves an existing table alone, and the
+// catalogue check makes it safe for two gateways to open the file at once.
+var v5Columns = []struct{ name, decl string }{
+	{"reported_at", "TEXT NOT NULL DEFAULT ''"},
+}
+
 var v3Indexes = []string{
 	`CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id, state)`,
 }
@@ -328,6 +338,11 @@ func (db *DB) migrate() error {
 	}
 	for _, c := range v4Columns {
 		if err := db.ensureColumn(c.table, c.name, c.decl); err != nil {
+			return err
+		}
+	}
+	for _, c := range v5Columns {
+		if err := db.ensureColumn("tasks", c.name, c.decl); err != nil {
 			return err
 		}
 	}

--- a/internal/coord/reports_test.go
+++ b/internal/coord/reports_test.go
@@ -1,0 +1,216 @@
+package coord
+
+import (
+	"testing"
+	"time"
+)
+
+// delegated creates a task agent "a2" handed to agent "a1", claims it as a1 and
+// finishes it — the shape the reporter is meant to pick up.
+func delegated(t *testing.T, db *DB, title, state, result string) *Task {
+	t.Helper()
+	task, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: title})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	c, err := db.ClaimTask("a1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := db.FinishTask(c.ID, "a1", state, result, c.Attempts); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	return task
+}
+
+func TestPendingReportsFindsDelegatedWorkThatFinished(t *testing.T) {
+	db := testDB(t)
+	task := delegated(t, db, "crawl listings", TaskCompleted, "62 jobs")
+
+	got, err := db.PendingReports("a2", 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != task.ID {
+		t.Fatalf("want the one finished task, got %+v", got)
+	}
+	if got[0].Result != "62 jobs" || got[0].ClaimedBy != "a1" {
+		t.Errorf("the report needs the result and who ran it, got %+v", got[0])
+	}
+}
+
+// The executor is not owed a report about its own work — it was there.
+func TestPendingReportsIsScopedToTheRequester(t *testing.T) {
+	db := testDB(t)
+	delegated(t, db, "crawl listings", TaskCompleted, "62 jobs")
+
+	if got, _ := db.PendingReports("a1", 0); len(got) != 0 {
+		t.Errorf("a1 ran the task; it should owe itself nothing, got %+v", got)
+	}
+	if got, _ := db.PendingReports("a3", 0); len(got) != 0 {
+		t.Errorf("an unrelated agent should see nothing, got %+v", got)
+	}
+}
+
+// Failure is the outcome most worth hearing about, so it reports like any other.
+func TestPendingReportsIncludesFailures(t *testing.T) {
+	db := testDB(t)
+	delegated(t, db, "broken job", TaskFailed, "exit 3")
+
+	got, _ := db.PendingReports("a2", 0)
+	if len(got) != 1 || got[0].State != TaskFailed {
+		t.Fatalf("a failed hand-off must still be reported, got %+v", got)
+	}
+}
+
+func TestPendingReportsSkipsWorkStillInFlight(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "queued"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.PendingReports("a2", 0); len(got) != 0 {
+		t.Errorf("submitted work is not an outcome, got %+v", got)
+	}
+
+	if _, err := db.ClaimTask("a1"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := db.PendingReports("a2", 0); len(got) != 0 {
+		t.Errorf("working is not an outcome either, got %+v", got)
+	}
+}
+
+// A task the requester ran itself needs no report: it watched it happen. This is
+// what claimed_by != created_by buys, and it is why assigned_to is not the test
+// — an unassigned task the requester happens to claim would slip through.
+func TestPendingReportsSkipsWorkTheRequesterRanItself(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.CreateTask(NewTask{CreatedBy: "a2", Title: "anyone can take this"}); err != nil {
+		t.Fatal(err)
+	}
+	c, err := db.ClaimTask("a2") // the creator claims its own unassigned task
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.FinishTask(c.ID, "a2", TaskCompleted, "did it myself", c.Attempts); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := db.PendingReports("a2", 0); len(got) != 0 {
+		t.Errorf("the requester ran this one; reporting it would tell them what they just did: %+v", got)
+	}
+}
+
+// Scheduled work is settled and delivered by scheduler.settle. Matching it here
+// too would send every scheduled result to Telegram twice.
+func TestPendingReportsLeavesScheduledWorkToTheScheduler(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.CreateTask(NewTask{
+		CreatedBy: "a2", AssignedTo: "a1", Title: "nightly", Kind: KindScheduled, ScheduleID: "sch_1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c, _ := db.ClaimTask("a1")
+	if err := db.FinishTask(c.ID, "a1", TaskCompleted, "done", c.Attempts); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := db.PendingReports("a2", 0); len(got) != 0 {
+		t.Errorf("the scheduler reports its own runs; this would double up: %+v", got)
+	}
+}
+
+// A sub-task is a detail of its parent's work; the parent's outcome is the one
+// that was actually asked for.
+func TestPendingReportsReportsRootTasksOnly(t *testing.T) {
+	db := testDB(t)
+	parent, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "parent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateTask(NewTask{
+		CreatedBy: "a2", AssignedTo: "a1", Title: "child", ParentID: parent.ID, Kind: KindSub, Depth: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Finish the child only.
+	c, _ := db.ClaimTask("a1")
+	for c.ParentID == "" { // claim order is not guaranteed; find the child
+		if err := db.FinishTask(c.ID, "a1", TaskCompleted, "root done", c.Attempts); err != nil {
+			t.Fatal(err)
+		}
+		if c, err = db.ClaimTask("a1"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.FinishTask(c.ID, "a1", TaskCompleted, "child done", c.Attempts); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, got := range mustPending(t, db, "a2") {
+		if got.ParentID != "" {
+			t.Errorf("a sub-task should not be reported on its own: %+v", got)
+		}
+	}
+}
+
+func mustPending(t *testing.T, db *DB, agent string) []Task {
+	t.Helper()
+	got, err := db.PendingReports(agent, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	return got
+}
+
+// The whole point of the marker: every gateway runs the same query against the
+// same file, and exactly one of them may deliver.
+func TestMarkReportedIsWonOnceOnly(t *testing.T) {
+	db := testDB(t)
+	task := delegated(t, db, "crawl listings", TaskCompleted, "62 jobs")
+	now := time.Now()
+
+	won, err := db.MarkReported(task.ID, now)
+	if err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if !won {
+		t.Fatal("the first caller must win the delivery")
+	}
+
+	again, err := db.MarkReported(task.ID, now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("mark twice: %v", err)
+	}
+	if again {
+		t.Error("a second gateway must lose, or the user hears the same result twice")
+	}
+}
+
+func TestMarkReportedRemovesItFromThePendingList(t *testing.T) {
+	db := testDB(t)
+	task := delegated(t, db, "crawl listings", TaskCompleted, "62 jobs")
+
+	if _, err := db.MarkReported(task.ID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustPending(t, db, "a2"); len(got) != 0 {
+		t.Errorf("a reported task must not come back round: %+v", got)
+	}
+
+	// And the marker is readable, so `task show` can say it was delivered.
+	after, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ReportedAt == "" {
+		t.Error("reported_at should be set and scannable through taskCols")
+	}
+}
+
+func TestPendingReportsRequiresAnAgent(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.PendingReports("", 0); err == nil {
+		t.Error("an empty agent id would match every task in the file; it must be refused")
+	}
+}

--- a/internal/coord/schedules_test.go
+++ b/internal/coord/schedules_test.go
@@ -3,6 +3,7 @@ package coord
 import (
 	"database/sql"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -337,13 +338,21 @@ func TestMigrateV3DatabaseGainsSchedules(t *testing.T) {
 	defer db.Close()
 	var version string
 	db.conn.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&version)
-	if version != "4" {
-		t.Errorf("schema_version %s, want 4", version)
+	// Against the constant, not a literal: this asserts "migrating brings an old
+	// file fully up to date", which stays true across the next bump.
+	if want := strconv.Itoa(schemaVersion); version != want {
+		t.Errorf("schema_version %s, want %s", version, want)
 	}
 	var n int
 	db.conn.QueryRow(`SELECT count(*) FROM pragma_table_info('agents') WHERE name='scratch'`).Scan(&n)
 	if n != 1 {
 		t.Error("agents.scratch missing after migration")
+	}
+	// v5: without this column the reporter's query fails on every existing
+	// coord.db rather than on a fresh one, which is the only kind anyone has.
+	db.conn.QueryRow(`SELECT count(*) FROM pragma_table_info('tasks') WHERE name='reported_at'`).Scan(&n)
+	if n != 1 {
+		t.Error("tasks.reported_at missing after migration")
 	}
 	if _, err := db.ListSchedules(); err != nil {
 		t.Errorf("schedules table: %v", err)

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -97,6 +97,10 @@ type Task struct {
 	MaxContinuations int    `json:"max_continuations"`
 	BlockedOn        string `json:"blocked_on,omitempty"`
 	FailReason       string `json:"fail_reason,omitempty"`
+
+	// v5: set once this task's outcome has been delivered to whoever asked for
+	// it. Empty on a terminal task means a report is still owed.
+	ReportedAt string `json:"reported_at,omitempty"`
 }
 
 // SessionRef names the CLI session a task's work lives in. Both CLIs keep the
@@ -133,7 +137,7 @@ const taskCols = `id, context_id, created_by, assigned_to, claimed_by, state,
 	priority, title, body, result, trace_id, lease_until, attempts,
 	max_attempts, depth, created_at, updated_at,
 	parent_id, kind, schedule_id, checkpoint, session_ref, continuations,
-	max_continuations, blocked_on, fail_reason`
+	max_continuations, blocked_on, fail_reason, reported_at`
 
 // TaskEvent is an append-only record of one state transition.
 type TaskEvent struct {
@@ -577,11 +581,94 @@ func scanTask(s scanner) (*Task, error) {
 		&t.State, &t.Priority, &t.Title, &t.Body, &t.Result, &t.TraceID,
 		&lease, &t.Attempts, &t.MaxAttempts, &t.Depth, &created, &updated,
 		&t.ParentID, &t.Kind, &t.ScheduleID, &t.Checkpoint, &t.SessionRef, &t.Continuations,
-		&t.MaxContinuations, &t.BlockedOn, &t.FailReason); err != nil {
+		&t.MaxContinuations, &t.BlockedOn, &t.FailReason, &t.ReportedAt); err != nil {
 		return nil, err
 	}
 	t.LeaseUntil = parseTS(lease)
 	t.CreatedAt = parseTS(created)
 	t.UpdatedAt = parseTS(updated)
 	return &t, nil
+}
+
+// TerminalTaskStates are the states a task never leaves. A task in one of these
+// has an outcome worth reporting; anything else is still in play.
+var TerminalTaskStates = []string{TaskCompleted, TaskFailed, TaskCanceled, TaskRejected}
+
+// PendingReports lists tasks agentID delegated that have finished and whose
+// outcome nobody has delivered yet — the requester's side of the queue, which
+// until now had no query at all. Oldest first, so a backlog reports in order.
+//
+// Four clauses decide what counts as "delegated to someone else", and each one
+// keeps a class of task out:
+//
+//   - claimed_by != created_by is the actual test. Whoever ran it was not me,
+//     so I did not watch it happen. A task that died before anyone claimed it
+//     has claimed_by = ” and still qualifies, which is right: a rejected or
+//     cancelled hand-off is exactly the outcome worth hearing about.
+//   - schedule_id = ” leaves scheduled work alone. The scheduler already
+//     settles and reports its own runs (scheduler.settle), so matching them
+//     here would deliver every scheduled result to Telegram twice.
+//   - parent_id = ” reports root tasks only. A sub-task is a detail of its
+//     parent's work; the parent's own outcome is the one that was asked for.
+//   - reported_at = ” is the marker MarkReported sets, so a result is
+//     delivered once even though every gateway runs this query.
+func (db *DB) PendingReports(agentID string, limit int) ([]Task, error) {
+	if agentID == "" {
+		return nil, fmt.Errorf("pending reports: agent id is required")
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	states := make([]string, len(TerminalTaskStates))
+	args := []any{agentID}
+	for i, s := range TerminalTaskStates {
+		states[i] = "?"
+		args = append(args, s)
+	}
+	args = append(args, limit)
+
+	rows, err := db.conn.Query(`SELECT `+taskCols+`
+		FROM tasks
+		WHERE created_by = ?
+		  AND claimed_by != created_by
+		  AND schedule_id = ''
+		  AND parent_id = ''
+		  AND state IN (`+strings.Join(states, ",")+`)
+		  AND reported_at = ''
+		ORDER BY updated_at, rowid LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("pending reports: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Task{}
+	for rows.Next() {
+		t, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *t)
+	}
+	return out, rows.Err()
+}
+
+// MarkReported claims the delivery of one task's outcome. It returns true for
+// exactly one caller.
+//
+// Every gateway on the machine runs the same PendingReports query against the
+// same file, so two of them can see the same finished task in the same tick.
+// The compare-and-set on reported_at is what makes the second one a no-op —
+// the same idiom as ClaimTask, ClaimSchedule and SettleScheduleRun, and for the
+// same reason: the shared database is the only coordination primitive here, so
+// there is no lock and no leader to lose.
+func (db *DB) MarkReported(taskID string, now time.Time) (bool, error) {
+	res, err := db.conn.Exec(
+		`UPDATE tasks SET reported_at = ? WHERE id = ? AND reported_at = ''`,
+		ts(now), taskID)
+	if err != nil {
+		return false, fmt.Errorf("mark reported %s: %w", taskID, err)
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -1,0 +1,228 @@
+// Package reporter closes the return leg of a delegated task: it tells the
+// person who asked what came of work their agent handed to a peer.
+//
+// The queue is a pull system — "poll, claim, run, report. The database is the
+// source of truth" — and that reasoning was only ever applied to the executor.
+// The requester had no loop at all, so a peer's result landed in tasks.result
+// and stopped there: no query read it back, and Bot.Notify had exactly one
+// producer in the tree (the scheduler). This is the missing half.
+//
+// It is deliberately the same shape as scheduler.settle, which already does
+// this job for scheduled work: list what I delegated, ask whether it finished,
+// win a compare-and-set so only one gateway delivers, then notify.
+//
+// # Why this is its own loop
+//
+// The two loops that already tick are both the wrong host. taskrunner starts
+// only when tasks.auto_claim is true and scheduler only when schedules.enabled
+// is true — and a gateway delegates precisely because it does not run the work
+// itself, so it is exactly the gateway with both switched off. This one starts
+// wherever the coordination database is open, the same condition that already
+// mounts /api/tasks/poke "even when this agent does not claim tasks".
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// maxResultChars bounds one delivery. Telegram rejects a message over 4096
+// characters outright, and a truncated result the user can follow up on beats a
+// send that fails silently.
+const maxResultChars = 3500
+
+// Config tunes the loop. Zero values take the defaults noted.
+type Config struct {
+	AgentID string
+	Tick    time.Duration // how often to look for finished work; default 30s
+	Batch   int           // most reports to deliver per tick; default 20
+}
+
+func (c *Config) defaults() {
+	if c.Tick <= 0 {
+		c.Tick = 30 * time.Second
+	}
+	if c.Batch <= 0 {
+		c.Batch = 20
+	}
+}
+
+// Reporter is the loop. Create with New, wire SetNotify, then Start.
+type Reporter struct {
+	db  *coord.DB
+	cfg Config
+
+	notify func(text string) // deliver a line to the owner; nil = log only
+	now    func() time.Time  // test seam
+	poke   chan struct{}
+	work   sync.WaitGroup
+}
+
+// New builds a reporter. It does nothing until Start.
+func New(db *coord.DB, cfg Config) *Reporter {
+	cfg.defaults()
+	return &Reporter{
+		db:   db,
+		cfg:  cfg,
+		now:  time.Now,
+		poke: make(chan struct{}, 1),
+	}
+}
+
+// SetNotify installs the delivery path — in the gateway, the owner's Telegram.
+func (r *Reporter) SetNotify(fn func(text string)) {
+	if r == nil {
+		return
+	}
+	r.notify = fn
+}
+
+// Poke asks for a tick now, so a result does not wait out the interval. Safe to
+// call on a nil Reporter, which is what a gateway without coord has.
+func (r *Reporter) Poke() {
+	if r == nil {
+		return
+	}
+	select {
+	case r.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Start runs the loop until ctx ends. The first tick is immediate: results that
+// arrived while this gateway was down are still owed a report.
+func (r *Reporter) Start(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	if r.notify == nil {
+		log.Printf("reporter: no delivery path (no Telegram on this gateway) — " +
+			"delegated results are left for a peer that has one")
+		return
+	}
+	log.Printf("reporter: reporting delegated results as %s every %s", r.cfg.AgentID, r.cfg.Tick)
+	r.work.Add(1)
+	go func() {
+		defer r.work.Done()
+		t := time.NewTicker(r.cfg.Tick)
+		defer t.Stop()
+		r.Tick()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			case <-r.poke:
+			}
+			r.Tick()
+		}
+	}()
+}
+
+// Wait blocks until the loop has stopped. Used by tests and shutdown.
+func (r *Reporter) Wait() {
+	if r == nil {
+		return
+	}
+	r.work.Wait()
+}
+
+// Tick is one pass: deliver the outcome of every finished task this agent
+// delegated and nobody has reported yet. Exported so tests can drive it.
+func (r *Reporter) Tick() {
+	if r == nil || r.db == nil {
+		return
+	}
+
+	// A gateway that cannot reach the owner must not touch the queue. Claiming
+	// a report here would mark it delivered and then write it to a log nobody
+	// reads, while the peer that does have Telegram never sees it again — the
+	// marker makes silence permanent. Leaving it untouched costs nothing: any
+	// gateway with a delivery path picks it up on its next tick.
+	if r.notify == nil {
+		return
+	}
+
+	pending, err := r.db.PendingReports(r.cfg.AgentID, r.cfg.Batch)
+	if err != nil {
+		log.Printf("reporter: %v", err)
+		return
+	}
+
+	for i := range pending {
+		task := pending[i]
+
+		// Win the delivery before sending, never after. The other order would
+		// send twice from two gateways and mark once.
+		won, err := r.db.MarkReported(task.ID, r.now())
+		if err != nil {
+			log.Printf("reporter: %v", err)
+			continue
+		}
+		if !won {
+			continue // a peer got there first
+		}
+
+		r.notify(Format(&task))
+		log.Printf("reporter: delivered %s (%s) for task %s", task.State, task.ClaimedBy, task.ID)
+	}
+}
+
+// Format writes the line the owner sees.
+//
+// It leads with the outcome rather than the title because the outcome is what
+// the reader is waiting for, and names the agent that ran it: with two agents
+// on one machine, "done" without a name does not say whose work finished.
+func Format(t *coord.Task) string {
+	var b strings.Builder
+
+	switch t.State {
+	case coord.TaskCompleted:
+		b.WriteString("✅ ")
+	case coord.TaskFailed:
+		b.WriteString("⛔ ")
+	default: // canceled, rejected
+		b.WriteString("⚠️ ")
+	}
+
+	b.WriteString(t.Title)
+	if by := ranBy(t); by != "" {
+		fmt.Fprintf(&b, "\n%s · %s", t.State, by)
+	} else {
+		fmt.Fprintf(&b, "\n%s", t.State)
+	}
+	if t.FailReason != "" {
+		fmt.Fprintf(&b, " (%s)", t.FailReason)
+	}
+
+	if result := strings.TrimSpace(t.Result); result != "" {
+		fmt.Fprintf(&b, "\n\n%s", truncate(result, maxResultChars))
+	} else {
+		b.WriteString("\n\n(finished without a result)")
+	}
+
+	return b.String()
+}
+
+// ranBy names the agent that executed the task, or nothing when it died before
+// anyone claimed it — in which case saying "by ”" would be worse than silence.
+func ranBy(t *coord.Task) string {
+	if t.ClaimedBy != "" {
+		return t.ClaimedBy
+	}
+	return ""
+}
+
+func truncate(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
+}

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -1,0 +1,243 @@
+package reporter
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+func openDB(t *testing.T) *coord.DB {
+	t.Helper()
+	db, err := coord.Open(filepath.Join(t.TempDir(), "coord.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// delegate creates work "a2" handed to "a1", then finishes it as a1.
+func delegate(t *testing.T, db *coord.DB, title, state, result string) *coord.Task {
+	t.Helper()
+	task, err := db.CreateTask(coord.NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: title})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	c, err := db.ClaimTask("a1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := db.FinishTask(c.ID, "a1", state, result, c.Attempts); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	return task
+}
+
+// collector stands in for Bot.Notify.
+type collector struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *collector) add(s string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, s)
+}
+
+func (c *collector) all() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.lines...)
+}
+
+func TestTickDeliversAFinishedHandOff(t *testing.T) {
+	db := openDB(t)
+	delegate(t, db, "crawl listings", coord.TaskCompleted, "62 jobs found")
+
+	var got collector
+	r := New(db, Config{AgentID: "a2"})
+	r.SetNotify(got.add)
+	r.Tick()
+
+	lines := got.all()
+	if len(lines) != 1 {
+		t.Fatalf("want one delivery, got %d: %v", len(lines), lines)
+	}
+	for _, want := range []string{"crawl listings", "62 jobs found", "a1", "completed"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("delivery missing %q:\n%s", want, lines[0])
+		}
+	}
+}
+
+// The marker is what stops a result being announced on every tick forever.
+func TestASecondTickSaysNothingNew(t *testing.T) {
+	db := openDB(t)
+	delegate(t, db, "crawl listings", coord.TaskCompleted, "62 jobs")
+
+	var got collector
+	r := New(db, Config{AgentID: "a2"})
+	r.SetNotify(got.add)
+	r.Tick()
+	r.Tick()
+	r.Tick()
+
+	if n := len(got.all()); n != 1 {
+		t.Errorf("reported %d times; the marker should make it exactly once", n)
+	}
+}
+
+// Two gateways open the same file and run the same query in the same tick. The
+// compare-and-set is the only thing standing between that and the user being
+// told twice — so it is worth testing with real concurrency rather than by
+// inspection.
+func TestTwoGatewaysDeliverOnce(t *testing.T) {
+	db := openDB(t)
+	const n = 12
+	for i := range n {
+		delegate(t, db, "job "+string(rune('a'+i)), coord.TaskCompleted, "ok")
+	}
+
+	var got collector
+	a := New(db, Config{AgentID: "a2"})
+	a.SetNotify(got.add)
+	b := New(db, Config{AgentID: "a2"})
+	b.SetNotify(got.add)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); a.Tick() }()
+	go func() { defer wg.Done(); b.Tick() }()
+	wg.Wait()
+
+	if len(got.all()) != n {
+		t.Errorf("delivered %d lines for %d tasks — a duplicate or a dropped report", len(got.all()), n)
+	}
+}
+
+// A gateway with no Telegram must not consume the report: nothing was
+// delivered, so the marker has to stay unset for a gateway that can deliver.
+func TestWithoutADeliveryPathTheReportIsNotConsumed(t *testing.T) {
+	db := openDB(t)
+	task := delegate(t, db, "crawl listings", coord.TaskCompleted, "62 jobs")
+
+	silent := New(db, Config{AgentID: "a2"}) // no SetNotify
+	silent.Tick()
+
+	var got collector
+	loud := New(db, Config{AgentID: "a2"})
+	loud.SetNotify(got.add)
+	loud.Tick()
+
+	if len(got.all()) != 1 {
+		t.Fatalf("a gateway that cannot deliver must leave the report for one that can; got %v", got.all())
+	}
+	after, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ReportedAt == "" {
+		t.Error("the delivering gateway should have marked it")
+	}
+}
+
+func TestStartDeliversAndStopsWithTheContext(t *testing.T) {
+	db := openDB(t)
+	delegate(t, db, "crawl listings", coord.TaskCompleted, "62 jobs")
+
+	var got collector
+	r := New(db, Config{AgentID: "a2", Tick: time.Hour}) // only the immediate tick fires
+	r.SetNotify(got.add)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for len(got.all()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	r.Wait()
+
+	if len(got.all()) != 1 {
+		t.Errorf("the first tick should be immediate, so a result waiting at startup is not held for a full interval; got %v", got.all())
+	}
+}
+
+// A nil Reporter is what a gateway without a coordination database has. Every
+// exported method has to tolerate it, because main.go calls them unconditionally.
+func TestNilReporterIsInert(t *testing.T) {
+	var r *Reporter
+	r.SetNotify(func(string) { t.Error("nil reporter must not deliver") })
+	r.Poke()
+	r.Start(context.Background())
+	r.Wait()
+	r.Tick()
+}
+
+func TestFormatSaysWhatHappenedFirst(t *testing.T) {
+	cases := []struct {
+		name  string
+		task  coord.Task
+		want  []string
+		avoid string
+	}{
+		{
+			name: "completed",
+			task: coord.Task{State: coord.TaskCompleted, Title: "crawl listings", Result: "62 jobs", ClaimedBy: "a1"},
+			want: []string{"✅", "crawl listings", "completed", "a1", "62 jobs"},
+		},
+		{
+			name: "failed carries the reason the system gave up",
+			task: coord.Task{State: coord.TaskFailed, Title: "broken", ClaimedBy: "a1", FailReason: coord.FailExhausted},
+			want: []string{"⛔", "failed", coord.FailExhausted},
+		},
+		{
+			name: "finished with nothing to say",
+			task: coord.Task{State: coord.TaskCompleted, Title: "quiet job", ClaimedBy: "a1"},
+			want: []string{"finished without a result"},
+		},
+		// Nobody ever claimed it, so there is no agent to name — and "· " with
+		// an empty name reads like a bug.
+		{
+			name:  "never claimed",
+			task:  coord.Task{State: coord.TaskRejected, Title: "nobody took it"},
+			want:  []string{"⚠️", "rejected"},
+			avoid: "· ",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Format(&c.task)
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("missing %q in:\n%s", w, got)
+				}
+			}
+			if c.avoid != "" && strings.Contains(got, c.avoid) {
+				t.Errorf("should not contain %q:\n%s", c.avoid, got)
+			}
+		})
+	}
+}
+
+// Telegram rejects a message over 4096 characters outright, so a long result
+// has to arrive trimmed rather than not at all.
+func TestFormatTrimsALongResult(t *testing.T) {
+	long := strings.Repeat("x", maxResultChars*2)
+	got := Format(&coord.Task{State: coord.TaskCompleted, Title: "big", Result: long, ClaimedBy: "a1"})
+
+	if len([]rune(got)) > maxResultChars+200 {
+		t.Errorf("delivery is %d runes; too close to Telegram's limit", len([]rune(got)))
+	}
+	if !strings.Contains(got, "…") {
+		t.Error("a trimmed result should say so")
+	}
+}


### PR DESCRIPTION
When agent 2 handed work to agent 1, the chain ended at agent 1's `task done`: FinishTask wrote state and result, printed a line, and nothing read either back. Three things had to be missing at once for that, and all three were. NotifyTaskCreated fires only on creation (three call sites, all `task new`-shaped). No query anywhere asked "what did I create that finished" — the runner polls for work claimable by *it*. And completion reached only the dashboard socket, because Bot.Notify had exactly one producer in the tree: the scheduler.

This is the missing half, and deliberately not new machinery: scheduler.settle already does this job for scheduled work — list what I delegated, ask whether it finished, win a compare-and-set so one gateway delivers, notify. The new internal/reporter is that shape, bound to tasks.created_by instead of schedule_runs.

Its own loop, not a branch of an existing one, and that is the load-bearing decision. taskrunner starts only when tasks.auto_claim is true and scheduler only when schedules.enabled is true — and a gateway delegates *because* it does not run the work itself, so it is exactly the gateway with both switched off. Both "disabled" lines appear on every start of the gateway this was built on. So the reporter starts wherever coord is open, the same condition that already mounts /api/tasks/poke "even when this agent does not claim tasks".

Four clauses decide what counts as delegated, each keeping out a class of task that would otherwise be noise or a duplicate:

  - claimed_by != created_by is the real test — whoever ran it was not me. Not assigned_to, which would let an unassigned task the requester happens to claim slip through and report work it watched itself do. A task that died before anyone claimed it still qualifies: a rejected hand-off is exactly the outcome worth hearing about.
  - schedule_id = '' leaves scheduled work to scheduler.settle, which already reports it. Matching it here would deliver every scheduled result twice.
  - parent_id = '' reports root tasks only; a sub-task is a detail of its parent's work.
  - reported_at = '' is the new marker, so a result is delivered once even though every gateway runs the same query against the same file.

The decisions that were open, resolved by following the scheduler: failures report too (a silent failure is the worst outcome, and FailReason is carried), no Quiet flag for now (the scheduler's lives on AgentPayload, which delegated tasks do not have), and a report never creates a task, so tasks.depth and the ping-pong guard are untouched.

One flaw the tests caught before it shipped: a gateway with no Telegram was claiming the report first and then logging it, so on a two-gateway machine the silent one could swallow a result the other could have delivered — the marker makes that silence permanent. Tick now returns early when there is no delivery path and leaves the queue alone.

Schema v5 adds one column with the same guarded ALTER as v3Columns, so an existing coord.db gains it on open; the migration test now asserts against the schemaVersion constant rather than a literal, and checks the column arrives.

Verified end to end on the live gateway: a task delegated to a peer, finished by that peer, delivered to Telegram once — `reporter: delivered completed` — and not repeated on subsequent ticks.