### PR TITLE
docs: record the second cause of the Telegram getUpdates conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,27 @@ When restarting the gateway service, stale Claude CLI subprocesses (spawned by p
 2. Clear Telegram state: `curl "https://api.telegram.org/bot${TOKEN}/deleteWebhook?drop_pending_updates=true"`
 3. Then restart: `./bomclaw gateway restart`
 
-**Root cause:** `client.go` spawns `claude -p --resume <session>` as a child process. If the parent gateway dies (crash, restart) without killing the child, the orphaned claude process keeps its Telegram long-poll alive. The new gateway instance then conflicts with it.
+**Root cause — there are two, and this file only had one until 2026-09-10:**
 
-**TODO:** Add child process cleanup on gateway shutdown (kill all spawned claude subprocesses in `Bot.Shutdown()`).
+1. **Orphaned subprocesses.** `client.go` spawns `claude -p --resume <session>`
+   as a child process. If the parent gateway dies (crash, restart) without
+   killing the child, the orphaned claude process keeps its Telegram long-poll
+   alive. The new gateway instance then conflicts with it.
+
+2. **Two gateways, one token.** Telegram serves `getUpdates` to exactly one
+   consumer per token. Agents 1 and 2 both had `TELEGRAM_TOKEN` in their `.env`
+   — which overrides `telegram.token: ""` in config (`config.go` Load) — so
+   both were polling the same bot, permanently. Fixed by `telegram.poll`
+   (default true): agent 1 polls, agents 2 and 3 set it false. They still build
+   the bot object, because that object is the shared turn engine `deps.Turn`;
+   dropping the token instead would push the dashboard and `bomclaw send` onto
+   the older non-streaming `agent.RunAgent` path.
+
+   Check with: `grep -c "telegram polling off" ~/.goterm<N>/logs/gateway.err.log`
+
+**Agents on this machine:** `bomclaw` (:18789, claude), `bomclaw2` (:18790,
+codex), `bomclaw3` (:18791, claude, shares agent 1's OAuth quota). One shared
+binary at `~/.bomclaw/bomclaw`, so a deploy restarts all three. Adding one:
+`docs/adding-an-agent.md`.
+
+**TODO:** Add child process cleanup on gateway shutdown (kill all spawned claude subprocesses in `Bot.Shutdown()`). Cause 2 is fixed; this is still open for cause 1.


### PR DESCRIPTION
`CLAUDE.md` quy nguyên nhân conflict cho orphaned `claude -p --resume` subprocess. Đúng, nhưng **không phải nguyên nhân duy nhất**.

Phát hiện khi dựng agent 3: agent 1 và agent 2 đều có `TELEGRAM_TOKEN` trong `.env`, mà biến môi trường này **ghi đè** `telegram.token: ""` trong config (`config.go` Load). Nên hai gateway đã cùng long-poll một bot suốt từ đầu — Telegram chỉ phục vụ `getUpdates` cho đúng một consumer mỗi token.

Bằng chứng trong log trước khi sửa:
```
~/.bomclaw2/gateway.log:1248  gateway: starting Telegram bot
~/.goterm/logs/gateway.err.log:71452  gateway: starting Telegram bot
```
cùng một token `bot8796570812:...`.

`telegram.poll` (PR #106) sửa nguyên nhân này: agent 1 poll, agent 2 và 3 không. Chúng vẫn dựng bot object vì đó chính là turn engine dùng chung (`deps.Turn`) — bỏ token đi thay vì bỏ poll sẽ đẩy dashboard và `bomclaw send` về đường `agent.RunAgent` cũ không streaming.

TODO dọn child process vẫn còn nguyên cho nguyên nhân 1.

Kèm ghi lại ba agent đang chạy và trỏ sang `docs/adding-an-agent.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)