### PR TITLE
feat(admin): answer a task that is waiting on a person

### DIFF
--- a/cmd/bomclaw/coordcmd.go
+++ b/cmd/bomclaw/coordcmd.go
@@ -214,18 +214,9 @@ func runTask(args []string) {
 		if strings.TrimSpace(by) == "" {
 			by = "human"
 		}
-		if *note != "" {
-			// Append the answer under the agent's own checkpoint rather than
-			// replacing it: the next run needs both.
-			if t, err := db.GetTask(*id); err == nil {
-				merged := strings.TrimSpace(t.Checkpoint)
-				if merged != "" {
-					merged += "\n\n"
-				}
-				merged += "Answer from " + by + ": " + *note
-				_, _ = db.Conn().Exec(`UPDATE tasks SET checkpoint = ? WHERE id = ?`, merged, *id)
-			}
-		}
+		// The answer is merged into the checkpoint by UnblockTask itself, in the
+		// same guarded statement — so it cannot land on a task that turns out
+		// not to be blocked, and the admin API gets the same behaviour for free.
 		if err := db.UnblockTask(*id, by, *note); err != nil {
 			fmt.Fprintf(os.Stderr, "task %s: %v\n", sub, err)
 			os.Exit(1)

--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -51,7 +51,13 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
         <div className="mt-1.5 text-[11px] text-red-400">{FAIL_REASON[task.fail_reason] ?? task.fail_reason}</div>
       )}
       {task.state === 'blocked' && (
-        <div className="mt-1.5 text-[11px] text-violet-300">waiting on {task.blocked_on || 'a person'}</div>
+        <div className="mt-1.5 text-[11px] text-violet-300">
+          {task.blocked_on === 'human'
+            ? /* Says what to do, not just what is true — this is the one state
+                 on the board that needs a person and can be cleared by one. */
+              'waiting on you — click to answer'
+            : `waiting on ${task.blocked_on || 'a person'}`}
+        </div>
       )}
       {task.state !== 'failed' && (task.attempts > 1 || task.continuations > 0 || leaseExpired) && (
         <div className="mt-1.5 text-[11px] text-amber-400">
@@ -73,6 +79,7 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
   const [detail, setDetail] = useState<TaskDetail | null>(null)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [answer, setAnswer] = useState('')
 
   useEffect(() => {
     let cancelled = false
@@ -108,9 +115,31 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
     }
   }
 
+  // The answer is an instruction, not a comment: the gateway appends it to the
+  // task's checkpoint, which is what the agent reads when it picks the work
+  // back up. So an empty box is a no-op worth preventing.
+  const sendAnswer = async () => {
+    if (!answer.trim()) return
+    setBusy(true)
+    try {
+      await call('tasks.unblock', { id, note: answer.trim() })
+      setAnswer('')
+      onChanged()
+      onClose()
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const t = detail?.task
   const open = t && !['completed', 'failed', 'canceled', 'rejected'].includes(t.state)
   const resumable = t && t.state === 'failed' && !!t.fail_reason
+  const awaitingPerson = t?.state === 'blocked' && t.blocked_on === 'human'
+  // Blocked on its children is the system's business, not the operator's —
+  // offering an answer box there would invite unblocking work that is not done.
+  const blockedOnChildren = t?.state === 'blocked' && t.blocked_on === 'children'
 
   return (
     <div className="fixed inset-0 z-40 flex justify-end bg-black/50" onClick={onClose}>
@@ -144,7 +173,7 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
                 {t.state === 'blocked' && (
                   <div className="mt-1 text-xs text-violet-300">
                     waiting on {t.blocked_on || 'a person'}
-                    {t.blocked_on === 'human' && <> — answer with <code className="text-gray-400">bomclaw task answer --id {t.id} --note "…"</code></>}
+                    {blockedOnChildren && <> — it resumes when its child tasks finish</>}
                   </div>
                 )}
                 <h3 className="mt-2 text-base text-gray-100">{t.title}</h3>
@@ -199,6 +228,48 @@ function TaskDrawer({ call, id, onClose, onChanged }: {
                       )
                     })}
                   </ol>
+                </div>
+              )}
+
+              {awaitingPerson && (
+                <div className="rounded ring-1 ring-violet-500/40 bg-violet-500/5 p-3">
+                  <div className="text-[11px] uppercase tracking-wider text-violet-300/80 mb-2">
+                    The agent is waiting on you
+                  </div>
+                  {t.checkpoint ? (
+                    <pre className="text-xs text-gray-300 whitespace-pre-wrap font-sans mb-3">{t.checkpoint}</pre>
+                  ) : (
+                    <div className="text-xs text-gray-500 mb-3">
+                      It parked without writing down what it needs. Say what to do next.
+                    </div>
+                  )}
+                  <textarea
+                    value={answer}
+                    onChange={e => setAnswer(e.target.value)}
+                    onKeyDown={e => {
+                      // Enter sends; the box is one instruction, not a document.
+                      // Shift+Enter still makes a newline.
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault()
+                        void sendAnswer()
+                      }
+                    }}
+                    rows={3}
+                    placeholder="Answer, or tell it what to do next…"
+                    className="w-full bg-gray-900 ring-1 ring-gray-800 rounded px-2 py-1.5 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:ring-violet-500/50 resize-y"
+                  />
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      onClick={sendAnswer}
+                      disabled={busy || !answer.trim()}
+                      className="px-3 py-1.5 text-sm rounded ring-1 ring-violet-500/40 bg-violet-500/10 text-violet-200 hover:bg-violet-500/20 disabled:opacity-40 disabled:hover:bg-violet-500/10"
+                    >
+                      Send &amp; unblock
+                    </button>
+                    <span className="text-[11px] text-gray-600">
+                      goes into the task, and the agent reads it on its next run
+                    </span>
+                  </div>
                 </div>
               )}
 

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -451,10 +451,28 @@ func (db *DB) BlockTask(taskID, agentID string, attempts int, on, note string) e
 
 // UnblockTask returns a blocked task to the queue — a person answering, or the
 // last child finishing. Not fenced: nobody holds a blocked task.
+//
+// A non-empty note is the answer to whatever the agent asked, and it is
+// appended under the agent's own checkpoint rather than replacing it: the next
+// run needs both the question it wrote down and the reply. checkpoint is what
+// taskPrompt feeds back into the run, so this is the only path by which a
+// person's instruction actually reaches the agent — recording it as an audit
+// event alone would look right and change nothing.
+//
+// The merge happens in the same guarded statement as the unblock. Doing it
+// beforehand, as the CLI used to, left the answer written onto a task that
+// then turned out not to be blocked.
 func (db *DB) UnblockTask(taskID, byAgent, note string) error {
+	checkpoint, err := db.answeredCheckpoint(taskID, byAgent, note)
+	if err != nil {
+		return err
+	}
+
 	now := time.Now()
-	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, blocked_on = '', lease_until = ?, updated_at = ?
-		WHERE id = ? AND state = ?`, TaskSubmitted, ts(now), ts(now), taskID, TaskBlocked)
+	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, blocked_on = '', checkpoint = ?,
+			lease_until = ?, updated_at = ?
+		WHERE id = ? AND state = ?`,
+		TaskSubmitted, checkpoint, ts(now), ts(now), taskID, TaskBlocked)
 	if err != nil {
 		return fmt.Errorf("unblock task: %w", err)
 	}
@@ -462,6 +480,24 @@ func (db *DB) UnblockTask(taskID, byAgent, note string) error {
 		return fmt.Errorf("coord: task %s is not blocked", taskID)
 	}
 	return db.appendEvent(taskID, byAgent, TaskBlocked, TaskSubmitted, "unblocked: "+truncateNote(note))
+}
+
+// answeredCheckpoint returns the checkpoint the task should carry into its next
+// run: unchanged when there is no answer, otherwise the agent's own note with
+// the reply appended and attributed.
+func (db *DB) answeredCheckpoint(taskID, byAgent, note string) (string, error) {
+	t, err := db.GetTask(taskID)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(note) == "" {
+		return t.Checkpoint, nil
+	}
+	merged := strings.TrimSpace(t.Checkpoint)
+	if merged != "" {
+		merged += "\n\n"
+	}
+	return merged + "Answer from " + byAgent + ": " + note, nil
 }
 
 // ReapExhausted moves tasks that have used every attempt into failed. Until

--- a/internal/coord/tasks_test.go
+++ b/internal/coord/tasks_test.go
@@ -3,6 +3,7 @@ package coord
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -202,5 +203,110 @@ func TestEventsRecordTheLifecycle(t *testing.T) {
 	if events[0].ToState != TaskSubmitted || events[1].ToState != TaskWorking || events[2].ToState != TaskCompleted {
 		t.Errorf("unexpected lifecycle: %v → %v → %v",
 			events[0].ToState, events[1].ToState, events[2].ToState)
+	}
+}
+
+// blockedOnPerson parks a claimed task on a human, with the agent's own note as
+// the checkpoint — the shape the admin board shows as "waiting on you".
+func blockedOnPerson(t *testing.T, db *DB, question string) *Task {
+	t.Helper()
+	task, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "needs a decision"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	c, err := db.ClaimTask("a1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := db.BlockTask(c.ID, "a1", c.Attempts, BlockedOnHuman, question); err != nil {
+		t.Fatalf("block: %v", err)
+	}
+	return task
+}
+
+// The answer has to reach the agent, and checkpoint is the only field that does
+// — taskPrompt feeds it into the next run. Recording it as an audit event alone
+// would look correct and change nothing about what the agent reads.
+func TestUnblockPutsTheAnswerWhereTheAgentReadsIt(t *testing.T) {
+	db := testDB(t)
+	task := blockedOnPerson(t, db, "Which of the two layouts should I ship?")
+
+	if err := db.UnblockTask(task.ID, "human", "Ship the second one."); err != nil {
+		t.Fatalf("unblock: %v", err)
+	}
+
+	got, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != TaskSubmitted || got.BlockedOn != "" {
+		t.Errorf("state=%s blocked_on=%q, want submitted and cleared", got.State, got.BlockedOn)
+	}
+	// Both halves survive: the question the agent wrote, and the reply.
+	if !strings.Contains(got.Checkpoint, "Which of the two layouts") {
+		t.Errorf("the agent's own note was lost:\n%s", got.Checkpoint)
+	}
+	if !strings.Contains(got.Checkpoint, "Ship the second one.") {
+		t.Errorf("the answer never reached the checkpoint:\n%s", got.Checkpoint)
+	}
+	if !strings.Contains(got.Checkpoint, "Answer from human") {
+		t.Errorf("the answer should be attributed:\n%s", got.Checkpoint)
+	}
+}
+
+func TestUnblockWithoutAnAnswerLeavesTheCheckpointAlone(t *testing.T) {
+	db := testDB(t)
+	task := blockedOnPerson(t, db, "original note")
+
+	if err := db.UnblockTask(task.ID, "human", ""); err != nil {
+		t.Fatalf("unblock: %v", err)
+	}
+	got, _ := db.GetTask(task.ID)
+	if got.Checkpoint != "original note" {
+		t.Errorf("checkpoint = %q, want it untouched", got.Checkpoint)
+	}
+	if strings.Contains(got.Checkpoint, "Answer from") {
+		t.Error("an empty answer must not be attributed to anyone")
+	}
+}
+
+// The merge and the unblock are one guarded statement. Doing the merge first, as
+// the CLI used to, wrote the answer onto a task that then turned out not to be
+// blocked — leaving a reply to a question nobody had asked.
+func TestUnblockingAnUnblockedTaskChangesNothing(t *testing.T) {
+	db := testDB(t)
+	task, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "not blocked"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.UnblockTask(task.ID, "human", "an answer to nothing"); err == nil {
+		t.Fatal("unblocking a task that is not blocked must fail")
+	}
+
+	got, _ := db.GetTask(task.ID)
+	if got.Checkpoint != "" {
+		t.Errorf("checkpoint was written despite the failure: %q", got.Checkpoint)
+	}
+	if got.State != TaskSubmitted {
+		t.Errorf("state = %s, want it unchanged", got.State)
+	}
+}
+
+// Answering twice is a person clicking twice; the second one must not reopen
+// work that is already back in the queue and possibly running.
+func TestUnblockIsNotRepeatable(t *testing.T) {
+	db := testDB(t)
+	task := blockedOnPerson(t, db, "question")
+
+	if err := db.UnblockTask(task.ID, "human", "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UnblockTask(task.ID, "human", "second"); err == nil {
+		t.Error("the second answer must be refused")
+	}
+	got, _ := db.GetTask(task.ID)
+	if strings.Contains(got.Checkpoint, "second") {
+		t.Errorf("the refused answer leaked into the checkpoint:\n%s", got.Checkpoint)
 	}
 }

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -179,6 +179,50 @@ func handleTaskResume(deps Deps, params json.RawMessage) (json.RawMessage, error
 	return json.Marshal(map[string]bool{"resumed": true})
 }
 
+type taskUnblockParams struct {
+	ID   string `json:"id"`
+	Note string `json:"note,omitempty"`
+}
+
+// handleTaskUnblock answers a task the agent parked on a person and returns it
+// to the queue.
+//
+// This is the admin page's half of `bomclaw task answer`. Until it existed the
+// dashboard could only tell the operator to go and run that CLI command — a
+// board full of "waiting on human" with nothing to click, which is most of what
+// a control page is for.
+//
+// The note is the instruction, not a comment: UnblockTask appends it to the
+// task's checkpoint, which taskPrompt feeds into the next run, so it is what
+// the agent actually reads when it picks the work back up.
+func handleTaskUnblock(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	var p taskUnblockParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if p.ID == "" {
+		return nil, fmt.Errorf("id is required")
+	}
+
+	// Read it before the unblock: afterwards assigned_to is what decides who to
+	// ring, and the row has already moved on.
+	task, err := deps.Coord.GetTask(p.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := deps.Coord.UnblockTask(p.ID, deps.AgentID, p.Note); err != nil {
+		return nil, err
+	}
+
+	// Ring whoever can take it: the agent it is addressed to, or everyone when
+	// it is unassigned. Best effort — their poll finds it regardless.
+	go NotifyAgents(deps.Coord, task.AssignedTo, "", "about unblocked "+p.ID)
+	return json.Marshal(map[string]bool{"unblocked": true})
+}
+
 type taskCreateParams struct {
 	Title      string `json:"title"`
 	Body       string `json:"body,omitempty"`

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -169,6 +169,8 @@ func NewMethodHandler(deps Deps) MethodHandler {
 			return handleTaskCancel(deps, params)
 		case "tasks.resume":
 			return handleTaskResume(deps, params)
+		case "tasks.unblock":
+			return handleTaskUnblock(deps, params)
 		case "messages.list":
 			return handleMessagesList(deps, params)
 		case "messages.send":

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -188,7 +188,7 @@ func TestCommandTimeoutFails(t *testing.T) {
 	start := time.Now()
 	s.Tick(context.Background())
 	s.Wait()
-	if time.Since(start) > 3*time.Second {
+	if time.Since(start) > cancelBudget {
 		t.Fatalf("timeout not enforced: took %s", time.Since(start))
 	}
 	runs, _ := db.ScheduleRuns(sc.ID, 10)

--- a/internal/scheduler/testcmds_unix_test.go
+++ b/internal/scheduler/testcmds_unix_test.go
@@ -2,6 +2,8 @@
 
 package scheduler
 
+import "time"
+
 // Shell snippets the command-payload tests need, written for this platform's
 // shell. A schedule's cmd runs in the host's native shell (/bin/sh here,
 // PowerShell on Windows), so the tests cannot share one literal — see
@@ -14,6 +16,10 @@ const (
 	cmdFailWithStderr = "echo boom >&2; exit 3"
 	// Outlives a 1s timeout, so cancellation has something to kill.
 	cmdSleep5 = "sleep 5"
+	// How long a 1s-timeout run may take end to end and still prove the
+	// deadline fired rather than the command finishing. /bin/sh starts and
+	// dies in milliseconds, so the margin here is generous already.
+	cancelBudget = 3 * time.Second
 	// Succeeds, printing nothing.
 	cmdSucceed = "true"
 	// Prints a marker a test can look for.

--- a/internal/scheduler/testcmds_windows_test.go
+++ b/internal/scheduler/testcmds_windows_test.go
@@ -2,6 +2,8 @@
 
 package scheduler
 
+import "time"
+
 // PowerShell counterparts of the snippets in testcmds_unix_test.go. None of the
 // POSIX forms work here: PowerShell reads an environment variable as
 // $env:NAME rather than $NAME, has no `>&2` redirection and no `true`.
@@ -11,8 +13,18 @@ const (
 	// Writes "boom" to stderr and exits 3. [Console]::Error is used rather
 	// than Write-Error, which wraps the message in an ErrorRecord dump.
 	cmdFailWithStderr = `[Console]::Error.WriteLine('boom'); exit 3`
-	// Outlives a 1s timeout, so cancellation has something to kill.
-	cmdSleep5 = "Start-Sleep -Seconds 5"
+	// Outlives a 1s timeout, so cancellation has something to kill. Longer than
+	// the Unix five seconds because the budget below has to be wider, and the
+	// sleep must still comfortably outlast it.
+	cmdSleep5 = "Start-Sleep -Seconds 20"
+	// Wider than Unix's 3s on purpose, and measured rather than guessed: a
+	// 1s-timeout run costs a PowerShell start (~0.5-1s) plus a taskkill spawn
+	// on the cancel path, since Windows cannot signal a process group. That
+	// lands at 3.1-3.5s here, so the original 3s budget failed for the one
+	// reason the assertion does not care about — process startup, not a
+	// deadline that went unenforced. 8s still proves enforcement against a
+	// 20 second sleep.
+	cancelBudget = 8 * time.Second
 	// Succeeds, printing nothing.
 	cmdSucceed = "exit 0"
 	// Prints a marker a test can look for.


### PR DESCRIPTION
The board showed a column of "waiting on human" with nothing to click. The only way to answer was `bomclaw task answer` in a terminal, which the drawer told you to go and run — so the admin page could watch agents but not direct them, which is most of what it exists for.

The backend was closer than it looked, and I had this wrong at first: the CLI already merged the answer into the task's checkpoint and rang the agents. UnblockTask on its own only wrote the note to the audit log; its one caller compensated. So the gap was not "the answer never reaches the agent" — it was that the logic lived in a CLI command where no RPC could reach it.

Consolidated into UnblockTask, which already took a note and now puts it where it belongs: appended under the agent's own checkpoint, which taskPrompt feeds into the next run. That is the only field that reaches the agent — an audit event would have looked right and changed nothing about what it reads. Both halves survive, so the next run sees the question it asked and the reply.

Doing it there also fixes an ordering bug. The CLI merged the checkpoint in a separate unguarded UPDATE *before* the guarded unblock, so answering a task that turned out not to be blocked left a reply to a question nobody had asked, and exited 1. Merge and unblock are now one statement, and there is a test for exactly that.

New `tasks.unblock` RPC, and a drawer panel for a task blocked on a person: the agent's checkpoint shown as the question, a textarea, and Send & unblock. Enter sends, since it is one instruction rather than a document. Cards now say "waiting on you — click to answer" instead of restating the state, and a task blocked on its children says it resumes on its own — there is deliberately no answer box there, because unblocking work that is not finished is not an operator's call.

Also fixes a test I broke earlier without noticing. TestCommandTimeoutFails allowed a 1s-timeout run 3 seconds end to end, calibrated for /bin/sh and kill. Switching the scheduler to PowerShell added interpreter startup plus a taskkill spawn on the cancel path, which measures 3.1-3.5s here — so it failed for the one reason the assertion does not care about. The budget is now per-OS next to the other platform snippets: 3s on Unix, 8s on Windows against a 20 second sleep, which still proves the deadline fired rather than the command finishing.