### PR TITLE
Fix task retries for missing Claude sessions and preserve CLI errors

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -5,11 +5,15 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
+
+// ErrSessionNotFound means the provider explicitly rejected a saved resume ID.
+var ErrSessionNotFound = errors.New("provider session not found")
 
 // StreamCallbacks lets the bot layer react to provider events as they arrive.
 type StreamCallbacks struct {

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -111,6 +112,7 @@ type streamEvent struct {
 	SessionID string      `json:"session_id,omitempty"`
 	Result    string      `json:"result,omitempty"`
 	IsError   bool        `json:"is_error,omitempty"`
+	Errors    []string    `json:"errors,omitempty"`
 	Usage     *cliUsage   `json:"usage,omitempty"`
 }
 
@@ -204,11 +206,26 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 		return fmt.Errorf("start claude: %w", err)
 	}
 
+	// Drain stderr concurrently; join it before examining diagnostics or returning.
+	waited := false
+	var stderrText bytes.Buffer
+	stderrDone := make(chan struct{})
+	defer func() {
+		_ = cmd.Process.Kill()
+		<-stderrDone
+		if !waited {
+			_ = cmd.Wait()
+		}
+	}()
 	// Drain stderr to logs.
 	go func() {
+		defer close(stderrDone)
 		s := bufio.NewScanner(stderr)
 		for s.Scan() {
 			log.Printf("claude stderr: %s", s.Text())
+			if stderrText.Len() < 64*1024 {
+				stderrText.WriteString(s.Text() + "\n")
+			}
 		}
 	}()
 
@@ -304,7 +321,10 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 					ev.Usage.CacheReadInputTokens + ev.Usage.CacheCreationInputTokens)
 			}
 			if ev.IsError {
-				return fmt.Errorf("claude error: %s", ev.Result)
+				// Error results are terminal. Kill/wait even if the CLI leaves pipes open.
+				_ = cmd.Process.Kill()
+				<-stderrDone
+				return cliError(sessionID, ev.Result, ev.Errors, stderrText.String())
 			}
 		}
 	}
@@ -313,7 +333,16 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	return cmd.Wait()
+	<-stderrDone
+	waitErr := cmd.Wait()
+	waited = true
+	if waitErr != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return cliError(sessionID, waitErr.Error(), nil, stderrText.String())
+	}
+	return nil
 }
 
 // fsGuardPrompt keeps the CLI's own file tools (Glob, Grep, Bash find …)
@@ -399,4 +428,29 @@ func formatInput(raw json.RawMessage) string {
 	}
 	b, _ := json.MarshalIndent(pretty, "", "  ")
 	return string(b)
+}
+
+// Only the exact requested resume ID can invalidate a session. Generic API,
+// authentication and network failures must retain the conversation.
+func cliError(resumeID, result string, details []string, stderr string) error {
+	parts := []string{}
+	for _, part := range append(append([]string{result}, details...), stderr) {
+		if part = strings.TrimSpace(part); part != "" {
+			parts = append(parts, part)
+		}
+	}
+	message := strings.Join(parts, "; ")
+	if message == "" {
+		message = "CLI returned an error without diagnostics"
+	}
+	if resumeID != "" {
+		for _, part := range parts {
+			for _, line := range strings.Split(part, "\n") {
+				if strings.TrimSpace(line) == "No conversation found with session ID: "+resumeID {
+					return fmt.Errorf("%w: %s", chat.ErrSessionNotFound, message)
+				}
+			}
+		}
+	}
+	return fmt.Errorf("claude error: %s", message)
 }

--- a/internal/claude/errors_test.go
+++ b/internal/claude/errors_test.go
@@ -1,0 +1,76 @@
+package claude
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+func TestCLIErrorClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name, id, result, stderr string
+		details                  []string
+		missing                  bool
+	}{
+		{name: "stderr", id: "gone", stderr: "No conversation found with session ID: gone\n", missing: true},
+		{name: "errors array", id: "gone", details: []string{"No conversation found with session ID: gone"}, missing: true},
+		{name: "wrong session", id: "kept", stderr: "No conversation found with session ID: gone"},
+		{name: "new session", stderr: "No conversation found with session ID: gone"},
+		{name: "rate limit", id: "kept", details: []string{"Rate limit exceeded"}},
+		{name: "empty diagnostics"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cliError(tc.id, tc.result, tc.details, tc.stderr)
+			if errors.Is(err, chat.ErrSessionNotFound) != tc.missing {
+				t.Fatalf("wrong classification: %v", err)
+			}
+			if err.Error() == "claude error: " {
+				t.Fatal("empty diagnostic")
+			}
+		})
+	}
+}
+
+func TestSendMessagePreservesTerminalErrorAndReapsCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires POSIX")
+	}
+	for _, resultEvent := range []bool{true, false} {
+		t.Run(map[bool]string{true: "result event", false: "exit only"}[resultEvent], func(t *testing.T) {
+			dir := t.TempDir()
+			script := "#!/bin/sh\necho 'No conversation found with session ID: gone' >&2\n"
+			if resultEvent {
+				script += "echo '{\"type\":\"result\",\"is_error\":true,\"errors\":[\"resume failed\"]}'\nexec sleep 60\n"
+			} else {
+				script += "exit 1\n"
+			}
+			if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			sess := session.New(1)
+			sess.SetSessionID("gone")
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			err := New("", nil).SendMessage(ctx, sess, "test", "test", "", chat.StreamCallbacks{})
+			if !errors.Is(err, chat.ErrSessionNotFound) {
+				t.Fatalf("error = %v", err)
+			}
+			if resultEvent && !strings.Contains(err.Error(), "resume failed") {
+				t.Fatalf("lost errors array: %v", err)
+			}
+			if ctx.Err() != nil {
+				t.Fatal("terminal error did not stop child promptly")
+			}
+		})
+	}
+}

--- a/internal/coord/taskruns.go
+++ b/internal/coord/taskruns.go
@@ -43,12 +43,13 @@ type TaskRun struct {
 
 // RunOutcome is what the runner reports when a run ends.
 type RunOutcome struct {
-	Liveness   string
-	Result     string     // the deliverable (completed) or the partial reply
-	Checkpoint string     // progress note written this run, if any
-	SessionRef SessionRef // the CLI session this run used; recorded for --resume
-	BlockedOn  string     // for RunBlocked: children | human
-	Note       string     // short human-readable reason (error text, cap hit…)
+	Liveness     string
+	Result       string     // the deliverable (completed) or the partial reply
+	Checkpoint   string     // progress note written this run, if any
+	ResetSession bool       // discard an explicitly rejected resume ID, preserving account
+	SessionRef   SessionRef // the CLI session this run used; recorded for --resume
+	BlockedOn    string     // for RunBlocked: children | human
+	Note         string     // short human-readable reason (error text, cap hit…)
 }
 
 // ErrTaskFinished means the task reached a terminal state (canceled by a
@@ -171,7 +172,7 @@ func (db *DB) FinishRun(runID string, o RunOutcome) (*Task, error) {
 	if o.Checkpoint != "" {
 		t.Checkpoint = o.Checkpoint
 	}
-	if o.SessionRef.SessionID != "" {
+	if o.ResetSession || o.SessionRef.SessionID != "" {
 		t.SessionRef = o.SessionRef.String()
 	}
 

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -122,9 +122,10 @@ func ParseSessionRef(raw string) SessionRef {
 	return r
 }
 
-// String encodes the ref for storage.
+// String encodes the ref for storage. An account-only ref keeps the credential
+// pin when a missing conversation must be replaced on the next attempt.
 func (r SessionRef) String() string {
-	if r.SessionID == "" {
+	if r.SessionID == "" && r.Account == "" {
 		return ""
 	}
 	b, _ := json.Marshal(r)

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -252,7 +252,7 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	sess := session.New(taskChatID)
 	sess.ID = "task_" + task.ID
 	resumed := false
-	if ref := coord.ParseSessionRef(task.SessionRef); ref.SessionID != "" {
+	if ref := coord.ParseSessionRef(task.SessionRef); ref.Provider != "" {
 		// Only the same CLI can resume its own session; a ref from the other
 		// backend (after a provider switch) is simply not used.
 		if ref.Provider == r.llm.Name() {
@@ -261,7 +261,7 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 			if ref.Account != "" {
 				sess.SetAccount(ref.Account) // the credential pool honours the pin
 			}
-			resumed = true
+			resumed = ref.SessionID != ""
 		}
 	}
 
@@ -328,6 +328,11 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	outcome := classify(task, after, sendErr, runCtx.Err(), reply.String(), todoPending)
 	outcome.SessionRef = coord.SessionRef{
 		Provider: r.llm.Name(), SessionID: sess.GetSessionID(), Account: sess.GetAccount(),
+	}
+
+	if errors.Is(sendErr, chat.ErrSessionNotFound) {
+		outcome.ResetSession = true
+		outcome.SessionRef.SessionID = ""
 	}
 
 	var spanErr error

--- a/internal/taskrunner/runner_test.go
+++ b/internal/taskrunner/runner_test.go
@@ -526,3 +526,49 @@ func TestHasPendingTodos(t *testing.T) {
 		t.Error("garbage must not read as pending")
 	}
 }
+
+func TestMissingSessionRetriesFreshWithCheckpointAndAccount(t *testing.T) {
+	db := testDB(t)
+	created, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "Audit games", Body: "Inspect all ten repositories"})
+	llm := &stubLLM{err: errors.New("temporary API failure")}
+	llm.hook = func(_ context.Context, s *session.Session, _ chat.StreamCallbacks) {
+		s.SetAccount("account-one")
+		tk, _ := db.GetTask(created.ID)
+		if err := db.SetCheckpoint(created.ID, "a2", tk.Attempts, "games 1-3 inspected"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := newRunner(db, llm)
+	r.claimAndRun(context.Background())
+	task, _ := db.GetTask(created.ID)
+	if coord.ParseSessionRef(task.SessionRef).SessionID != "stub-session" {
+		t.Fatal("generic error discarded session")
+	}
+	llm.hook = nil
+	llm.err = chat.ErrSessionNotFound
+	r.claimAndRun(context.Background())
+	task, _ = db.GetTask(created.ID)
+	ref := coord.ParseSessionRef(task.SessionRef)
+	if ref.SessionID != "" || ref.Account != "account-one" {
+		t.Fatalf("bad recovery ref: %+v", ref)
+	}
+	if task.Checkpoint != "games 1-3 inspected" {
+		t.Fatalf("lost checkpoint: %q", task.Checkpoint)
+	}
+	llm.err = nil
+	llm.reply = "Completed audit."
+	llm.hook = func(_ context.Context, s *session.Session, _ chat.StreamCallbacks) {
+		if s.GetAccount() != "account-one" {
+			t.Fatalf("lost account pin: %s", s.GetAccount())
+		}
+	}
+	r.claimAndRun(context.Background())
+	ids := llm.seenSessions()
+	if len(ids) != 3 || ids[1] != "stub-session" || ids[2] != "" {
+		t.Fatalf("sessions: %v", ids)
+	}
+	prompts := llm.seen()
+	if !strings.Contains(prompts[2], "games 1-3 inspected") || !strings.Contains(prompts[2], "Inspect all ten repositories") || strings.Contains(prompts[2], "has been resumed") {
+		t.Fatalf("bad recovery prompt: %s", prompts[2])
+	}
+}


### PR DESCRIPTION
A task whose Claude conversation no longer exists repeatedly retries the same `--resume` ID until its attempt budget is exhausted. The dashboard shows only `claude error:` because the provider ignores the CLI's `errors` array and stderr diagnostics.

This change preserves those diagnostics and recognizes an explicit missing-conversation error for the exact requested session. The task runner clears that resume ID when recording the failed run, so the next permitted attempt starts fresh with the task body, checkpoint and original credential account. Generic API/authentication errors retain the existing session. Retry budgets are unchanged; an already-exhausted task still requires resume.

The Claude subprocess is also stopped and reaped on terminal error/scan-error paths, and stderr is joined before inspection. No live deployment or database migration is included.

Validation:
- `go test ./...`
- `go test -race ./internal/claude ./internal/taskrunner ./internal/coord`
- Regression coverage: missing session in stderr or structured errors; empty diagnostics; unrelated errors and wrong IDs; real fake-CLI subprocess termination; persisted task recovery retaining checkpoint/account and starting the next attempt without the stale resume ID.
