### PR TITLE
feat(coord): cascade cancel, children from the dashboard, schedule_runs retention

### DIFF
--- a/cmd/bomclaw/coordcmd.go
+++ b/cmd/bomclaw/coordcmd.go
@@ -205,6 +205,27 @@ func runTask(args []string) {
 		}
 		fmt.Printf("%s → %s\n", *id, state)
 
+	case "cancel":
+		// A person stopping work. Takes every unfinished child with it: a
+		// canceled parent never comes back for their results.
+		fs := flag.NewFlagSet("task cancel", flag.ExitOnError)
+		agent, dbPath := agentFlag(fs), dbFlag(fs)
+		id := fs.String("id", "", "Task id (required)")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		children, err := db.CancelTaskTree(*id, requireAgent(*agent))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "task cancel: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s canceled", *id)
+		if len(children) > 0 {
+			fmt.Printf(" — and %d unfinished child task(s): %s", len(children), strings.Join(children, ", "))
+		}
+		fmt.Println()
+
 	case "progress":
 		// The agent's own "here is how far I got". Fed into the next run's
 		// prompt, so a run that hits its time cap loses nothing it wrote down.
@@ -461,6 +482,7 @@ func taskUsage() {
   claim  [--json]                                           take the next claimable task
   done   --id ID [--result R] [--attempts N]                finish it
   fail   --id ID [--result R] [--attempts N]                give up on it
+  cancel --id ID                                            (person) stop it, and every unfinished child with it
   progress --id ID --note "..."                             record how far you got (fed to the next run)
   block  --id ID --on human|children [--note "..."]         park it until answered / children finish
   answer --id ID --note "..."                               (person) unblock with an answer

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -759,14 +759,28 @@ func startCoordUpkeep(ctx context.Context, cdb *coord.DB, cfg *config.Config, bi
 		}
 	}()
 
-	if days := cfg.Coord.TraceRetentionDays; days > 0 {
+	// Retention. Trace spans and schedule runs age out on their own clocks;
+	// tasks and task_runs are the work ledger and are kept. Every gateway runs
+	// this — a DELETE below a cutoff is idempotent, so two of them are harmless.
+	traceDays, scheduleDays := cfg.Coord.TraceRetentionDays, cfg.Schedules.RunRetentionDays
+	if traceDays > 0 || scheduleDays > 0 {
 		go func() {
 			purge := func() {
-				n, err := cdb.PurgeRunsBefore(time.Now().AddDate(0, 0, -days))
-				if err != nil {
-					log.Printf("coord: purge traces: %v", err)
-				} else if n > 0 {
-					log.Printf("coord: purged %d trace rows older than %d days", n, days)
+				if traceDays > 0 {
+					n, err := cdb.PurgeRunsBefore(time.Now().AddDate(0, 0, -traceDays))
+					if err != nil {
+						log.Printf("coord: purge traces: %v", err)
+					} else if n > 0 {
+						log.Printf("coord: purged %d trace rows older than %d days", n, traceDays)
+					}
+				}
+				if scheduleDays > 0 {
+					n, err := cdb.PurgeScheduleRunsBefore(time.Now().AddDate(0, 0, -scheduleDays))
+					if err != nil {
+						log.Printf("coord: purge schedule runs: %v", err)
+					} else if n > 0 {
+						log.Printf("coord: purged %d schedule runs older than %d days", n, scheduleDays)
+					}
 				}
 			}
 			purge()

--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,7 @@ schedules:
   enabled: false
   tick_seconds: 30              # how often to look for due schedules
   command_timeout_seconds: 60   # cap on a --command payload (its --timeout overrides)
+  run_retention_days: 30        # finished schedule_runs older than this are purged (0 = keep forever)
 
 # Heartbeat (design §5.6): every `every`, this agent looks at its own scratchpad
 # (`bomclaw heartbeat scratch`) and acts only if a note asks for it. Costs

--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -91,28 +91,54 @@ function TaskCard({ task, kids, onOpen }: { task: Task; kids: { total: number; d
   )
 }
 
-function TaskDrawer({ call, id, onClose, onChanged, onOpenTask }: {
-  call: Call; id: string; onClose: () => void; onChanged: () => void; onOpenTask: (id: string) => void
+function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask }: {
+  call: Call; id: string; agents: string[]; onClose: () => void; onChanged: () => void; onOpenTask: (id: string) => void
 }) {
   const [detail, setDetail] = useState<TaskDetail | null>(null)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const [answer, setAnswer] = useState('')
+  const [childTitle, setChildTitle] = useState('')
+  const [childBody, setChildBody] = useState('')
+  const [childTo, setChildTo] = useState('')
 
-  useEffect(() => {
-    let cancelled = false
+  const load = useCallback(() => {
     call('tasks.get', { id })
-      .then((d: TaskDetail) => { if (!cancelled) setDetail(d) })
-      .catch((e: any) => { if (!cancelled) setErr(String(e?.message ?? e)) })
-    return () => { cancelled = true }
+      .then((d: TaskDetail) => setDetail(d))
+      .catch((e: any) => setErr(String(e?.message ?? e)))
   }, [call, id])
 
+  useEffect(() => { load() }, [load])
+
+  // Cancelling a parent cancels its unfinished children too — say so before
+  // doing it, since those may be running on another agent right now.
+  const openChildren = detail?.children?.filter(c => !['completed', 'failed', 'canceled', 'rejected'].includes(c.state)).length ?? 0
   const cancel = async () => {
+    if (openChildren > 0 && !confirm(`Cancel this task and its ${openChildren} unfinished child task${openChildren > 1 ? 's' : ''}?`)) return
     setBusy(true)
     try {
       await call('tasks.cancel', { id })
       onChanged()
       onClose()
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // A person splitting a piece off a task in flight: same path as the agent's
+  // `bomclaw task sub`, so the same rules apply — the cap, the depth, and a
+  // brief of its own, because whoever claims it has none of this conversation.
+  const addChild = async () => {
+    if (!childTitle.trim()) return
+    setBusy(true)
+    try {
+      await call('tasks.create', { title: childTitle.trim(), body: childBody.trim(), parent_id: id, assigned_to: childTo || undefined })
+      setChildTitle(''); setChildBody('')
+      setErr(null)
+      load()
+      onChanged()
     } catch (e: any) {
       setErr(String(e?.message ?? e))
     } finally {
@@ -255,6 +281,36 @@ function TaskDrawer({ call, id, onClose, onChanged, onOpenTask }: {
                 </div>
               )}
 
+              {open && (
+                <div className="rounded ring-1 ring-gray-800 bg-gray-900/40 p-2 space-y-1.5">
+                  <div className="flex gap-2 items-center">
+                    <span className="text-gray-600 text-xs shrink-0">↳ add child</span>
+                    <input
+                      value={childTitle}
+                      onChange={e => setChildTitle(e.target.value)}
+                      placeholder="a piece a peer could do in parallel…"
+                      className="flex-1 px-2 py-1 text-xs bg-gray-900 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
+                    />
+                    <select value={childTo} onChange={e => setChildTo(e.target.value)}
+                      className="px-2 py-1 text-xs bg-gray-900 rounded ring-1 ring-gray-800 text-gray-300 outline-none">
+                      <option value="">any agent</option>
+                      {agents.map(a => <option key={a} value={a}>{a}</option>)}
+                    </select>
+                    <button onClick={addChild} disabled={busy || !childTitle.trim()}
+                      className="px-2.5 py-1 text-xs rounded bg-gray-100 text-gray-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed">
+                      Add
+                    </button>
+                  </div>
+                  <textarea
+                    value={childBody}
+                    onChange={e => setChildBody(e.target.value)}
+                    rows={2}
+                    placeholder="its brief — what to do, where, what done looks like (whoever claims it has none of this task's conversation)"
+                    className="w-full px-2 py-1 text-xs bg-gray-900 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600 resize-none"
+                  />
+                </div>
+              )}
+
               {detail!.runs?.length > 0 && (
                 <div>
                   <div className="text-[11px] uppercase tracking-wider text-gray-600 mb-2">Runs</div>
@@ -345,8 +401,9 @@ function TaskDrawer({ call, id, onClose, onChanged, onOpenTask }: {
                 onClick={cancel}
                 disabled={busy}
                 className="px-3 py-1.5 text-sm rounded ring-1 ring-red-500/40 bg-red-500/10 text-red-300 hover:bg-red-500/20 disabled:opacity-50"
+                title={openChildren > 0 ? 'Its unfinished children are canceled with it' : undefined}
               >
-                Cancel task
+                {openChildren > 0 ? `Cancel task + ${openChildren} child${openChildren > 1 ? 'ren' : ''}` : 'Cancel task'}
               </button>
             )}
             {resumable && (
@@ -467,7 +524,7 @@ export default function TaskBoard({ call, agents }: { call: Call; agents: string
       </div>
 
       {openID && (
-        <TaskDrawer call={call} id={openID} onClose={() => setOpenID(null)} onChanged={load} onOpenTask={setOpenID} />
+        <TaskDrawer call={call} id={openID} agents={agents} onClose={() => setOpenID(null)} onChanged={load} onOpenTask={setOpenID} />
       )}
     </div>
   )

--- a/docs/design/scheduling-and-long-tasks.md
+++ b/docs/design/scheduling-and-long-tasks.md
@@ -401,8 +401,8 @@ P0 trước P1 vì lịch sinh ra task — task chưa "dài được, thấy đ�
 - **Spec không parse được** (TZ bị gỡ, lỗi dữ liệu) → tự `enabled=0` + báo, thay vì log lỗi mỗi 30s mãi.
 - Parser cron: `robfig/cron/v3` chuẩn 5 trường + descriptor (`@daily`, `@every 1h`); DOM và DOW cùng đặt → **OR** (ghi trong `schedule --help`).
 - `schedule run-now` chỉ đẩy `next_run_at = now`; gateway bắt ở tick kế (≤30s). RPC `schedules.run` có thêm poke vòng quét cục bộ nên từ dashboard là ngay.
-- Chưa có: purge `schedule_runs` theo tuổi (hàng nhỏ; thêm khi cần).
-- Dashboard (P1c): Go marshal `time.Time{}` thành `0001-01-01T00:00:00Z` (`omitempty` không bỏ struct zero) → `last_run_at`/`ended_at` rỗng tới UI như "739867d ago"; `format.ts` có `isZeroTime`/`rel` (hai chiều "in 3m"/"3m ago") thay cho `ago` chỉ-quá-khứ.
+- Purge `schedule_runs` theo tuổi: `schedules.run_retention_days` (mặc định 30, 0 = giữ mãi) — `PurgeScheduleRunsBefore` chạy cùng vòng 6h với purge trace trong `startCoordUpkeep`; **không xoá run `pending`** (đang chờ task; settle sẽ đóng khi task bị reap). `tasks`/`task_runs` là sổ cái, không purge.
+- Dashboard (P1c): Go marshal `time.Time{}` thành `0001-01-01T00:00:00Z` (`omitempty` không bỏ struct zero) → `last_run_at`/`ended_at` rỗng tới UI như "739867d ago"; `format.ts` có `isZeroTime`/`rel` (hai chiều "in 3m"/"3m ago") thay cho `ago` chỉ-quá-khứ. Phía Go sau đó đổi hai cột này sang `omitzero` (Go ≥1.24) nên JSON bỏ hẳn; UI vẫn giữ guard cho dữ liệu cũ.
 
 ### Ghi chú P1b (heartbeat)
 
@@ -418,11 +418,11 @@ P0 trước P1 vì lịch sinh ra task — task chưa "dài được, thấy đ�
 
 ## 9c. Ghi chú triển khai P2/P3
 
-- **Cha thức bằng sweep, không phải hook trong FinishRun của con.** Con kết thúc qua nhiều đường (FinishRun, CancelTask, ReapExhausted, người bấm trên dashboard); một câu hỏi "còn con nào chưa terminal không?" phủ hết. Runner gọi `WakeParents` ngay sau khi kết thúc run của một task có `parent_id` (độ trễ ~0 cho đường thường) và trong mỗi sweep (đường còn lại, ≤ poll interval). Cha bị cancel/fail bởi người trong lúc chờ: con vẫn chạy tới hết — chấp nhận, không cascade cancel (đơn giản, và kết quả con vẫn có ích).
+- **Cha thức bằng sweep, không phải hook trong FinishRun của con.** Con kết thúc qua nhiều đường (FinishRun, CancelTask, ReapExhausted, người bấm trên dashboard); một câu hỏi "còn con nào chưa terminal không?" phủ hết. Runner gọi `WakeParents` ngay sau khi kết thúc run của một task có `parent_id` (độ trễ ~0 cho đường thường) và trong mỗi sweep (đường còn lại, ≤ poll interval). Cha bị **cancel** (người, dashboard, `bomclaw task cancel`) → `CancelTaskTree` **cascade** xuống mọi hậu duệ chưa terminal (BFS, chặn bởi `MaxDepth`), event `canceled with parent <id>`; con đã xong giữ nguyên kết quả; con đang chạy trên agent khác: run kết thúc gặp task terminal → `FinishRun` ghi run, `ErrTaskFinished`, không ghi đè. Cha bị **fail** thì không cascade (fail là của hệ thống/agent, không phải ý người dừng việc).
 - Cha `block --on children` mà **không tạo con nào** → thức ngay với ghi chú "none were created" thay vì ngủ mãi.
 - `MaxOpenChildren` tính con chưa terminal, không phải tổng — cha có thể fan-out nhiều đợt.
 - P3: `claimAndRun` (đồng bộ) giữ cho test; loop dùng `claimAndStart` (goroutine + slot). Heartbeat "agent busy" đọc `deps.Runs` nên khi có task chạy song song heartbeat vẫn skip — đúng ý.
-- Chưa làm: cascade cancel con khi cha bị cancel; `tasks.create` từ dashboard với `parent_id`.
+- `tasks.create` nhận `parent_id` → đi `CreateSubTask` (cùng cap 8 con mở, cùng depth, cùng "cha phải còn mở"); TaskDrawer có ô "↳ add child" khi task còn mở; nút Cancel nói rõ "+ N children" và hỏi lại trước khi cascade. RPC `tasks.cancel` trả `children_canceled`.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,7 @@ type SchedulesConfig struct {
 	Enabled               bool `yaml:"enabled"`
 	TickSeconds           int  `yaml:"tick_seconds"`            // default 30
 	CommandTimeoutSeconds int  `yaml:"command_timeout_seconds"` // default 60; a payload's timeout_s overrides
+	RunRetentionDays      int  `yaml:"run_retention_days"`      // default 30; finished schedule_runs older than this are purged
 }
 
 // HeartbeatConfig (docs/design/scheduling-and-long-tasks.md §5.6). The
@@ -317,6 +318,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Schedules.CommandTimeoutSeconds == 0 {
 		cfg.Schedules.CommandTimeoutSeconds = 60
+	}
+	if cfg.Schedules.RunRetentionDays == 0 {
+		cfg.Schedules.RunRetentionDays = 30
 	}
 	if cfg.Heartbeat.Every == "" {
 		cfg.Heartbeat.Every = "30m"

--- a/internal/coord/cascade_test.go
+++ b/internal/coord/cascade_test.go
@@ -1,0 +1,125 @@
+package coord
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Cancelling a parent takes its unfinished descendants with it — grandchildren
+// too — and leaves finished ones as they are.
+func TestCancelTaskTreeCascadesToOpenDescendants(t *testing.T) {
+	db := testDB(t)
+	db.CreateTask(NewTask{CreatedBy: "human", Title: "Report", AssignedTo: "a1"})
+	parent, prun := claimStart(t, db, "a1")
+	mustSub := func(title string) *Task {
+		t.Helper()
+		c, err := db.CreateSubTask(parent.ID, "a1", NewTask{Title: title, AssignedTo: "a2",
+			Body: "Write the section " + title + " of the report: two paragraphs, cite the source, plain text."})
+		if err != nil {
+			t.Fatalf("sub %s: %v", title, err)
+		}
+		return c
+	}
+	c1, c2, c3 := mustSub("Part 1"), mustSub("Part 2"), mustSub("Part 3")
+	if err := db.BlockTask(parent.ID, "a1", parent.Attempts, BlockedOnChildren, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.FinishRun(prun.ID, RunOutcome{Liveness: RunBlocked, BlockedOn: BlockedOnChildren}); err != nil {
+		t.Fatal(err)
+	}
+
+	// c1 finishes; c2 is running on a2 and has a grandchild; c3 is queued.
+	t1, r1 := claimStart(t, db, "a2")
+	if t1.ID != c1.ID {
+		t.Fatal("precondition: c1 first")
+	}
+	db.FinishRun(r1.ID, RunOutcome{Liveness: RunCompleted, Result: "part 1 done"})
+	t2, r2 := claimStart(t, db, "a2")
+	if t2.ID != c2.ID {
+		t.Fatal("precondition: c2 second")
+	}
+	grand, err := db.CreateSubTask(c2.ID, "a2", NewTask{Title: "Part 2a",
+		Body: "Collect the figures for part 2 from the finance sheet and list them as a table."})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	canceled, err := db.CancelTaskTree(parent.ID, "human")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{c2.ID: true, c3.ID: true, grand.ID: true}
+	if len(canceled) != len(want) {
+		t.Fatalf("canceled %v, want c2, c3 and the grandchild", canceled)
+	}
+	for _, id := range canceled {
+		if !want[id] {
+			t.Errorf("unexpected cancel of %s", id)
+		}
+	}
+	for id, wantState := range map[string]string{parent.ID: TaskCanceled, c1.ID: TaskCompleted, c2.ID: TaskCanceled, c3.ID: TaskCanceled, grand.ID: TaskCanceled} {
+		got, _ := db.GetTask(id)
+		if got.State != wantState {
+			t.Errorf("%s: state %s, want %s", got.Title, got.State, wantState)
+		}
+	}
+	// The finished child keeps its result; the canceled ones say why.
+	if got, _ := db.GetTask(c1.ID); got.Result != "part 1 done" {
+		t.Errorf("finished child touched: %+v", got)
+	}
+	events, _ := db.TaskEvents(grand.ID)
+	if len(events) == 0 || !strings.Contains(events[len(events)-1].Note, "canceled with parent "+parent.ID) {
+		t.Errorf("grandchild should record why: %+v", events)
+	}
+	// The run still going on a2 closes against the canceled task, not over it.
+	if _, err := db.FinishRun(r2.ID, RunOutcome{Liveness: RunCompleted, Result: "too late"}); err != ErrTaskFinished {
+		t.Errorf("late finish: %v, want ErrTaskFinished", err)
+	}
+	if got, _ := db.GetTask(c2.ID); got.State != TaskCanceled || got.Result == "too late" {
+		t.Errorf("late result overwrote the cancel: %+v", got)
+	}
+	// Nothing is left for the parent to be woken by, and nothing is claimable.
+	if woken, _ := db.WakeParents(time.Now()); len(woken) != 0 {
+		t.Error("a canceled parent must not be woken")
+	}
+	if _, err := db.ClaimTask("a2"); err != ErrNoTask {
+		t.Errorf("claim after cascade: %v", err)
+	}
+	// Cancelling again is refused, and a leaf cancel cascades to nothing.
+	if _, err := db.CancelTaskTree(parent.ID, "human"); err == nil {
+		t.Error("second cancel should be refused")
+	}
+	leaf, _ := db.CreateTask(NewTask{CreatedBy: "h", Title: "leaf"})
+	if kids, err := db.CancelTaskTree(leaf.ID, "h"); err != nil || len(kids) != 0 {
+		t.Errorf("leaf cancel: %v %v", kids, err)
+	}
+}
+
+func TestPurgeScheduleRunsBeforeKeepsPendingAndRecent(t *testing.T) {
+	db := testDB(t)
+	s := newSchedule(t, db, "s", time.Now())
+	now := time.Now()
+	old := now.Add(-40 * 24 * time.Hour)
+	db.RecordScheduleRun(ScheduleRun{ScheduleID: s.ID, StartedAt: old, EndedAt: old, Status: ScheduleRunOK})
+	db.RecordScheduleRun(ScheduleRun{ScheduleID: s.ID, StartedAt: old, EndedAt: old, Status: ScheduleRunFailed})
+	db.RecordScheduleRun(ScheduleRun{ScheduleID: s.ID, TaskID: "t_x", StartedAt: old, Status: ScheduleRunPending})
+	db.RecordScheduleRun(ScheduleRun{ScheduleID: s.ID, StartedAt: now, EndedAt: now, Status: ScheduleRunOK})
+
+	n, err := db.PurgeScheduleRunsBefore(now.Add(-30 * 24 * time.Hour))
+	if err != nil || n != 2 {
+		t.Fatalf("purged %d (%v), want 2", n, err)
+	}
+	runs, _ := db.ScheduleRuns(s.ID, 10)
+	if len(runs) != 2 {
+		t.Fatalf("left %d runs, want the pending and the recent one", len(runs))
+	}
+	for _, r := range runs {
+		if r.Status != ScheduleRunPending && !r.StartedAt.After(now.Add(-time.Minute)) {
+			t.Errorf("wrong survivor: %+v", r)
+		}
+	}
+	if n, _ := db.PurgeScheduleRunsBefore(now.Add(-30 * 24 * time.Hour)); n != 0 {
+		t.Error("second purge should find nothing")
+	}
+}

--- a/internal/coord/schedules.go
+++ b/internal/coord/schedules.go
@@ -69,7 +69,7 @@ type Schedule struct {
 	System              bool            `json:"system"`
 	SkipMissed          bool            `json:"skip_missed"`
 	NextRunAt           time.Time       `json:"next_run_at"`
-	LastRunAt           time.Time       `json:"last_run_at,omitempty"`
+	LastRunAt           time.Time       `json:"last_run_at,omitzero"` // omitzero: omitempty never drops a struct
 	LastStatus          string          `json:"last_status,omitempty"`
 	ConsecutiveFailures int             `json:"consecutive_failures"`
 	CreatedAt           time.Time       `json:"created_at"`
@@ -113,7 +113,7 @@ type ScheduleRun struct {
 	ScheduleID string    `json:"schedule_id"`
 	TaskID     string    `json:"task_id,omitempty"`
 	StartedAt  time.Time `json:"started_at"`
-	EndedAt    time.Time `json:"ended_at,omitempty"`
+	EndedAt    time.Time `json:"ended_at,omitzero"`
 	Status     string    `json:"status"`
 	ExitCode   int       `json:"exit_code"`
 	Output     string    `json:"output,omitempty"`
@@ -580,6 +580,18 @@ func (db *DB) PendingScheduleRuns() ([]ScheduleRun, error) {
 	}
 	defer rows.Close()
 	return scanScheduleRuns(rows)
+}
+
+// PurgeScheduleRunsBefore deletes finished runs older than cutoff. Pending runs
+// stay whatever their age: they are waiting on a task, and settle() closes
+// them (as failed) once that task is reaped. Returns the rows removed.
+func (db *DB) PurgeScheduleRunsBefore(cutoff time.Time) (int64, error) {
+	res, err := db.conn.Exec(`DELETE FROM schedule_runs WHERE started_at < ? AND status != ?`,
+		ts(cutoff), ScheduleRunPending)
+	if err != nil {
+		return 0, fmt.Errorf("purge schedule runs: %w", err)
+	}
+	return res.RowsAffected()
 }
 
 // ScheduleRuns lists a schedule's firings, newest first.

--- a/internal/coord/tasks.go
+++ b/internal/coord/tasks.go
@@ -328,19 +328,72 @@ func (db *DB) AttachTrace(taskID, traceID string) error {
 	return err
 }
 
-// CancelTask stops a task from any non-terminal state. Used by the dashboard,
-// which is not the claiming agent and so carries no fencing token.
+// CancelTask stops a task from any non-terminal state — and every unfinished
+// descendant with it, see CancelTaskTree. Used by the dashboard and the CLI,
+// which are not the claiming agent and so carry no fencing token.
 func (db *DB) CancelTask(taskID, byAgent string) error {
-	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, updated_at = ?
+	_, err := db.CancelTaskTree(taskID, byAgent)
+	return err
+}
+
+// CancelTaskTree cancels a task and every unfinished descendant, and returns
+// the descendants it canceled. A canceled parent is never coming back for its
+// children's results, so work still queued or running for it would be spent
+// on nobody. A child that already finished is left alone — its result is
+// history, not waste. A running child's agent finds out at the end of its run:
+// FinishRun sees the terminal state and records the run against it.
+func (db *DB) CancelTaskTree(taskID, byAgent string) ([]string, error) {
+	now := ts(time.Now())
+	res, err := db.conn.Exec(`UPDATE tasks SET state = ?, blocked_on = '', updated_at = ?
 		WHERE id = ? AND state IN (?, ?, ?, ?)`,
-		TaskCanceled, ts(time.Now()), taskID, TaskSubmitted, TaskWorking, TaskInputRequired, TaskBlocked)
+		TaskCanceled, now, taskID, TaskSubmitted, TaskWorking, TaskInputRequired, TaskBlocked)
 	if err != nil {
-		return fmt.Errorf("cancel task: %w", err)
+		return nil, fmt.Errorf("cancel task: %w", err)
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
-		return fmt.Errorf("coord: task %s is already finished", taskID)
+		return nil, fmt.Errorf("coord: task %s is already finished", taskID)
 	}
-	return db.appendEvent(taskID, byAgent, "", TaskCanceled, "canceled")
+	_ = db.appendEvent(taskID, byAgent, "", TaskCanceled, "canceled")
+
+	// Breadth-first down the tree. RETURNING yields only the rows this
+	// statement flipped, so each level is exactly the children still open.
+	var canceled []string
+	frontier := []string{taskID}
+	for depth := 0; len(frontier) > 0 && depth < MaxDepth; depth++ {
+		var next []string
+		for _, parent := range frontier {
+			ids, err := db.cancelOpenChildren(parent, now)
+			if err != nil {
+				return canceled, err
+			}
+			next = append(next, ids...)
+		}
+		for _, id := range next {
+			_ = db.appendEvent(id, byAgent, "", TaskCanceled, "canceled with parent "+taskID)
+		}
+		canceled = append(canceled, next...)
+		frontier = next
+	}
+	return canceled, nil
+}
+
+func (db *DB) cancelOpenChildren(parentID, now string) ([]string, error) {
+	rows, err := db.conn.Query(`UPDATE tasks SET state = ?, blocked_on = '', updated_at = ?
+		WHERE parent_id = ? AND state IN (?, ?, ?, ?) RETURNING id`,
+		TaskCanceled, now, parentID, TaskSubmitted, TaskWorking, TaskInputRequired, TaskBlocked)
+	if err != nil {
+		return nil, fmt.Errorf("cancel children of %s: %w", parentID, err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return ids, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 // TaskFilter narrows a task listing.

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -233,6 +233,7 @@ type taskCreateParams struct {
 	Body       string `json:"body,omitempty"`
 	AssignedTo string `json:"assigned_to,omitempty"`
 	Priority   int    `json:"priority,omitempty"`
+	ParentID   string `json:"parent_id,omitempty"` // set: a child of that task, same rules as `bomclaw task sub`
 }
 
 func handleTaskCreate(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -243,15 +244,25 @@ func handleTaskCreate(deps Deps, params json.RawMessage) (json.RawMessage, error
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
-	// Depth stays 0: a task created from the dashboard is a human starting a
-	// chain, not an agent extending one.
-	task, err := deps.Coord.CreateTask(coord.NewTask{
+	n := coord.NewTask{
 		CreatedBy:  deps.AgentID,
 		AssignedTo: p.AssignedTo,
 		Title:      p.Title,
 		Body:       p.Body,
 		Priority:   p.Priority,
-	})
+	}
+	var task *coord.Task
+	var err error
+	if p.ParentID != "" {
+		// A person adding a piece to a task in flight. It inherits the parent's
+		// context and depth like a child the agent made, and counts against
+		// the same open-children cap.
+		task, err = deps.Coord.CreateSubTask(p.ParentID, deps.AgentID, n)
+	} else {
+		// Depth stays 0: a task created from the dashboard is a human starting
+		// a chain, not an agent extending one.
+		task, err = deps.Coord.CreateTask(n)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -269,10 +280,13 @@ func handleTaskCancel(deps Deps, params json.RawMessage) (json.RawMessage, error
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, fmt.Errorf("invalid params: %w", err)
 	}
-	if err := deps.Coord.CancelTask(p.ID, deps.AgentID); err != nil {
+	// Cancelling a parent takes its unfinished children with it; the count
+	// comes back so the dashboard can say what actually stopped.
+	children, err := deps.Coord.CancelTaskTree(p.ID, deps.AgentID)
+	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(map[string]bool{"canceled": true})
+	return json.Marshal(map[string]any{"canceled": true, "children_canceled": len(children)})
 }
 
 // --- shared notes ----------------------------------------------------------


### PR DESCRIPTION
## Ba việc còn lại của P2 (design §9c)

### 1. Cascade cancel con khi cha bị cancel
- `coord.CancelTaskTree(taskID, by) ([]string, error)`: cancel task rồi **BFS xuống mọi hậu duệ chưa terminal** (submitted/working/blocked/input-required), chặn bởi `MaxDepth`; mỗi tầng là một `UPDATE … RETURNING id` nên chỉ đụng đúng các con còn mở. Event `canceled with parent <id>` trên từng con. `CancelTask` giữ chữ ký cũ, giờ gọi qua đây.
- Con đã xong giữ nguyên kết quả. Con **đang chạy trên agent khác**: run kết thúc gặp task terminal → `FinishRun` ghi run + `ErrTaskFinished`, không ghi đè (test kiểm chứng). Cha bị **fail** thì không cascade — fail là của hệ thống/agent, không phải người dừng việc.
- RPC `tasks.cancel` trả `children_canceled`; CLI mới `bomclaw task cancel --id T` in số con bị dừng; TaskDrawer nút Cancel đổi thành "Cancel task + N children" và `confirm()` trước khi cascade.

### 2. Tạo task có `parent_id` từ dashboard
- `tasks.create` nhận `parent_id` → đi `CreateSubTask` (cùng luật với `bomclaw task sub`: cha phải còn mở, cap 8 con chưa xong, depth kế thừa, và **brief ≥ 40 ký tự** theo luật mới trên main).
- TaskDrawer: ô **"↳ add child"** (title + agent + textarea brief) hiện khi task còn mở; lỗi từ gateway (thiếu brief, quá cap) hiện inline; tạo xong drawer reload tại chỗ.

### 3. Purge `schedule_runs` theo tuổi
- `schedules.run_retention_days` (mặc định **30**, 0 = giữ mãi). `PurgeScheduleRunsBefore` chạy cùng vòng 6h với purge trace trong `startCoordUpkeep` (vòng giờ chạy khi *một trong hai* retention > 0). **Không xoá run `pending`** — đang chờ task, `settle()` sẽ đóng khi task bị reap. `tasks`/`task_runs` là sổ cái, không purge.
- Tiện thể: `Schedule.LastRunAt` / `ScheduleRun.EndedAt` chuyển `omitempty` → **`omitzero`** (Go ≥1.24) nên JSON bỏ hẳn `0001-01-01…`; UI vẫn giữ guard `isZeroTime` cho dữ liệu cũ.

### Test
`go test ./...` xanh. Mới: `TestCancelTaskTreeCascadesToOpenDescendants` (con xong giữ nguyên; con đang chạy + cháu bị cancel; run trễ không ghi đè; `WakeParents` không đánh thức cha đã cancel; cancel lần 2 bị từ chối; leaf cascade rỗng), `TestPurgeScheduleRunsBeforeKeepsPendingAndRecent`.

### Deploy
Có thay đổi Go + dashboard → deploy đầy đủ (build + copy dist + restart 2 gateway). Config live không cần đổi (mặc định 30 ngày).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
