### PR TITLE
feat(channel): a mention becomes a chat turn

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -500,6 +500,16 @@ func runGateway(args []string) {
 		// channels share one execution path: CLI tool loop, memory, trace.
 		deps.Turn = tgBot.Handler()
 	}
+
+	// Answering a mention is a chat turn, not a task: it needs the turn engine
+	// above, so the watcher is built after it. Nil when this gateway has no
+	// shared database or no engine — Start and Poke are no-ops then.
+	var mentions *gateway.MentionWatcher
+	if cfg.Coord.AnswersMentions() {
+		mentions = gateway.NewMentionWatcher(deps)
+	} else {
+		log.Printf("mentions: answering off (coord.reply_to_mentions=false)")
+	}
 	// Everything running right now, from both sources: chat turns and claimed
 	// tasks. The tray's awake-while-running mode, `bomclaw status` and the
 	// dashboard all read this list — a task run missing from it meant the Mac
@@ -537,8 +547,21 @@ func runGateway(args []string) {
 				TaskID:    strings.TrimPrefix(s.ID, "task_"),
 			})
 		}
+		for _, s := range mentions.Live() {
+			info := s.RunInfo()
+			out = append(out, gateway.RunInfo{
+				ChatID:    s.ChatID,
+				SessionID: s.ID,
+				Task:      info.CurrentTask,
+				LastTool:  info.LastTool,
+				ToolCount: info.ToolCount,
+				StartedAt: info.StartedAt.Format(time.RFC3339),
+				Kind:      "channel",
+			})
+		}
 		return out
 	}
+	mentions.Start(ctx)
 	if sched != nil {
 		sched.SetBusy(func() bool { return len(deps.Runs()) > 0 })
 		sched.Start(ctx)
@@ -586,7 +609,13 @@ func runGateway(args []string) {
 		// is on by default, so every cross-agent poke was a 401. Mounted even
 		// when this agent does not claim tasks (runner nil → Poke is a no-op),
 		// so a peer never gets a 404 for ringing.
-		srv.Handle("/api/tasks/poke", authMgr.RequireAuthExceptLocal(gateway.PokeHandler(runner.Poke)))
+		// One doorbell, two listeners: work waiting in the queue and a line
+		// with this agent's name in it arrive the same way, and the ringer
+		// should not have to know which it is.
+		srv.Handle("/api/tasks/poke", authMgr.RequireAuthExceptLocal(gateway.PokeHandler(func() {
+			runner.Poke()
+			mentions.Poke()
+		})))
 	}
 
 	// Start Telegram bot polling in background.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,17 @@ type CoordConfig struct {
 	NotesFile          string `yaml:"notes_file"`           // default ~/goterm-shared/NOTES.md
 	ArtifactsDir       string `yaml:"artifacts_dir"`        // default ~/goterm-shared/artifacts
 	TraceRetentionDays int    `yaml:"trace_retention_days"` // default 7; 0 disables the purge
+
+	// ReplyToMentions is whether being named in a channel makes this agent run
+	// a turn and answer. Pointer for the same reason as Enabled: absent means
+	// on. Turning it off leaves the room readable and the mention recorded —
+	// only the answering stops, which is what an agent kept for scheduled work
+	// alone wants.
+	ReplyToMentions *bool `yaml:"reply_to_mentions"`
 }
+
+// AnswersMentions reports whether a mention of this agent becomes a chat turn.
+func (c CoordConfig) AnswersMentions() bool { return c.ReplyToMentions == nil || *c.ReplyToMentions }
 
 // IsEnabled reports whether the shared coordination database should be opened.
 func (c CoordConfig) IsEnabled() bool { return c.Enabled == nil || *c.Enabled }

--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -1,6 +1,7 @@
 package coord
 
 import (
+	"database/sql"
 	"fmt"
 	"regexp"
 	"sort"
@@ -554,6 +555,70 @@ func (db *DB) MarkMentionsRead(memberKind, memberID string, messageIDs []string)
 		return 0, fmt.Errorf("mark mentions read: %w", err)
 	}
 	return res.RowsAffected()
+}
+
+// ThreadKey names the conversation a message belongs to: the thread it is in,
+// or the thread it starts. Two threads in one room are two conversations, and
+// an agent must not answer one while remembering the other.
+//
+// A top-level message keys on its own id rather than on the channel, because a
+// reply to it goes into a thread rooted there — key it by the channel and the
+// answer to a line and the follow-up under that same line land in two
+// different conversations, which is a conversation with amnesia every other
+// turn.
+func ThreadKey(m ChannelMessage) string {
+	if m.ThreadRoot != "" {
+		return m.ThreadRoot
+	}
+	return m.ID
+}
+
+// ThreadSession is what an agent remembers of one conversation: the CLI
+// session to resume, and how many turns it has already spent there.
+type ThreadSession struct {
+	ThreadKey string
+	AgentID   string
+	Provider  string
+	SessionID string
+	Turns     int
+	UpdatedAt time.Time
+}
+
+// GetThreadSession returns the agent's memory of a thread. A thread nobody has
+// answered yet is not an error — it is a zero-value row, which is what the
+// first turn wants.
+func (db *DB) GetThreadSession(threadKey, agentID string) (*ThreadSession, error) {
+	row := db.conn.QueryRow(`SELECT thread_key, agent_id, provider, session_id, turns, updated_at
+		FROM channel_sessions WHERE thread_key = ? AND agent_id = ?`, threadKey, agentID)
+	var t ThreadSession
+	var updated string
+	switch err := row.Scan(&t.ThreadKey, &t.AgentID, &t.Provider, &t.SessionID, &t.Turns, &updated); {
+	case err == sql.ErrNoRows:
+		return &ThreadSession{ThreadKey: threadKey, AgentID: agentID}, nil
+	case err != nil:
+		return nil, fmt.Errorf("thread session %s/%s: %w", threadKey, agentID, err)
+	}
+	t.UpdatedAt = parseTS(updated)
+	return &t, nil
+}
+
+// SaveThreadSession records the session the turn ran under and counts the turn.
+// Turns is incremented here rather than by the caller so the cap cannot be
+// skipped by a code path that forgets.
+func (db *DB) SaveThreadSession(threadKey, agentID, provider, sessionID string) error {
+	_, err := db.conn.Exec(`INSERT INTO channel_sessions
+		(thread_key, agent_id, provider, session_id, turns, updated_at)
+		VALUES (?, ?, ?, ?, 1, ?)
+		ON CONFLICT(thread_key, agent_id) DO UPDATE SET
+			provider   = excluded.provider,
+			session_id = excluded.session_id,
+			turns      = channel_sessions.turns + 1,
+			updated_at = excluded.updated_at`,
+		threadKey, agentID, provider, sessionID, ts(time.Now()))
+	if err != nil {
+		return fmt.Errorf("save thread session %s/%s: %w", threadKey, agentID, err)
+	}
+	return nil
 }
 
 func (db *DB) getMessage(id string) (*ChannelMessage, error) {

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -26,7 +26,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 6
+const schemaVersion = 7
 
 // DB is the shared coordination database.
 type DB struct {
@@ -379,6 +379,24 @@ var ddl = []string{
 		PRIMARY KEY (message_id, member_kind, member_id)
 	) STRICT`,
 	`CREATE INDEX IF NOT EXISTS idx_channel_mentions_unread ON channel_mentions(member_kind, member_id, read_at, created_at DESC)`,
+
+	// What an agent remembers of a thread. A mention is answered by a chat turn,
+	// and a chat turn that forgets the last one is not a conversation — so the
+	// CLI session the agent used is kept here and resumed next time, the way
+	// tasks.session_ref keeps a task's own thread of thought across runs.
+	//
+	// Keyed by thread rather than by channel: two threads in one room are two
+	// conversations, and Slack's own model says so. turns is the loop stop —
+	// nothing inside a conversation ever says "enough".
+	`CREATE TABLE IF NOT EXISTS channel_sessions (
+		thread_key TEXT NOT NULL,             -- thread_root, or channel_id for the main line
+		agent_id   TEXT NOT NULL,
+		provider   TEXT NOT NULL DEFAULT '',
+		session_id TEXT NOT NULL DEFAULT '',
+		turns      INTEGER NOT NULL DEFAULT 0,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (thread_key, agent_id)
+	) STRICT`,
 }
 
 // v3Columns are the columns added to tasks after it first shipped. CREATE TABLE

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -1,0 +1,312 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+// Answering a mention.
+//
+// Posting already recorded the mention and rang the named agent's doorbell.
+// What nothing did was convert "you were named" into "run a turn": the
+// doorbell wakes the claim loop, and the claim loop only reads the tasks
+// table, so an agent sat awake beside an unread mention forever.
+//
+// The conversion here is deliberately a CHAT turn and not a task. A task is a
+// unit of work on a board, with a lease, attempts and a result; answering
+// "are you there" is none of those, and a board that fills up with greetings
+// stops showing the work. More to the point, every task run is its own prompt:
+// an agent answering that way would not remember what it said a minute ago,
+// which is the one thing a conversation requires. So a mention runs through
+// the same turn engine Telegram and the dashboard use, under a session kept
+// per thread — and work that turns out to be real gets a task of its own,
+// opened by the agent, which is where the board belongs.
+const (
+	// channelChatID namespaces channel sessions away from real Telegram chats
+	// and from task sessions (-1), so nothing in the session manager collides.
+	channelChatID = -2
+
+	// MaxThreadTurns caps one conversation. A names B, B answers naming A,
+	// and neither is misbehaving — there is simply nothing inside a
+	// conversation that says stop, so the stop has to be a number.
+	MaxThreadTurns = 6
+
+	// MentionsPerSweep keeps an agent back from an outage from waking into a
+	// hundred turns at once.
+	MentionsPerSweep = 5
+
+	// StaleMention is where answering becomes worse than not answering.
+	// Replying to yesterday's "are you there" is its own kind of broken.
+	StaleMention = 24 * time.Hour
+
+	// mentionPoll is the fallback for a doorbell that never rang — a peer
+	// that was down, a poke that lost its race with this process starting.
+	mentionPoll = 30 * time.Second
+
+	// mentionTurnTimeout bounds one reply. A channel turn is a conversation,
+	// not a task: if it needs longer than this it needs a task.
+	mentionTurnTimeout = 3 * time.Minute
+)
+
+// MentionWatcher answers the mentions addressed to one agent.
+type MentionWatcher struct {
+	deps Deps
+	poke chan struct{}
+	mu   sync.Mutex // one turn at a time; the engine queues anyway, this keeps sweeps honest
+	live sync.Map   // message id -> *session.Session, for StatusResult.Runs
+}
+
+// NewMentionWatcher returns nil when this gateway cannot answer — no shared
+// database, or no turn engine — so the caller can start it unconditionally.
+func NewMentionWatcher(deps Deps) *MentionWatcher {
+	if deps.Coord == nil || deps.Turn == nil || deps.AgentID == "" {
+		return nil
+	}
+	return &MentionWatcher{deps: deps, poke: make(chan struct{}, 1)}
+}
+
+// Poke asks for a sweep now. Non-blocking and coalescing: two mentions
+// arriving together are one sweep, and a full channel means a sweep is
+// already coming.
+func (w *MentionWatcher) Poke() {
+	if w == nil {
+		return
+	}
+	select {
+	case w.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Live is the channel turns running right now. Everything that runs has to be
+// visible from one place: the tray reads it to keep the Mac awake, and a reply
+// the Mac slept through is a reply nobody got.
+func (w *MentionWatcher) Live() []*session.Session {
+	if w == nil {
+		return nil
+	}
+	var out []*session.Session
+	w.live.Range(func(_, v any) bool {
+		out = append(out, v.(*session.Session))
+		return true
+	})
+	return out
+}
+
+// Start runs sweeps until ctx ends.
+func (w *MentionWatcher) Start(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	log.Printf("mentions: answering mentions of %s in channels", w.deps.AgentID)
+	go func() {
+		t := time.NewTicker(mentionPoll)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			case <-w.poke:
+			}
+			w.sweep(ctx)
+		}
+	}()
+}
+
+// sweep answers every unread mention of this agent. Each agent reads only its
+// own mentions, so two gateways never race for one and no locking is needed
+// beyond this process.
+func (w *MentionWatcher) sweep(ctx context.Context) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	msgs, err := w.deps.Coord.UnreadMentions(coord.MemberAgent, w.deps.AgentID, MentionsPerSweep)
+	if err != nil {
+		log.Printf("mentions: read unread: %v", err)
+		return
+	}
+	// Oldest first: a conversation answered backwards is not a conversation.
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if ctx.Err() != nil {
+			return
+		}
+		w.answer(ctx, msgs[i])
+	}
+}
+
+// answer runs one turn for one mention and posts the reply where the mention
+// was. Every exit path clears the mention: a mention that stays unread after
+// being looked at would be answered again on the next sweep, forever.
+func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
+	clear := func(why string) {
+		if _, err := w.deps.Coord.MarkMentionsRead(coord.MemberAgent, w.deps.AgentID, []string{m.ID}); err != nil {
+			log.Printf("mentions: clear %s: %v", m.ID, err)
+		}
+		if why != "" {
+			log.Printf("mentions: %s (%s)", why, m.ID)
+		}
+	}
+
+	if age := time.Since(m.CreatedAt); age > StaleMention {
+		clear(fmt.Sprintf("skipped a mention %s old", age.Round(time.Hour)))
+		return
+	}
+
+	key := coord.ThreadKey(m)
+	mem, err := w.deps.Coord.GetThreadSession(key, w.deps.AgentID)
+	if err != nil {
+		log.Printf("mentions: thread session %s: %v", key, err)
+		return
+	}
+	if mem.Turns >= MaxThreadTurns {
+		clear(fmt.Sprintf("thread %s is at its %d-turn cap", key, MaxThreadTurns))
+		return
+	}
+
+	sess := session.New(channelChatID)
+	sess.ID = "ch_" + key
+	// Resuming is what makes turn 2 remember turn 1. A ref from the other CLI
+	// — after a provider switch — is simply not used; only the CLI that owns
+	// a session can resume it.
+	if mem.SessionID != "" && mem.Provider == w.deps.ProviderName {
+		sess.SetSessionID(mem.SessionID)
+		sess.SetProvider(mem.Provider)
+	}
+
+	turnCtx, cancel := context.WithTimeout(ctx, mentionTurnTimeout)
+	defer cancel()
+
+	sink := &replySink{}
+	sess.MarkRunning("channel: " + truncateLine(m.Body, 40))
+	w.live.Store(m.ID, sess)
+	_, err = w.deps.Turn.RunTurn(turnCtx, sess, sess.ChatID, w.model(), w.prompt(m, mem), sink)
+	sess.MarkIdle()
+	w.live.Delete(m.ID)
+	if err != nil {
+		log.Printf("mentions: turn for %s: %v", m.ID, err)
+		clear("")
+		return
+	}
+
+	reply := strings.TrimSpace(sink.Text())
+	if reply == "" {
+		clear("turn produced nothing to say")
+		return
+	}
+
+	// The reply belongs where the mention was: in the thread if the mention was
+	// in one, otherwise starting a thread under it — so the main line stays
+	// readable and the exchange stays in one place. That place is the same key
+	// the session is kept under, which is what makes the next turn remember.
+	if _, wake, err := w.deps.Coord.PostMessage(coord.NewChannelMessage{
+		ChannelID:  m.ChannelID,
+		ThreadRoot: key,
+		AuthorKind: coord.MemberAgent,
+		AuthorID:   w.deps.AgentID,
+		Body:       reply,
+	}); err != nil {
+		log.Printf("mentions: post reply to %s: %v", m.ChannelID, err)
+	} else {
+		for _, who := range wake {
+			NotifyAgents(w.deps.Coord, who, "", "about a mention in "+m.ChannelID)
+		}
+	}
+
+	if err := w.deps.Coord.SaveThreadSession(key, w.deps.AgentID, w.deps.ProviderName, sess.GetSessionID()); err != nil {
+		log.Printf("mentions: save thread session %s: %v", key, err)
+	}
+	clear("")
+}
+
+func (w *MentionWatcher) model() string {
+	if w.deps.Resolver == nil {
+		return ""
+	}
+	return w.deps.Resolver.Default()
+}
+
+// prompt carries the three things the agent cannot look up: what was said and
+// by whom, that its reply is posted into this thread rather than spoken to a
+// user, and what to do when the ask turns out to be bigger than a reply.
+func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession) string {
+	var b strings.Builder
+	channel := m.ChannelID
+	if c, err := w.deps.Coord.GetChannel(m.ChannelID); err == nil {
+		channel = "#" + c.Name
+	}
+
+	if mem.Turns > 0 {
+		fmt.Fprintf(&b, "You were named again in %s (your turn %d of %d in this thread).\n\n",
+			channel, mem.Turns+1, MaxThreadTurns)
+	} else {
+		fmt.Fprintf(&b, "You were named in %s, a room you share with the other agents and the owner.\n\n", channel)
+	}
+
+	// A thread has a history the model may not have seen — it may have been
+	// answered by another agent, or by this one before a restart.
+	if m.ThreadRoot != "" {
+		if thread, err := w.deps.Coord.ThreadMessages(m.ThreadRoot); err == nil && len(thread) > 1 {
+			b.WriteString("## The thread so far\n\n")
+			for _, t := range thread {
+				if t.ID == m.ID {
+					continue
+				}
+				fmt.Fprintf(&b, "- %s: %s\n", t.AuthorID, truncateLine(t.Body, 400))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	fmt.Fprintf(&b, "## %s said\n\n%s\n\n", m.AuthorID, strings.TrimSpace(m.Body))
+
+	b.WriteString("## How to answer\n\n")
+	b.WriteString("Reply in plain prose. What you write is posted into that thread as your " +
+		"message — it is not spoken to a user in a chat window, and nobody sees a preamble " +
+		"about what you are about to do.\n")
+	b.WriteString("Name an agent with @ only when you actually need it to act: @ is a doorbell " +
+		"and wakes that agent.\n")
+	b.WriteString("If this asks for real work — something with steps, or longer than a few " +
+		"minutes — say so briefly and open a task for it with `bomclaw task new`. The board is " +
+		"for work; this room is for talking about it.\n")
+	return b.String()
+}
+
+// replySink collects a turn's text. A channel has no stream to write to: the
+// reply is one message, posted when the turn is done.
+type replySink struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (r *replySink) Write(chunk string) {
+	r.mu.Lock()
+	r.b.WriteString(chunk)
+	r.mu.Unlock()
+}
+
+func (r *replySink) Text() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.b.String()
+}
+
+func (r *replySink) NoteTool(string)          {}
+func (r *replySink) Flush()                   {}
+func (r *replySink) SendPhoto(string, string) {}
+func (r *replySink) Finalize()                {}
+
+func truncateLine(s string, n int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if len([]rune(s)) <= n {
+		return s
+	}
+	return string([]rune(s)[:n]) + "…"
+}

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -1,0 +1,234 @@
+package gateway
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+// recordingTurn answers every turn with a fixed reply and remembers what it was
+// asked, including the session it ran under — which is how these tests see
+// whether the thread's conversation was resumed.
+type recordingTurn struct {
+	mu       sync.Mutex
+	calls    int
+	prompts  []string
+	sessions []string
+	resumed  []string
+	reply    string
+	newID    string
+}
+
+func (r *recordingTurn) RunTurn(ctx context.Context, sess *session.Session, chatID int64,
+	modelID, userText string, sink TurnSink) (*execution.RunResult, error) {
+	r.mu.Lock()
+	r.calls++
+	r.prompts = append(r.prompts, userText)
+	r.sessions = append(r.sessions, sess.ID)
+	r.resumed = append(r.resumed, sess.GetSessionID())
+	reply, newID := r.reply, r.newID
+	r.mu.Unlock()
+
+	if newID != "" {
+		sess.SetSessionID(newID) // the CLI hands back the session it just wrote
+	}
+	sink.Write(reply)
+	return &execution.RunResult{SessionID: sess.ID, Status: execution.RunSuccess}, nil
+}
+
+func (r *recordingTurn) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func mentionTestDeps(t *testing.T, turn *recordingTurn) (Deps, *coord.DB) {
+	t.Helper()
+	cdb, err := coord.Open(filepath.Join(t.TempDir(), "coord.db"))
+	if err != nil {
+		t.Fatalf("coord: %v", err)
+	}
+	t.Cleanup(func() { cdb.Close() })
+	for _, id := range []string{"bomclaw", "bomclaw2"} {
+		if err := cdb.RegisterAgent(coord.Agent{ID: id, DisplayName: id, WSAddr: "ws://127.0.0.1:0/ws"}); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+	}
+	return Deps{Coord: cdb, Turn: turn, AgentID: "bomclaw2", ProviderName: "claude"}, cdb
+}
+
+// TestMentionBecomesAChatTurn is the acceptance test of the whole feature:
+// naming an agent must produce an answer in the room, not silence — and not a
+// task, which is what the first attempt at this did.
+func TestMentionBecomesAChatTurn(t *testing.T) {
+	turn := &recordingTurn{reply: "chào, mình đây", newID: "sess-1"}
+	deps, cdb := mentionTestDeps(t, turn)
+
+	m, wake, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 chào bạn",
+	})
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if len(wake) != 1 || wake[0] != "bomclaw2" {
+		t.Fatalf("expected bomclaw2 to be woken, got %v", wake)
+	}
+
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if turn.count() != 1 {
+		t.Fatalf("expected exactly one turn, got %d", turn.count())
+	}
+	if !strings.Contains(turn.prompts[0], "chào bạn") {
+		t.Fatalf("prompt did not carry what was said:\n%s", turn.prompts[0])
+	}
+
+	// The reply is in the room, in a thread under the line that named it.
+	thread, err := cdb.ThreadMessages(m.ID)
+	if err != nil {
+		t.Fatalf("thread: %v", err)
+	}
+	if len(thread) != 2 {
+		t.Fatalf("expected the mention and one reply, got %d messages", len(thread))
+	}
+	if thread[1].Body != "chào, mình đây" || thread[1].AuthorID != "bomclaw2" {
+		t.Fatalf("unexpected reply: %+v", thread[1])
+	}
+
+	// And the summons is cleared, or the next sweep answers it again forever.
+	left, err := cdb.UnreadMentions(coord.MemberAgent, "bomclaw2", 10)
+	if err != nil {
+		t.Fatalf("unread: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("mention still unread after being answered: %v", left)
+	}
+}
+
+// TestSecondTurnInAThreadResumesTheFirst is the difference between a
+// conversation and two strangers: turn 2 must run on the session turn 1 left.
+func TestSecondTurnInAThreadResumesTheFirst(t *testing.T) {
+	turn := &recordingTurn{reply: "ừ", newID: "sess-1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	w := NewMentionWatcher(deps)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 xem hộ log",
+	})
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	w.sweep(context.Background())
+
+	// A follow-up inside the same thread.
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 thế còn dòng cuối?",
+	}); err != nil {
+		t.Fatalf("follow-up: %v", err)
+	}
+	w.sweep(context.Background())
+
+	if turn.count() != 2 {
+		t.Fatalf("expected two turns, got %d", turn.count())
+	}
+	if turn.sessions[0] != turn.sessions[1] {
+		t.Fatalf("thread ran under two different sessions: %s then %s", turn.sessions[0], turn.sessions[1])
+	}
+	if turn.resumed[0] != "" {
+		t.Fatalf("first turn resumed something: %q", turn.resumed[0])
+	}
+	if turn.resumed[1] != "sess-1" {
+		t.Fatalf("second turn did not resume the first: %q", turn.resumed[1])
+	}
+}
+
+// TestThreadStopsAtTheTurnCap: A names B, B answers naming A, and nothing in a
+// conversation ever says stop. The cap is the stop.
+func TestThreadStopsAtTheTurnCap(t *testing.T) {
+	turn := &recordingTurn{reply: "vẫn đây", newID: "sess-1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	w := NewMentionWatcher(deps)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 bắt đầu",
+	})
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	for i := 0; i < MaxThreadTurns+3; i++ {
+		if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+			ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID,
+			AuthorKind: coord.MemberAgent, AuthorID: "bomclaw",
+			Body: "@bomclaw2 còn đó không",
+		}); err != nil {
+			t.Fatalf("post %d: %v", i, err)
+		}
+		w.sweep(context.Background())
+	}
+	if turn.count() != MaxThreadTurns {
+		t.Fatalf("expected the thread to stop at %d turns, ran %d", MaxThreadTurns, turn.count())
+	}
+}
+
+// TestStaleMentionIsClearedNotAnswered: answering yesterday's "are you there"
+// is worse than not answering it.
+func TestStaleMentionIsClearedNotAnswered(t *testing.T) {
+	turn := &recordingTurn{reply: "muộn rồi"}
+	deps, cdb := mentionTestDeps(t, turn)
+
+	m, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 còn thức không",
+	})
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	old := time.Now().Add(-StaleMention - time.Hour).UTC().Format(time.RFC3339Nano)
+	if _, err := cdb.Conn().Exec(`UPDATE channel_messages SET created_at = ? WHERE id = ?`, old, m.ID); err != nil {
+		t.Fatalf("age the message: %v", err)
+	}
+
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if turn.count() != 0 {
+		t.Fatalf("a day-old mention was answered")
+	}
+	left, err := cdb.UnreadMentions(coord.MemberAgent, "bomclaw2", 10)
+	if err != nil {
+		t.Fatalf("unread: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatal("stale mention was left unread, so every sweep will look at it again")
+	}
+}
+
+// TestPlainLineWakesNobody guards the shape of the feature: visibility and
+// attention stay separate, so three agents in a room do not wake each other on
+// every line.
+func TestPlainLineWakesNobody(t *testing.T) {
+	turn := &recordingTurn{reply: "không nên nói gì"}
+	deps, cdb := mentionTestDeps(t, turn)
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "hi bạn",
+	}); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+	if turn.count() != 0 {
+		t.Fatal("a line with no @ woke an agent")
+	}
+}


### PR DESCRIPTION
Closes #112 — bản làm lại của PR #109 (đã đóng), theo đúng hướng đã chốt khi đóng nó.

## Vấn đề

Gọi tên một agent trong kênh thì không có gì xảy ra. Hai nửa đầu vẫn chạy đúng — `PostMessage` ghi `channel_mentions`, `NotifyAgents` bấm chuông — nhưng chuông đánh thức **vòng claim task**, mà vòng đó chỉ đọc bảng `tasks`. `UnreadMentions` có đúng một caller trong toàn bộ cây: lệnh `bomclaw ch mentions` do người gõ.

Bằng chứng: `@bomclaw3 you are live — say hello in this thread` post 2026-09-10, `read_at` vẫn rỗng tới hôm nay.

## Vì sao là lượt chat, không phải task

PR #109 biến mọi mention thành task và bị đóng vì đúng hai lý do đó: kanban đầy lời chào, và mỗi task run là một prompt độc lập nên agent trả lời mà **không nhớ thread**. Hội thoại là làn riêng; kanban chỉ vào cuộc khi agent tự thấy việc là lớn và gọi `bomclaw task new` (prompt nói rõ điều này).

## Cách làm

`MentionWatcher` (gateway — nơi duy nhất có đủ `Turn` + `Coord`) quét khi có poke và mỗi 30s:

1. `UnreadMentions` của **chính agent này** → hai gateway không bao giờ tranh nhau, không cần khoá.
2. Dựng session theo thread từ bảng mới `channel_sessions` (schema v7), resume nếu cùng provider.
3. `RunTurn` — engine của Telegram và dashboard.
4. Post reply vào **đúng thread**, `MarkMentionsRead`, `SaveThreadSession`.

Khoá thread là thread mà **câu trả lời rơi vào**: mention top-level khoá theo id của chính nó, vì reply mở thread ở đó. Khoá theo channel thì câu trả lời và câu hỏi tiếp theo dưới nó rơi vào hai hội thoại khác nhau — `TestSecondTurnInAThreadResumesTheFirst` bắt được đúng lỗi này khi viết.

Ba cái chặn: `MaxThreadTurns` (6), `MentionsPerSweep` (5), `StaleMention` (24h). Tắt bằng `coord.reply_to_mentions: false`.

## Telegram không bị đụng

Chỉ **thêm** một caller của `RunTurn`; `internal/bot` không đổi một dòng. Session kênh nằm ở chat id `-2` nên một lượt kênh không bao giờ xếp hàng sau một lượt Telegram (engine queue theo chatID).

## Trace

Không cần thêm gì: `RunTurn` đã mở span gốc `turn` kèm mọi tool span, nên lượt kênh hiện trong tab Traces y như lượt Telegram, dưới `session_id = ch_<thread>`. Lượt đang chạy cũng vào `StatusResult.Runs` với `kind: "channel"` — tray giữ máy thức xuyên suốt câu trả lời.

## Test

- `TestMentionBecomesAChatTurn` — `@agent` → đúng một lượt, reply nằm trong thread, mention hết unread
- `TestSecondTurnInAThreadResumesTheFirst` — lượt 2 resume session của lượt 1
- `TestThreadStopsAtTheTurnCap` — A@B ↔ B@A dừng ở 6
- `TestStaleMentionIsClearedNotAnswered` — mention 25h bị bỏ, và bị clear
- `TestPlainLineWakesNobody` — không `@` thì không ai thức

`go build ./...` và `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)