### PR TITLE
feat(taskrunner): a mention becomes work

### DIFF
--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -613,3 +613,29 @@ func slug(s string) string {
 	}
 	return out
 }
+
+// OpenMentionTasks counts the unfinished tasks an agent is carrying because it
+// was named. It bounds the one loop this design can produce: agent A answers a
+// mention by naming agent B, B answers by naming A, forever. Neither agent is
+// doing anything wrong — there is simply nothing in a conversation that says
+// when to stop — so the stop is a cap.
+func (db *DB) OpenMentionTasks(agentID string) (int, error) {
+	var n int
+	err := db.conn.QueryRow(`SELECT count(*) FROM tasks
+		WHERE kind = ? AND assigned_to = ? AND state NOT IN (?, ?, ?, ?)`,
+		KindMention, agentID, TaskCompleted, TaskFailed, TaskCanceled, TaskRejected).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("open mention tasks for %s: %w", agentID, err)
+	}
+	return n, nil
+}
+
+// ChannelName is the room's display name, for a prompt that should read like
+// a place rather than an id.
+func (db *DB) ChannelName(channelID string) string {
+	var name string
+	if err := db.conn.QueryRow(`SELECT name FROM channels WHERE id = ?`, channelID).Scan(&name); err != nil {
+		return channelID
+	}
+	return name
+}

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -28,7 +28,8 @@ const (
 	KindManual    = "manual"    // a person or an agent queued it
 	KindScheduled = "scheduled" // materialised from a schedule
 	KindHeartbeat = "heartbeat"
-	KindSub       = "sub" // a child of another task
+	KindSub       = "sub"     // a child of another task
+	KindMention   = "mention" // someone named this agent in a channel
 )
 
 // What a task can be blocked on.

--- a/internal/taskrunner/mentions.go
+++ b/internal/taskrunner/mentions.go
@@ -1,0 +1,138 @@
+package taskrunner
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// Mentions are how a channel reaches an agent that is not already running.
+//
+// Posting records the mention and rings the named agent's doorbell, but the
+// doorbell wakes this claim loop, and the claim loop only knows how to claim
+// tasks. Nothing turned the one into the other: a mention sat unread forever
+// while the agent slept a metre away from it. This file is that conversion —
+// an unread mention becomes an ordinary task, and then everything the task
+// machinery already does (lease, fencing, attempts, trace, transcript, the
+// Tasks tab) applies to answering a message for free.
+
+const (
+	// MaxMentionTasks is how many unanswered mentions an agent may be
+	// carrying before it stops taking new ones. Two agents can otherwise
+	// answer each other forever: neither is misbehaving, there is just
+	// nothing in a conversation that says when to stop.
+	MaxMentionTasks = 3
+
+	// MentionsPerSweep bounds one pass, so an agent that was offline for a
+	// day does not wake into a hundred turns at once.
+	MentionsPerSweep = 5
+
+	// StaleMention is when answering stops being useful and starts being
+	// confusing. Older ones are marked read with a log line instead.
+	StaleMention = 24 * time.Hour
+
+	// MentionRuns caps the task. A reply is a reply; if it turns out to need
+	// real work, the agent creates a task for that work and says so.
+	MentionRuns = 2
+)
+
+// mentionsToTasks converts this agent's unread mentions into work. Called from
+// sweep, so both the poll tick and a poke reach it.
+//
+// Each agent handles only its own mentions, so two gateways never race for the
+// same one and no cross-process locking is needed.
+func (r *Runner) mentionsToTasks() {
+	open, err := r.db.OpenMentionTasks(r.cfg.AgentID)
+	if err != nil {
+		log.Printf("taskrunner: count mention tasks: %v", err)
+		return
+	}
+	if open >= MaxMentionTasks {
+		return // already behind; answering more would only deepen it
+	}
+
+	msgs, err := r.db.UnreadMentions(coord.MemberAgent, r.cfg.AgentID, MentionsPerSweep)
+	if err != nil {
+		log.Printf("taskrunner: read mentions: %v", err)
+		return
+	}
+	// Oldest first: a conversation answered out of order reads as nonsense.
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if open >= MaxMentionTasks {
+			log.Printf("taskrunner: %d mention task(s) already open — the rest wait", open)
+			return
+		}
+		m := msgs[i]
+
+		if time.Since(m.CreatedAt) > StaleMention {
+			if _, err := r.db.MarkMentionsRead(coord.MemberAgent, r.cfg.AgentID, []string{m.ID}); err != nil {
+				log.Printf("taskrunner: clear stale mention %s: %v", m.ID, err)
+				return // do not spin on the same row
+			}
+			log.Printf("taskrunner: mention %s from %s is %s old — cleared without answering",
+				m.ID, m.AuthorID, time.Since(m.CreatedAt).Round(time.Hour))
+			continue
+		}
+
+		// Create first, mark read second. The other order loses a summons
+		// silently if the create fails; this order can at worst answer twice,
+		// which is visible and bounded by MaxMentionTasks.
+		task, err := r.db.CreateTask(coord.NewTask{
+			CreatedBy:        m.AuthorID,
+			AssignedTo:       r.cfg.AgentID,
+			Kind:             coord.KindMention,
+			Title:            mentionTitle(r.db.ChannelName(m.ChannelID), m.AuthorID),
+			Body:             mentionPrompt(r.db.ChannelName(m.ChannelID), m),
+			MaxContinuations: MentionRuns,
+		})
+		if err != nil {
+			log.Printf("taskrunner: mention %s → task: %v", m.ID, err)
+			return
+		}
+		if _, err := r.db.MarkMentionsRead(coord.MemberAgent, r.cfg.AgentID, []string{m.ID}); err != nil {
+			log.Printf("taskrunner: mention %s became %s but stayed unread: %v", m.ID, task.ID, err)
+		}
+		log.Printf("taskrunner: %s named you in %s → task %s", m.AuthorID, m.ChannelID, task.ID)
+		open++
+	}
+}
+
+func mentionTitle(channel, author string) string {
+	return fmt.Sprintf("Reply to %s in #%s", author, channel)
+}
+
+// mentionPrompt is what the agent reads. It has to carry three things the
+// agent cannot look up on its own: what was said, where the reply goes, and
+// that a reply is the whole job.
+func mentionPrompt(channel string, m coord.ChannelMessage) string {
+	thread := m.ThreadRoot
+	if thread == "" {
+		thread = m.ID // replying to a top-level message opens its thread
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s named you in #%s.\n\n", m.AuthorID, channel)
+	fmt.Fprintf(&b, "> %s\n\n", strings.ReplaceAll(strings.TrimSpace(m.Body), "\n", "\n> "))
+
+	if m.ThreadRoot != "" {
+		fmt.Fprintf(&b, "It is a reply inside a thread. Read the whole thread first:\n"+
+			"`bomclaw ch read %s --thread %s`\n\n", m.ChannelID, thread)
+	}
+	if m.TaskID != "" {
+		fmt.Fprintf(&b, "The thread is about task %s — `bomclaw task show --id %s`.\n\n", m.TaskID, m.TaskID)
+	}
+
+	fmt.Fprintf(&b, "Answer in the thread, not in the channel's main line:\n\n"+
+		"    bomclaw ch post %s --thread %s \"your reply\"\n\n", m.ChannelID, thread)
+
+	b.WriteString("This task is done when you have posted that reply. Notes:\n\n" +
+		"- Answer the question. If you cannot, say what you would need, in the thread.\n" +
+		"- Name another agent with `@` only when you actually need something from it. " +
+		"Every mention costs that agent a turn, and two agents naming each other back " +
+		"and forth is a loop nobody stops.\n" +
+		"- If answering properly turns out to be real work, create a task for the work " +
+		"(`bomclaw task new`), say so in the thread, and finish this one.\n")
+	return b.String()
+}

--- a/internal/taskrunner/mentions_test.go
+++ b/internal/taskrunner/mentions_test.go
@@ -1,0 +1,153 @@
+package taskrunner
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// The gap this file closes: posting recorded the mention and rang the
+// doorbell, but the doorbell woke a loop that only reads the task queue, so a
+// mention sat unread forever with the agent awake beside it.
+func TestAMentionBecomesWork(t *testing.T) {
+	db := testDB(t)
+	registerAgents(t, db, "a1", "a2")
+	r := newRunner(db, &stubLLM{})
+
+	if _, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorID: "a1",
+		Body: "@a2 you are live — say hello in this thread",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r.mentionsToTasks()
+
+	tasks, err := db.ListTasks(coord.TaskFilter{AgentID: "a2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("%d tasks for a2, want 1 — the mention never became work", len(tasks))
+	}
+	got := tasks[0]
+	if got.Kind != coord.KindMention {
+		t.Errorf("kind = %q, want %q", got.Kind, coord.KindMention)
+	}
+	if got.CreatedBy != "a1" {
+		t.Errorf("created_by = %q, want the agent that named it", got.CreatedBy)
+	}
+	// The prompt has to carry what the agent cannot look up: the words, and
+	// where the answer goes.
+	for _, want := range []string{"say hello in this thread", "bomclaw ch post", coord.GeneralChannelID} {
+		if !strings.Contains(got.Body, want) {
+			t.Errorf("prompt missing %q:\n%s", want, got.Body)
+		}
+	}
+	// Answered once, not on every sweep.
+	r.mentionsToTasks()
+	again, _ := db.ListTasks(coord.TaskFilter{AgentID: "a2"})
+	if len(again) != 1 {
+		t.Errorf("%d tasks after a second sweep, want 1", len(again))
+	}
+}
+
+func TestOnlyTheNamedAgentIsGivenTheWork(t *testing.T) {
+	db := testDB(t)
+	registerAgents(t, db, "a1", "a2", "a3")
+
+	if _, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorID: "a1", Body: "@a3 can you take this?",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// a2 sweeps first and must not pick up a summons addressed to a3.
+	newRunnerFor(db, "a2").mentionsToTasks()
+	if tasks, _ := db.ListTasks(coord.TaskFilter{AgentID: "a2"}); len(tasks) != 0 {
+		t.Fatalf("a2 took %d task(s) from a mention of a3", len(tasks))
+	}
+	newRunnerFor(db, "a3").mentionsToTasks()
+	if tasks, _ := db.ListTasks(coord.TaskFilter{AgentID: "a3"}); len(tasks) != 1 {
+		t.Fatalf("a3 got %d task(s), want 1", len(tasks))
+	}
+}
+
+func TestAnAgentStopsTakingMentionsWhenItIsBehind(t *testing.T) {
+	db := testDB(t)
+	registerAgents(t, db, "a1", "a2")
+	r := newRunnerFor(db, "a2")
+
+	// Two agents answering each other by name is a loop with no natural end.
+	// The cap is the end.
+	for i := 0; i < MaxMentionTasks+3; i++ {
+		if _, _, err := db.PostMessage(coord.NewChannelMessage{
+			ChannelID: coord.GeneralChannelID, AuthorID: "a1", Body: "@a2 and another thing",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 5; i++ {
+		r.mentionsToTasks()
+	}
+
+	tasks, _ := db.ListTasks(coord.TaskFilter{AgentID: "a2"})
+	if len(tasks) > MaxMentionTasks {
+		t.Fatalf("%d open mention tasks, want at most %d", len(tasks), MaxMentionTasks)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("the cap swallowed every mention")
+	}
+}
+
+func TestAStaleMentionIsClearedNotAnswered(t *testing.T) {
+	db := testDB(t)
+	registerAgents(t, db, "a1", "a2")
+	r := newRunnerFor(db, "a2")
+
+	m, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorID: "a1", Body: "@a2 are you there",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Age it past the window: an agent back from a long outage should not
+	// wake into a day of stale conversation.
+	old := time.Now().Add(-StaleMention - time.Hour).UTC().Format("2006-01-02T15:04:05Z")
+	if _, err := db.Conn().Exec(`UPDATE channel_messages SET created_at = ? WHERE id = ?`, old, m.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	r.mentionsToTasks()
+
+	if tasks, _ := db.ListTasks(coord.TaskFilter{AgentID: "a2"}); len(tasks) != 0 {
+		t.Errorf("answered a stale mention (%d tasks)", len(tasks))
+	}
+	pending, _ := db.UnreadMentions(coord.MemberAgent, "a2", 10)
+	if len(pending) != 0 {
+		t.Error("stale mention left unread — it would be reconsidered on every sweep forever")
+	}
+}
+
+// newRunnerFor is newRunner under a chosen identity: mention handling is
+// per-agent, so most of these tests need to say who is sweeping.
+func newRunnerFor(db *coord.DB, agentID string) *Runner {
+	return New(db, &stubLLM{}, nil, Config{
+		AgentID:  agentID,
+		Model:    "m",
+		Interval: 10 * time.Millisecond,
+		Timeout:  5 * time.Second,
+	})
+}
+
+// registerAgents puts agents in the shared database so @names resolve —
+// resolveMentions deliberately ignores an @ that is not a known agent.
+func registerAgents(t *testing.T, db *coord.DB, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		if err := db.RegisterAgent(coord.Agent{ID: id, DisplayName: id}); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+	}
+}

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -194,6 +194,9 @@ func (r *Runner) Wait() {
 // tasks that have used every attempt (they used to sit in `working` forever),
 // and open up tasks addressed to an agent that has stopped heartbeating.
 func (r *Runner) sweep() {
+	// A mention is not a task until this turns it into one; without it the
+	// doorbell rings a loop that only reads the task queue. See mentions.go.
+	r.mentionsToTasks()
 	if ids, err := r.db.ReapExhausted(); err != nil {
 		log.Printf("taskrunner: reap: %v", err)
 	} else if len(ids) > 0 {


### PR DESCRIPTION
**Tag một agent thì không có gì xảy ra.** Người dùng phát hiện; đây là mắt xích tôi dựng thiếu ở #106.

## Đường đi thật trước PR này

| Bước | Chạy? |
|---|---|
| `PostMessage` ghi mention row | ✅ |
| Người gửi rung chuông agent được nhắc (`/api/tasks/poke` → 200) | ✅ |
| Poke đánh thức vòng lặp **task runner** | ✅ |
| Runner gọi `ClaimTask` → nhìn bảng **`tasks`** | ✅ |
| Mention **không phải** task → không có gì để claim → ngủ tiếp | ❌ |

`UnreadMentions` có đúng **một** caller trong toàn bộ cây code: lệnh `bomclaw ch mentions` do người gõ. Không có gì biến "bị nhắc tên" thành "chạy một lượt".

Bằng chứng trên máy thật: mention lúc `09-10 13:06` vẫn `unread` sau 19 giờ, không task nào được tạo, log runner của agent 3 không có dòng nào sau khi khởi động.

Tôi verify #106 bằng cách kiểm tra hai đầu — mention ghi được, poke trả 200 — nên nó trông như đã xong.

## Sửa

`sweep()` chuyển mention chưa đọc của chính agent đó thành một task thường. Mọi thứ task machinery đã có — lease, fencing, attempts, trace, transcript, tab Tasks — áp dụng luôn cho việc trả lời một tin nhắn. Mỗi agent chỉ xử lý mention của mình nên hai gateway không bao giờ tranh nhau một mention, không cần khoá liên tiến trình.

Ba cái chặn, vì một cuộc hội thoại không có điểm dừng tự nhiên:

- **`MaxMentionTasks` (3)** — A trả lời B bằng cách gọi tên A, mãi mãi. Không agent nào sai; chỉ là trong hội thoại không có gì nói "dừng". Nên cái dừng là một cap.
- **`MentionsPerSweep` (5)** — agent vừa quay lại sau sự cố không tỉnh dậy giữa một trăm lượt.
- **`StaleMention` (24h)** — cũ hơn thì xoá kèm một dòng log. Trả lời câu "còn đó không" của hôm qua tệ hơn là không trả lời.

Prompt mang ba thứ agent không tự tra được: nội dung đã nói, việc trả lời đi vào thread và đi bằng lệnh nào, và rằng đăng được câu trả lời là xong việc — nếu hoá ra cần làm thật thì tạo task riêng chứ không phình task này.

## Test

`internal/taskrunner/mentions_test.go`: mention thành task (đúng kind, đúng người tạo, prompt có nội dung + lệnh trả lời), sweep lần hai không tạo trùng, agent khác không nhặt mention không phải của mình, cap giữ được khi bị dội, mention quá hạn bị xoá chứ không trả lời và không bị cân nhắc lại mỗi vòng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)