### PR TITLE
feat(dashboard): give every tab an address, and show what a span actu…

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useStore } from './stores/store'
 import { useGateway } from './hooks/useGateway'
 import { eventsToMessages } from './lib/transcript'
@@ -7,6 +7,7 @@ import ChatView from './components/ChatView'
 import StatusBar from './components/StatusBar'
 import AdminView from './admin/AdminView'
 import type { Me } from './Root'
+import { parseRoute, pathFor, type AdminPane } from './lib/route'
 
 export default function App({ me, onLogout }: { me: Me; onLogout?: () => void }) {
   const { call } = useGateway()
@@ -21,6 +22,10 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
   const sessions = useStore(s => s.sessions)
   const externalTurn = useStore(s => s.externalTurn)
   const sending = useStore(s => s.sending)
+
+  // Which admin pane is on screen. Lifted out of AdminView so that one place
+  // owns the address bar; AdminView is now told which pane to show.
+  const [adminPane, setAdminPane] = useState<AdminPane>('overview')
 
   // Another channel wrote to a session — Telegram, or an agent that claimed a
   // task. Refresh the list (labels, counts), and if that session is the one on
@@ -43,39 +48,37 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
     return () => clearInterval(t)
   }, [externalTurn, activeSessionId, sending, call, setSessions, setMessages])
 
-  // Sync URL ↔ state: read on load, write on change
+  // Sync URL → state, on load and whenever the browser navigates. The popstate
+  // half is new: without it Back and Forward changed the address bar and left
+  // the view where it was.
   useEffect(() => {
-    const path = location.pathname
-    if (path.startsWith('/chat/')) {
-      const id = path.slice(6)
-      if (id) {
-        setActiveSessionId(id)
-        setTab('chat')
-      }
-    } else if (path === '/chat') {
-      setTab('chat')
-    } else if (path === '/status') {
-      setTab('status')
-    } else if (path === '/admin') {
-      setTab('admin')
+    const apply = () => {
+      const r = parseRoute(location.pathname)
+      setTab(r.tab)
+      if (r.sessionId) setActiveSessionId(r.sessionId)
+      if (r.adminPane) setAdminPane(r.adminPane)
     }
+    apply()
+    window.addEventListener('popstate', apply)
+    return () => window.removeEventListener('popstate', apply)
   }, [setActiveSessionId, setTab])
 
-  // Update URL when session/tab changes
+  // State → URL. pushState rather than replaceState, so moving between tabs
+  // leaves history to go back through; and only when the path actually differs,
+  // which keeps the effect from stacking an entry per render (including the one
+  // right after the read above).
+  //
+  // The exception is filling in a detail on the tab already showing — /chat
+  // becoming /chat/<id> when the newest session is auto-selected. That is the
+  // same navigation, not a second one: pushing it would leave a /chat entry
+  // that Back returns to and the auto-select immediately leaves again.
   useEffect(() => {
-    if (tab === 'chat') {
-      // A chat with no session picked still needs its own URL — without this
-      // branch the address bar kept showing the tab you arrived from.
-      const path = activeSessionId && activeSessionId !== 'new' ? `/chat/${activeSessionId}` : '/chat'
-      history.replaceState(null, '', path)
-    } else if (tab === 'status') {
-      history.replaceState(null, '', '/status')
-    } else if (tab === 'admin') {
-      history.replaceState(null, '', '/admin')
-    } else if (tab === 'sessions') {
-      history.replaceState(null, '', '/')
-    }
-  }, [tab, activeSessionId])
+    const path = pathFor({ tab, sessionId: activeSessionId ?? undefined, adminPane })
+    const here = location.pathname
+    if (path === here) return
+    const refines = here !== '/' && path.startsWith(here + '/')
+    history[refines ? 'replaceState' : 'pushState'](null, '', path)
+  }, [tab, activeSessionId, adminPane])
 
   // Load sessions + status on connect
   useEffect(() => {
@@ -168,7 +171,7 @@ export default function App({ me, onLogout }: { me: Me; onLogout?: () => void })
         {tab === 'sessions' && <SessionList call={call} />}
         {tab === 'chat' && <ChatView call={call} />}
         {tab === 'status' && <StatusBar />}
-        {tab === 'admin' && <AdminView call={call} />}
+        {tab === 'admin' && <AdminView call={call} pane={adminPane} onPane={setAdminPane} />}
       </main>
     </div>
   )

--- a/dashboard/src/admin/AdminView.tsx
+++ b/dashboard/src/admin/AdminView.tsx
@@ -6,21 +6,24 @@ import TaskBoard from './TaskBoard'
 import MessageStream from './MessageStream'
 import NotesPane from './NotesPane'
 import SchedulesPane from './SchedulesPane'
+import { ADMIN_PANES, type AdminPane as Pane } from '../lib/route'
 
 type Call = (method: string, params?: any) => Promise<any>
-type Pane = 'overview' | 'traces' | 'tasks' | 'schedules' | 'notes' | 'messages'
 
-const PANES: { key: Pane; label: string }[] = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'traces', label: 'Traces' },
-  { key: 'tasks', label: 'Tasks' },
-  { key: 'schedules', label: 'Schedules' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'messages', label: 'Messages' },
-]
+// Keyed by Pane rather than listed, so a pane added to the route table cannot
+// reach the address bar without also getting a tab to click.
+const LABELS: Record<Pane, string> = {
+  overview: 'Overview',
+  traces: 'Traces',
+  tasks: 'Tasks',
+  schedules: 'Schedules',
+  notes: 'Notes',
+  messages: 'Messages',
+}
 
-export default function AdminView({ call }: { call: Call }) {
-  const [pane, setPane] = useState<Pane>('overview')
+const PANES = ADMIN_PANES.map(key => ({ key, label: LABELS[key] }))
+
+export default function AdminView({ call, pane, onPane }: { call: Call; pane: Pane; onPane: (p: Pane) => void }) {
   const [data, setData] = useState<OverviewData | null>(null)
   const [err, setErr] = useState<string | null>(null)
 
@@ -66,7 +69,7 @@ export default function AdminView({ call }: { call: Call }) {
         {PANES.map(p => (
           <button
             key={p.key}
-            onClick={() => setPane(p.key)}
+            onClick={() => onPane(p.key)}
             className={`px-3 py-1 text-sm rounded-md transition-colors ${
               pane === p.key ? 'bg-gray-700 text-white' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
             }`}

--- a/dashboard/src/admin/TraceExplorer.tsx
+++ b/dashboard/src/admin/TraceExplorer.tsx
@@ -42,22 +42,159 @@ function TraceRow({ t, active, onClick }: { t: TraceSummary; active: boolean; on
   )
 }
 
-function Payload({ label, body }: { label: string; body?: string }) {
+// A tool's payload reaches the page as a JSON *string*, so rendering it raw
+// shows the escapes rather than the content: `&&` arrives as &&,
+// quotes as \", and a heredoc as one line of literal \n. Parsing it back is most
+// of the readability win; lifting the one field that matters out of the wrapper
+// is the rest — for a Bash span that field is the command someone actually ran.
+const PRIMARY_FIELD: Record<string, string> = {
+  Bash: 'command',
+  PowerShell: 'command',
+  run_shell: 'command',
+  Read: 'file_path',
+  Write: 'file_path',
+  Edit: 'file_path',
+  NotebookEdit: 'notebook_path',
+  Grep: 'pattern',
+  Glob: 'pattern',
+  WebFetch: 'url',
+  browse_url: 'url',
+  browser_navigate: 'url',
+  Task: 'prompt',
+}
+
+// Tried in order when the span name is not one we know — the shapes above
+// cover the tools that actually appear, and this catches the rest.
+const FALLBACK_FIELDS = [
+  'command', 'script', 'prompt', 'file_path', 'pattern', 'url', 'query',
+  // Result-side shapes. PRIMARY_FIELD names the field a *call* is about, so the
+  // output payload is matched by these instead.
+  'stdout', 'output', 'result', 'content', 'text',
+]
+
+type Decoded = { primary?: { key: string; text: string }; rest: [string, unknown][] }
+
+function decodePayload(body: string, name?: string): Decoded | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return null // not JSON — the caller renders it as it arrived
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+
+  const obj = parsed as Record<string, unknown>
+  const wanted = (name && PRIMARY_FIELD[name]) || FALLBACK_FIELDS.find(f => typeof obj[f] === 'string')
+
+  let primary: Decoded['primary']
+  if (wanted && typeof obj[wanted] === 'string') {
+    primary = { key: wanted, text: obj[wanted] as string }
+  }
+  return { primary, rest: Object.entries(obj).filter(([k]) => k !== primary?.key) }
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [done, setDone] = useState(false)
+  return (
+    <button
+      onClick={() => {
+        void navigator.clipboard?.writeText(text).then(
+          () => { setDone(true); setTimeout(() => setDone(false), 1200) },
+          () => {},
+        )
+      }}
+      className="text-[11px] px-1.5 py-0.5 rounded ring-1 ring-gray-700 text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+      title="Copy so you can run it yourself"
+    >
+      {done ? 'copied' : 'copy'}
+    </button>
+  )
+}
+
+function Payload({ label, body, name }: { label: string; body?: string; name?: string }) {
   if (!body) return null
+  const decoded = decodePayload(body, name)
+
+  // Unparseable, or an object with nothing worth lifting out: show it whole,
+  // but re-serialised so at least the escapes are resolved.
+  if (!decoded) {
+    let text = body
+    try {
+      text = JSON.stringify(JSON.parse(body), null, 2)
+    } catch {
+      /* genuinely not JSON; the raw string is the best we have */
+    }
+    return (
+      <div className="mt-2">
+        <div className="text-[11px] uppercase tracking-wider text-gray-600 mb-1">{label}</div>
+        <pre className="text-xs text-gray-300 bg-gray-950 rounded p-2 ring-1 ring-gray-800 whitespace-pre-wrap break-words max-h-64 overflow-y-auto">
+          {text}
+        </pre>
+      </div>
+    )
+  }
+
   return (
     <div className="mt-2">
-      <div className="text-[11px] uppercase tracking-wider text-gray-600 mb-1">{label}</div>
-      <pre className="text-xs text-gray-300 bg-gray-950 rounded p-2 ring-1 ring-gray-800 whitespace-pre-wrap break-words max-h-64 overflow-y-auto">
-        {body}
-      </pre>
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600">{label}</span>
+        {decoded.primary && (
+          <>
+            <span className="text-[11px] font-mono text-gray-500">{decoded.primary.key}</span>
+            <CopyButton text={decoded.primary.text} />
+          </>
+        )}
+      </div>
+
+      {decoded.primary && (
+        <pre className="text-xs text-gray-200 bg-gray-950 rounded p-2 ring-1 ring-gray-800 whitespace-pre-wrap break-words max-h-80 overflow-y-auto font-mono">
+          {decoded.primary.text}
+        </pre>
+      )}
+
+      {/* Everything else as one line each: a description or a timeout is worth
+          seeing, but it should not compete with the command for attention. */}
+      {decoded.rest.length > 0 && (
+        <dl className="mt-1.5 space-y-0.5">
+          {decoded.rest.map(([k, v]) => (
+            <div key={k} className="flex gap-2 text-[11px]">
+              <dt className="font-mono text-gray-600 shrink-0">{k}</dt>
+              <dd className="text-gray-400 break-words min-w-0">
+                {typeof v === 'string' ? v : JSON.stringify(v)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
     </div>
   )
+}
+
+// summarise is the one line a collapsed span gets. Without it a trace of twelve
+// Bash calls renders as twelve rows saying "Bash", which tells you something ran
+// but never what — the difference this closes.
+//
+// description wins when the caller supplied one: it is a human summary of the
+// command's intent, which is what you want at a glance. Otherwise the command
+// itself, flattened, because a heredoc's newlines would otherwise break the row.
+function summarise(run: Run): string | null {
+  if (!run.inputs) return null
+  const d = decodePayload(run.inputs, run.name)
+  if (!d) return null
+
+  const desc = d.rest.find(([k]) => k === 'description')?.[1]
+  const text = typeof desc === 'string' && desc.trim() ? desc : d.primary?.text
+  if (!text) return null
+
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat || null
 }
 
 function WaterfallRow({ run, t0, span, expanded, onToggle }: {
   run: Run; t0: number; span: number; expanded: boolean; onToggle: () => void
 }) {
   const color = runColor(run.run_type)
+  const summary = summarise(run)
   const start = new Date(run.started_at).getTime()
   // A pending run has no end yet; show it running to "now" rather than as a
   // zero-width sliver that looks like it never happened.
@@ -94,6 +231,18 @@ function WaterfallRow({ run, t0, span, expanded, onToggle }: {
             {run.input_tokens + run.output_tokens > 0 ? tokens(run.input_tokens + run.output_tokens) : ''}
           </span>
         </div>
+
+        {/* Second line rather than a column, so the waterfall bar keeps its
+            width — the same shape the trace list already uses. */}
+        {summary && !expanded && (
+          <div
+            className="mt-0.5 text-[11px] text-gray-500 truncate font-mono"
+            style={{ paddingLeft: run.depth * 14 + 20 }}
+            title={summary}
+          >
+            {summary}
+          </div>
+        )}
       </button>
 
       {expanded && (
@@ -110,7 +259,9 @@ function WaterfallRow({ run, t0, span, expanded, onToggle }: {
               {run.error}
             </div>
           )}
-          <Payload label="input" body={run.inputs} />
+          <Payload label="input" body={run.inputs} name={run.name} />
+          {/* No name for the output: PRIMARY_FIELD maps a tool to the field its
+              call is about, which a result does not have. */}
           <Payload label="output" body={run.outputs} />
         </div>
       )}

--- a/dashboard/src/lib/route.ts
+++ b/dashboard/src/lib/route.ts
@@ -1,0 +1,60 @@
+// One address per view, so a pane can be linked, bookmarked and reloaded.
+//
+// The gateway already serves index.html for any path that is not a real file,
+// so every route below survives a hard refresh with no server change. What was
+// missing was the client half: the admin panes lived in component state and
+// never reached the address bar, so "send me the traces tab" meant "open /admin
+// and then click Traces".
+//
+// Kept as pure functions on purpose — routing is the kind of thing that is
+// easier to test than to debug through a browser.
+
+export type Tab = 'sessions' | 'chat' | 'status' | 'admin'
+export type AdminPane = 'overview' | 'traces' | 'tasks' | 'schedules' | 'notes' | 'messages'
+
+export const ADMIN_PANES: AdminPane[] = ['overview', 'traces', 'tasks', 'schedules', 'notes', 'messages']
+
+export interface Route {
+  tab: Tab
+  sessionId?: string
+  adminPane?: AdminPane
+}
+
+/** parseRoute reads a pathname into the view it names. */
+export function parseRoute(pathname: string): Route {
+  const parts = pathname.split('/').filter(Boolean)
+
+  switch (parts[0]) {
+    case 'chat':
+      // /chat/<id> opens that session; bare /chat is the composer.
+      return parts[1] ? { tab: 'chat', sessionId: decodeURIComponent(parts[1]) } : { tab: 'chat' }
+
+    case 'status':
+      return { tab: 'status' }
+
+    case 'admin': {
+      // An unknown or missing pane lands on Overview rather than a blank panel,
+      // which is what a stale or hand-typed link deserves.
+      const pane = ADMIN_PANES.find(p => p === parts[1])
+      return { tab: 'admin', adminPane: pane ?? 'overview' }
+    }
+
+    default:
+      return { tab: 'sessions' }
+  }
+}
+
+/** pathFor is parseRoute's inverse: the address a view should be showing. */
+export function pathFor(r: Route): string {
+  switch (r.tab) {
+    case 'chat':
+      // "new" is the composer's placeholder id, not a session that exists.
+      return r.sessionId && r.sessionId !== 'new' ? `/chat/${encodeURIComponent(r.sessionId)}` : '/chat'
+    case 'status':
+      return '/status'
+    case 'admin':
+      return `/admin/${r.adminPane ?? 'overview'}`
+    case 'sessions':
+      return '/'
+  }
+}


### PR DESCRIPTION
…ally ran

Two things you could not do from the UI before.

Tabs had no addresses. /admin was one URL for five panes, which lived in component state, so "look at the traces tab" meant "open /admin, then click Traces" — and Back and Forward moved the address bar while leaving the view where it was. Routing now lives in one place (lib/route.ts) as a pathname -> view function and its inverse, both pure, and App owns the sync: read on load and on popstate, write on change. /admin/tasks, /admin/traces and /chat/<id> are all linkable and survive a reload; the gateway already serves index.html for any non-file path, so no backend change was needed.

pushState rather than replaceState, so tab moves leave history to walk back through. The one exception is a path refining the one showing — /chat becoming /chat/<id> when the newest session is auto-selected — which is the same navigation, not a second one; pushing it would leave a /chat entry that Back returns to and the auto-select immediately leaves again.

Traces showed twelve rows saying "Bash" and, once expanded, the payload as the JSON string it arrives as: && as &&, quotes escaped, a heredoc as one line of literal \n. Parsing it back is most of the readability win; lifting the field that matters (the command, the file, the pattern — PRIMARY_FIELD, by tool) out of the wrapper is the rest. Each collapsed row now carries a one-line summary: the caller's description when there is one, else the flattened command, so a waterfall reads as a list of what ran. Expanded, the command gets a mono block with a copy button and everything else a compact key/value line.