### PR TITLE
fix(daemon): give each agent its own gateway log

### DIFF
--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -31,8 +31,17 @@ func newLaunchdService(agentID string) (*launchdService, error) {
 	return &launchdService{
 		label:     launchdLabelFor(agentID),
 		plistPath: filepath.Join(home, "Library", "LaunchAgents", launchdLabelFor(agentID)+".plist"),
-		logDir:    filepath.Join(home, ".goterm", "logs"),
+		logDir:    launchdLogDirFor(home, agentID),
 	}, nil
+}
+
+// launchdLogDirFor keeps each agent's gateway log to itself. Agent 1 stays at
+// ~/.goterm/logs so nothing that already tails it has to change; the rest get
+// ~/.goterm<N>/logs, which is beside the data dir they already own. Three
+// agents interleaved into one file makes every startup question ("did it
+// register? is it polling?") an exercise in guessing which process wrote what.
+func launchdLogDirFor(home, agentID string) string {
+	return filepath.Join(home, ".goterm"+unitSuffix(agentID), "logs")
 }
 
 func (s *launchdService) Label() string { return "LaunchAgent" }

--- a/internal/daemon/launchd_plist_test.go
+++ b/internal/daemon/launchd_plist_test.go
@@ -84,3 +84,35 @@ func TestBuildPlistEscaping(t *testing.T) {
 		t.Error("unescaped < > in program args")
 	}
 }
+
+func TestEachAgentGetsItsOwnLogDir(t *testing.T) {
+	// Agent 1 keeps the original path — anything already tailing it, or any
+	// runbook naming it, must not break on an upgrade.
+	if got := launchdLogDirFor("/Users/x", "bomclaw"); got != "/Users/x/.goterm/logs" {
+		t.Errorf("agent 1 log dir moved to %q", got)
+	}
+	if got := launchdLogDirFor("/Users/x", ""); got != "/Users/x/.goterm/logs" {
+		t.Errorf("default log dir = %q", got)
+	}
+	// Everyone else is separate, or three startups interleave in one file.
+	if got := launchdLogDirFor("/Users/x", "bomclaw3"); got != "/Users/x/.goterm3/logs" {
+		t.Errorf("agent 3 log dir = %q, want its own", got)
+	}
+	if launchdLogDirFor("/Users/x", "bomclaw2") == launchdLogDirFor("/Users/x", "bomclaw3") {
+		t.Error("two agents share a log file")
+	}
+}
+
+func TestServiceNamesAreDerivedFromTheAgent(t *testing.T) {
+	cases := map[string]string{
+		"":         "com.bomclaw.gateway",
+		"bomclaw":  "com.bomclaw.gateway",
+		"bomclaw2": "com.bomclaw2.gateway",
+		"bomclaw3": "com.bomclaw3.gateway",
+	}
+	for id, want := range cases {
+		if got := launchdLabelFor(id); got != want {
+			t.Errorf("launchdLabelFor(%q) = %q, want %q", id, got, want)
+		}
+	}
+}

--- a/internal/daemon/launchd_plist_test.go
+++ b/internal/daemon/launchd_plist_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -88,17 +89,23 @@ func TestBuildPlistEscaping(t *testing.T) {
 func TestEachAgentGetsItsOwnLogDir(t *testing.T) {
 	// Agent 1 keeps the original path — anything already tailing it, or any
 	// runbook naming it, must not break on an upgrade.
-	if got := launchdLogDirFor("/Users/x", "bomclaw"); got != "/Users/x/.goterm/logs" {
+	// Expected paths go through filepath.Join too: this file is built on every
+	// platform even though launchd is darwin-only, and a hardcoded "/" fails
+	// on Windows without teaching anyone anything.
+	home := filepath.Join("/Users", "x")
+	agent1 := filepath.Join(home, ".goterm", "logs")
+
+	if got := launchdLogDirFor(home, "bomclaw"); got != agent1 {
 		t.Errorf("agent 1 log dir moved to %q", got)
 	}
-	if got := launchdLogDirFor("/Users/x", ""); got != "/Users/x/.goterm/logs" {
+	if got := launchdLogDirFor(home, ""); got != agent1 {
 		t.Errorf("default log dir = %q", got)
 	}
 	// Everyone else is separate, or three startups interleave in one file.
-	if got := launchdLogDirFor("/Users/x", "bomclaw3"); got != "/Users/x/.goterm3/logs" {
-		t.Errorf("agent 3 log dir = %q, want its own", got)
+	if got, want := launchdLogDirFor(home, "bomclaw3"), filepath.Join(home, ".goterm3", "logs"); got != want {
+		t.Errorf("agent 3 log dir = %q, want %q", got, want)
 	}
-	if launchdLogDirFor("/Users/x", "bomclaw2") == launchdLogDirFor("/Users/x", "bomclaw3") {
+	if launchdLogDirFor(home, "bomclaw2") == launchdLogDirFor(home, "bomclaw3") {
 		t.Error("two agents share a log file")
 	}
 }


### PR DESCRIPTION
`bomclaw gateway install --agent bomclaw3` viết plist trỏ log vào `~/.goterm/logs/gateway.err.log` — **file của agent 1**. Ba agent ghi chung một file thì mọi câu hỏi lúc khởi động ("nó đăng ký chưa? có đang poll không?") thành trò đoán xem dòng nào của process nào. Agent 2 đã được sửa tay khỏi chuyện này từ lâu.

Agent 1 giữ nguyên `~/.goterm/logs` (không phá thứ gì đang tail nó); các agent còn lại nhận `~/.goterm<N>/logs`, nằm cạnh data dir vốn đã của riêng chúng.

Phát hiện khi dựng agent 3 thật — plist agent 3 đã được cài lại bằng bản này và log giờ ở `~/.goterm3/logs/`.

Kèm test cho cả log dir và tên service theo agent id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)