### PR TITLE
fix(coord): stop stranding tasks that are making progress

### DIFF
--- a/internal/coord/taskruns.go
+++ b/internal/coord/taskruns.go
@@ -187,6 +187,24 @@ func (db *DB) FinishRun(runID string, o RunOutcome) (*Task, error) {
 			event(TaskWorking, TaskFailed, fmt.Sprintf("continuations exhausted after %d runs; last checkpoint kept", t.Continuations))
 			return nil
 		}
+		// Give the attempt back. ClaimTask increments attempts on every claim,
+		// but the two counters mean different things — §5.3: "attempts là lỗi,
+		// continuation là chưa xong" — and none of the runs that land here
+		// failed: they advanced, planned, came back empty, or hit the time cap
+		// with progress recorded.
+		//
+		// Without the refund a task making steady progress spent one of its
+		// three attempts per continuation, so MaxContinuations (20, ~5 hours of
+		// work) was unreachable and the fourth continuation requeued a task
+		// with attempts == max_attempts. That state is a dead end: ClaimTask
+		// needs attempts < max_attempts, so it is never claimed again, and
+		// nothing else moved it either. RunCanceled already refunds for the
+		// same reason, and this shares its one caveat — attempts doubles as the
+		// fencing token, so a stale holder's write can match a later claim.
+		// Bounded either way: continuations cap this path, empties cap theirs.
+		if t.Attempts > 0 {
+			t.Attempts--
+		}
 		t.State, t.AssignedTo, t.LeaseUntil = TaskSubmitted, run.AgentID, now
 		event(TaskWorking, TaskSubmitted, reason)
 		return nil

--- a/internal/coord/taskruns_test.go
+++ b/internal/coord/taskruns_test.go
@@ -76,7 +76,12 @@ func TestAdvancedRunRequeuesWithContextAndAffinity(t *testing.T) {
 	if task.AssignedTo != "a1" {
 		t.Errorf("assigned_to = %q, want a1: the session lives in a1's config dir", task.AssignedTo)
 	}
-	if task.Continuations != 1 || task.Attempts != 1 {
+	// attempts back to 0: ClaimTask charged one, and FinishRun refunds it
+	// because the run advanced. This assertion used to expect 1 while its own
+	// message said otherwise — and the 1 is what stranded tasks in production,
+	// since three continuations exhausted the attempt budget and ClaimTask
+	// needs attempts < max_attempts.
+	if task.Continuations != 1 || task.Attempts != 0 {
 		t.Errorf("continuations=%d attempts=%d; progress must count as a continuation, not a failed attempt", task.Continuations, task.Attempts)
 	}
 	if task.Checkpoint != "sources 1-3 summarised" {
@@ -94,8 +99,10 @@ func TestAdvancedRunRequeuesWithContextAndAffinity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a1 could not continue its own task: %v", err)
 	}
-	if again.Attempts != 2 {
-		t.Errorf("second claim attempts = %d, want 2", again.Attempts)
+	// 1, not 2: the first attempt was refunded when the run advanced, so a
+	// continuation costs nothing from the failure budget.
+	if again.Attempts != 1 {
+		t.Errorf("second claim attempts = %d, want 1 — a continuation must not accumulate attempts", again.Attempts)
 	}
 }
 

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -506,13 +506,37 @@ func (db *DB) answeredCheckpoint(taskID, byAgent, note string) (string, error) {
 // filters on attempts), yet counted as open and shown as "will be reclaimed".
 // Returns the ids it failed.
 func (db *DB) ReapExhausted() ([]string, error) {
+	// A working task whose lease ran out with its attempts spent: the holder
+	// died and nobody may retry it.
+	ids, err := db.reapExhaustedIn(TaskWorking,
+		"exhausted: every attempt ended without a result")
+	if err != nil {
+		return ids, err
+	}
+
+	// A submitted task with its attempts spent is not waiting, it is stranded.
+	// ClaimTask requires attempts < max_attempts, so nothing will ever pick it
+	// up; and while this sweep ignored it, no other path moved it either —
+	// RelaxDeadAssignments only lifts the agent pin, and ResumeTask accepts a
+	// failed task only. One such row held eight more tasks blocked behind it.
+	//
+	// Failing it is what makes it recoverable: `task resume` grants more
+	// attempts to a failed task, so this hands a stuck queue back to a person
+	// instead of leaving it invisible.
+	stranded, err := db.reapExhaustedIn(TaskSubmitted,
+		"stranded: requeued with no attempts left; nothing could claim it")
+	return append(ids, stranded...), err
+}
+
+// reapExhaustedIn fails the tasks in one state whose attempts are spent.
+func (db *DB) reapExhaustedIn(state, note string) ([]string, error) {
 	now := ts(time.Now())
 	rows, err := db.conn.Query(`UPDATE tasks SET state = ?, fail_reason = ?, updated_at = ?
 		WHERE state = ? AND lease_until <= ? AND attempts >= max_attempts
 		RETURNING id`,
-		TaskFailed, FailExhausted, now, TaskWorking, now)
+		TaskFailed, FailExhausted, now, state, now)
 	if err != nil {
-		return nil, fmt.Errorf("reap exhausted: %w", err)
+		return nil, fmt.Errorf("reap exhausted (%s): %w", state, err)
 	}
 	defer rows.Close()
 	var ids []string
@@ -523,9 +547,11 @@ func (db *DB) ReapExhausted() ([]string, error) {
 		}
 		ids = append(ids, id)
 	}
+	if err := rows.Err(); err != nil {
+		return ids, err
+	}
 	for _, id := range ids {
-		_ = db.appendEvent(id, "system", TaskWorking, TaskFailed,
-			"exhausted: every attempt ended without a result")
+		_ = db.appendEvent(id, "system", state, TaskFailed, note)
 	}
 	return ids, rows.Err()
 }
@@ -572,9 +598,17 @@ func (db *DB) ResumeTask(taskID, byAgent string, more int) error {
 	if err != nil {
 		return err
 	}
-	if t.State != TaskFailed {
-		return fmt.Errorf("coord: task %s is %s, only a failed task can be resumed", taskID, t.State)
+	// A submitted task with its attempts spent is accepted too. It is
+	// unclaimable — ClaimTask needs attempts < max_attempts — so it is stuck in
+	// exactly the way resume exists to fix, and refusing it sent people to a
+	// command that could not help either. ReapExhausted now fails such a row on
+	// its next sweep, but a person should not have to wait for one.
+	stranded := t.State == TaskSubmitted && t.Attempts >= t.MaxAttempts
+	if t.State != TaskFailed && !stranded {
+		return fmt.Errorf("coord: task %s is %s with %d/%d attempts — resume takes a failed task, "+
+			"or a submitted one that has run out of attempts", taskID, t.State, t.Attempts, t.MaxAttempts)
 	}
+	fromState := t.State
 	set := "max_attempts = max_attempts + ?"
 	switch t.FailReason {
 	case FailContinuationsExhausted:
@@ -584,12 +618,18 @@ func (db *DB) ResumeTask(taskID, byAgent string, more int) error {
 		// counter start over from this point.
 		set = "max_continuations = max_continuations + ?"
 	}
-	_, err = db.conn.Exec(`UPDATE tasks SET state = ?, fail_reason = '', lease_until = ?, updated_at = ?, `+set+`
-		WHERE id = ?`, TaskSubmitted, ts(time.Now()), ts(time.Now()), more, taskID)
+	// Guarded on the state we read, so two operators clicking Resume grant the
+	// allowance once rather than twice.
+	now := ts(time.Now())
+	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, fail_reason = '', lease_until = ?, updated_at = ?, `+set+`
+		WHERE id = ? AND state = ?`, TaskSubmitted, now, now, more, taskID, fromState)
 	if err != nil {
 		return fmt.Errorf("resume task: %w", err)
 	}
-	return db.appendEvent(taskID, byAgent, TaskFailed, TaskSubmitted,
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("coord: task %s moved on before the resume applied — check its state and retry", taskID)
+	}
+	return db.appendEvent(taskID, byAgent, fromState, TaskSubmitted,
 		fmt.Sprintf("resumed by %s (+%d)", byAgent, more))
 }
 

--- a/internal/coord/tasks_test.go
+++ b/internal/coord/tasks_test.go
@@ -2,6 +2,7 @@ package coord
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -308,5 +309,201 @@ func TestUnblockIsNotRepeatable(t *testing.T) {
 	got, _ := db.GetTask(task.ID)
 	if strings.Contains(got.Checkpoint, "second") {
 		t.Errorf("the refused answer leaked into the checkpoint:\n%s", got.Checkpoint)
+	}
+}
+
+// The deadlock seen in production: a task requeued as submitted with its
+// attempts spent could not be claimed (ClaimTask needs attempts <
+// max_attempts), could not be reaped (the sweep only looked at working), and
+// could not be resumed (resume took a failed task only). Eight more tasks sat
+// blocked behind it.
+//
+// This drives the state through the real path that created it — a run that
+// advanced, repeatedly — rather than writing the row by hand.
+func TestProgressDoesNotSpendTheFailureBudget(t *testing.T) {
+	db := testDB(t)
+	task, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "long job"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Six continuations — twice the three-attempt budget.
+	for i := range 6 {
+		c, err := db.ClaimTask("a1")
+		if err != nil {
+			t.Fatalf("claim %d: %v (a progressing task became unclaimable)", i+1, err)
+		}
+		run, err := db.StartRun(c.ID, "a1", c.Attempts, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.FinishRun(run.ID, RunOutcome{
+			Liveness: RunAdvanced, Checkpoint: fmt.Sprintf("step %d done", i+1),
+		}); err != nil {
+			t.Fatalf("finish %d: %v", i+1, err)
+		}
+	}
+
+	got, err := db.GetTask(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != TaskSubmitted {
+		t.Fatalf("state = %s, want submitted and claimable", got.State)
+	}
+	if got.Attempts >= got.MaxAttempts {
+		t.Errorf("attempts = %d/%d — progress spent the failure budget, which strands the task",
+			got.Attempts, got.MaxAttempts)
+	}
+	if got.Continuations != 6 {
+		t.Errorf("continuations = %d, want 6 — progress is what should be counted", got.Continuations)
+	}
+	// The proof: it can still be picked up.
+	if _, err := db.ClaimTask("a1"); err != nil {
+		t.Errorf("still unclaimable after 6 continuations: %v", err)
+	}
+}
+
+// strandTask forces the dead-end state directly, standing in for the rows that
+// already exist in a live database from before the refund above.
+func strandTask(t *testing.T, db *DB) *Task {
+	t.Helper()
+	task, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "stranded"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Conn().Exec(
+		`UPDATE tasks SET state = ?, attempts = max_attempts WHERE id = ?`,
+		TaskSubmitted, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	return task
+}
+
+func TestStrandedTaskIsUnclaimable(t *testing.T) {
+	db := testDB(t)
+	strandTask(t, db)
+	if _, err := db.ClaimTask("a1"); !errors.Is(err, ErrNoTask) {
+		t.Errorf("claim = %v, want ErrNoTask — this is the dead end, and the premise of the rest", err)
+	}
+}
+
+// The sweep is what hands a stuck queue back to a person: once the row is
+// failed, `task resume` can grant it more attempts.
+func TestReapExhaustedRescuesAStrandedTask(t *testing.T) {
+	db := testDB(t)
+	task := strandTask(t, db)
+
+	ids, err := db.ReapExhausted()
+	if err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != task.ID {
+		t.Fatalf("reaped %v, want the stranded task", ids)
+	}
+
+	got, _ := db.GetTask(task.ID)
+	if got.State != TaskFailed || got.FailReason != FailExhausted {
+		t.Errorf("state=%s reason=%s, want failed/exhausted", got.State, got.FailReason)
+	}
+	// And the audit says which state it came from, not a guess.
+	events, _ := db.TaskEvents(task.ID)
+	last := events[len(events)-1]
+	if last.FromState != TaskSubmitted || !strings.Contains(last.Note, "stranded") {
+		t.Errorf("event = %s→%s %q, want it to record the stranding", last.FromState, last.ToState, last.Note)
+	}
+}
+
+// A working task with an expired lease is the case the sweep already handled;
+// it must keep working.
+func TestReapExhaustedStillFailsADeadHolder(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "held"}); err != nil {
+		t.Fatal(err)
+	}
+	c, _ := db.ClaimTask("a1")
+	if _, err := db.Conn().Exec(
+		`UPDATE tasks SET attempts = max_attempts, lease_until = ? WHERE id = ?`,
+		"2000-01-01T00:00:00Z", c.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := db.ReapExhausted()
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("reap = %v, %v; want the dead holder failed", ids, err)
+	}
+	events, _ := db.TaskEvents(c.ID)
+	if last := events[len(events)-1]; last.FromState != TaskWorking {
+		t.Errorf("from-state = %s, want working for a dead holder", last.FromState)
+	}
+}
+
+// A submitted task with attempts left is simply waiting its turn, and must not
+// be touched.
+func TestReapExhaustedLeavesClaimableWorkAlone(t *testing.T) {
+	db := testDB(t)
+	task, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "queued"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids, err := db.ReapExhausted(); err != nil || len(ids) != 0 {
+		t.Fatalf("reap = %v, %v; a fresh task must be left alone", ids, err)
+	}
+	if got, _ := db.GetTask(task.ID); got.State != TaskSubmitted {
+		t.Errorf("state = %s, want submitted", got.State)
+	}
+}
+
+// Resume is the escape hatch, and a person should not have to wait for a sweep.
+func TestResumeAcceptsAStrandedTask(t *testing.T) {
+	db := testDB(t)
+	task := strandTask(t, db)
+	before, _ := db.GetTask(task.ID)
+
+	if err := db.ResumeTask(task.ID, "human", 5); err != nil {
+		t.Fatalf("resume: %v — this is the state resume exists for", err)
+	}
+	got, _ := db.GetTask(task.ID)
+	if got.MaxAttempts != before.MaxAttempts+5 {
+		t.Errorf("max_attempts = %d, want %d", got.MaxAttempts, before.MaxAttempts+5)
+	}
+	if _, err := db.ClaimTask("a1"); err != nil {
+		t.Errorf("still unclaimable after resume: %v", err)
+	}
+}
+
+// The old message named the state and stopped; it now says what resume accepts,
+// because the previous one sent people to a command that could not help.
+func TestResumeStillRefusesWorkInFlight(t *testing.T) {
+	db := testDB(t)
+	if _, err := db.CreateTask(NewTask{CreatedBy: "a2", AssignedTo: "a1", Title: "busy"}); err != nil {
+		t.Fatal(err)
+	}
+	c, _ := db.ClaimTask("a1") // now working, attempts 1/3
+
+	err := db.ResumeTask(c.ID, "human", 5)
+	if err == nil {
+		t.Fatal("a working task with attempts left must not be resumable")
+	}
+	if !strings.Contains(err.Error(), "1/3") {
+		t.Errorf("error should show the attempt count that explains the refusal: %v", err)
+	}
+}
+
+// Two operators clicking Resume must grant the allowance once.
+func TestResumeIsGuardedAgainstADoubleClick(t *testing.T) {
+	db := testDB(t)
+	task := strandTask(t, db)
+	before, _ := db.GetTask(task.ID)
+
+	if err := db.ResumeTask(task.ID, "human", 5); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ResumeTask(task.ID, "human", 5); err == nil {
+		t.Error("the second resume must be refused, not stack another +5")
+	}
+	got, _ := db.GetTask(task.ID)
+	if got.MaxAttempts != before.MaxAttempts+5 {
+		t.Errorf("max_attempts = %d, want a single +5 (%d)", got.MaxAttempts, before.MaxAttempts+5)
 	}
 }

--- a/internal/taskrunner/runner_test.go
+++ b/internal/taskrunner/runner_test.go
@@ -291,7 +291,10 @@ func TestRunThatTimesOutWithProgressContinuesAndResumes(t *testing.T) {
 	if task.State != coord.TaskSubmitted {
 		t.Fatalf("state = %s, want submitted (call me back)", task.State)
 	}
-	if task.Continuations != 1 || task.Attempts != 1 {
+	// 0, not 1 — which is what the message here always claimed. A timed-out run
+	// that recorded a checkpoint is progress, so FinishRun refunds the attempt
+	// ClaimTask charged.
+	if task.Continuations != 1 || task.Attempts != 0 {
 		t.Errorf("continuations=%d attempts=%d — progress must not spend an attempt", task.Continuations, task.Attempts)
 	}
 	if task.AssignedTo != "a2" {


### PR DESCRIPTION
A task requeued as submitted with attempts == max_attempts is a dead end. Three gates all refuse it and nothing else moves it:

  - ClaimTask needs attempts < max_attempts, so it is never picked up again.
  - ReapExhausted only looked at state='working', so it never became failed.
  - ResumeTask took a failed task only, so a person could not rescue it either.
  - RelaxDeadAssignments lifts the agent pin and nothing more, and the only code that raises max_attempts sits inside ResumeTask, behind that gate.

Seen in production: 05/14 ruins-dash stuck at submitted 3/3 with eight further tasks blocked on human behind it, and the nine `task resume` commands the agent prescribed would all have been refused — one task was submitted, eight were blocked, and resume accepted neither.

Root cause is notDone in FinishRun. It guarded continuations against MaxContinuations but never attempts against MaxAttempts, while ClaimTask charges an attempt on *every* claim. So a task making steady progress spent one of its three attempts per continuation and the fourth requeue stranded it — which also made MaxContinuations (20, documented as ~5 hours of work) unreachable, since three attempts capped it long before.

The fix is the one the design already specifies. §5.3: "attempts là lỗi, continuation là chưa xong", and its state machine gives advanced only continuations+1 while reserving attempts+1 for failed and for timed-out without progress. So notDone now refunds the attempt ClaimTask charged, exactly as RunCanceled already does — none of the runs reaching it failed: they advanced, planned, came back empty, or hit the cap with a checkpoint. Each path stays bounded by its own counter.

Two existing tests asserted attempts == 1 after one advance while their own failure messages said "progress must not spend an attempt" and "progress must count as a continuation, not a failed attempt". The messages were right and the assertions were pinned to the behaviour, not the intent; both now expect 0.

Two further changes so a queue that is already stuck can be recovered:

  - ReapExhausted also sweeps stranded submitted rows. Failing them is what makes them recoverable, because resume grants attempts to a failed task — it hands the queue back to a person instead of leaving it invisible.
  - ResumeTask accepts a stranded submitted task directly, so nobody waits for a sweep, and its refusal message now names the attempt count and says what resume does take. Its update is also guarded on the state it read, so two operators clicking Resume grant the allowance once rather than twice.

One trade-off, deliberate and shared with the existing RunCanceled refund: attempts doubles as the fencing token for SetCheckpoint and FinishTask, so returning it to a previous value means a stale holder's write can match a later claim. Continuations are a normal path rather than a rare one, so this matters more here than for cancels. Separating the fencing epoch from the failure counter is the clean answer and wants its own change.

The new test drives the state through the real path rather than writing the row by hand, and reproduces the incident exactly: with the refund reverted it fails at "claim 4: coord: no claimable task".