### PR TITLE
fix(dashboard): one press, one line in the channel

### DIFF
--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -24,6 +24,7 @@ export default function ChannelView({ call, agents, selfID }: {
   const [body, setBody] = useState('')
   const [as, setAs] = useState<string>(OWNER)
   const [err, setErr] = useState<string | null>(null)
+  const sending = useRef(false)
   const bottom = useRef<HTMLDivElement>(null)
 
   const loadChannels = useCallback(async () => {
@@ -86,9 +87,13 @@ export default function ChannelView({ call, agents, selfID }: {
     call('channels.read', { channel_id: active }).then(loadChannels).catch(() => {})
   }, [active, call, loadChannels])
 
+  // One post per press. The body is only cleared once the round trip is over,
+  // so without this latch a second Enter arriving before the reply re-sends the
+  // same text — which is how the room ended up with a line in it twice.
   const post = async () => {
     const text = body.trim()
-    if (!text || !active) return
+    if (!text || !active || sending.current) return
+    sending.current = true
     try {
       await call('channels.post', {
         channel_id: active, body: text, as,
@@ -100,6 +105,8 @@ export default function ChannelView({ call, agents, selfID }: {
       else bottom.current?.scrollIntoView({ behavior: 'smooth' })
     } catch (e: any) {
       setErr(String(e?.message ?? e))
+    } finally {
+      sending.current = false
     }
   }
 
@@ -261,7 +268,13 @@ function Composer({ value, onChange, onSend, as, setAs, agents, replyingTo, onCa
         <input
           value={value}
           onChange={e => onChange(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend() } }}
+          // Enter while an IME is composing commits the candidate — Vietnamese,
+          // Japanese, Korean — and is not a send. Chrome reports that press as
+          // keyCode 229; isComposing covers the rest.
+          onKeyDown={e => {
+            if (e.nativeEvent.isComposing || e.keyCode === 229) return
+            if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend() }
+          }}
           placeholder="Message the channel — @agent to wake one"
           className="flex-1 px-3 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
         />


### PR DESCRIPTION
Closes #111

## Triệu chứng

`ch_general` có hai dòng `hi bạn` giống hệt nhau, cách nhau **18 micro giây**:

```
cm_e5d76658…  bomclaw2  2026-09-12T13:56:58.801450000Z
cm_81a38785…  bomclaw2  2026-09-12T13:56:58.801468000Z
```

18µs không phải hai lần bấm của người — đó là hai WS frame rời trình duyệt trong cùng một tick. Phía server sạch: `handleWS` đọc một frame dispatch một lần, `PostMessage` chèn một hàng.

## Hai lỗ, không phải một

**Không có latch.** `post()` chỉ `setBody('')` sau khi `await` xong, nên Enter thứ hai đến trước round-trip sẽ gửi lại nguyên văn. `ChatView.tsx:47` có `sending` guard từ đầu; composer của kênh không bao giờ được cấp một cái.

**Không lọc IME.** `onKeyDown` chỉ nhìn `e.key === 'Enter'`. Gõ tiếng Việt thì Enter còn dùng để chốt ký tự đang soạn — cũng bị tính là gửi. Chrome báo phím đó là `keyCode 229`, phần còn lại do `isComposing` bắt. Không chỗ nào trong `dashboard/src` kiểm tra hai thứ này.

## Kiểm chứng

- `npx tsc --noEmit` sạch
- Thủ công: gõ tiếng Việt có dấu rồi Enter → một dòng; giữ Enter khi mạng chậm → một dòng

Một hàng `hi bạn` thừa trong `coord.db` vẫn cần xoá tay — dữ liệu đã ghi rồi, bản vá này chỉ chặn lần sau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)