### PR TITLE
fix(bot): the CLI children die with the gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,15 @@ When restarting the gateway service, stale Claude CLI subprocesses (spawned by p
    killing the child, the orphaned claude process keeps its Telegram long-poll
    alive. The new gateway instance then conflicts with it.
 
+   **Fixed 2026-09-12.** Children are spawned into their own process group and
+   registered in `internal/execution/children.go`; `Bot.Shutdown()` and the
+   gateway's own exit path both call `KillSpawned()`, which signals the group
+   so a CLI's own helpers die with it. Two gaps were part of the same bug:
+   `defer tgBot.Shutdown()` sat inside the `telegram.poll` branch, so agents 2
+   and 3 never ran it, and `log.Fatalf` on a failed start skipped every defer.
+   A `kill -9` of the gateway is still beyond reach — the checklist below stays
+   useful for that.
+
 2. **Two gateways, one token.** Telegram serves `getUpdates` to exactly one
    consumer per token. Agents 1 and 2 both had `TELEGRAM_TOKEN` in their `.env`
    — which overrides `telegram.token: ""` in config (`config.go` Load) — so
@@ -39,4 +48,4 @@ codex), `bomclaw3` (:18791, claude, shares agent 1's OAuth quota). One shared
 binary at `~/.bomclaw/bomclaw`, so a deploy restarts all three. Adding one:
 `docs/adding-an-agent.md`.
 
-**TODO:** Add child process cleanup on gateway shutdown (kill all spawned claude subprocesses in `Bot.Shutdown()`). Cause 2 is fixed; this is still open for cause 1.
+Both causes are now fixed in code. What remains is the ungraceful case (SIGKILL, power loss), where nothing in the process can run cleanup — that is what the checklist above is for.

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -31,6 +31,7 @@ import (
 	agentctx "github.com/ngocp/goterm-control/internal/context"
 	"github.com/ngocp/goterm-control/internal/coord"
 	"github.com/ngocp/goterm-control/internal/daemon"
+	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/gateway"
 	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/reporter"
@@ -596,12 +597,18 @@ func runGateway(args []string) {
 	// which is the failure this repo's CLAUDE.md documents. A secondary agent
 	// sets telegram.poll=false — it keeps the bot object, and with it the
 	// shared turn engine, but never touches the long poll.
+	if tgBot != nil {
+		// Shutdown regardless of polling. Agents 2 and 3 set telegram.poll=false
+		// and still run turns through this object, so they still have CLI
+		// children to kill — and they were the ones leaving orphans, because
+		// this defer used to sit inside the polling branch.
+		defer tgBot.Shutdown()
+	}
 	if tgBot != nil && cfg.Telegram.Polling() {
 		go func() {
 			log.Println("gateway: starting Telegram bot")
 			tgBot.Run()
 		}()
-		defer tgBot.Shutdown()
 	} else if tgBot != nil {
 		log.Println("gateway: telegram polling off (telegram.poll=false) — turn engine still shared")
 	}
@@ -612,11 +619,19 @@ func runGateway(args []string) {
 		log.Printf("warning: stale PID cleanup: %v", err)
 	}
 
+	// Not Fatalf: os.Exit skips every defer above, including the one that kills
+	// the CLI children — and a gateway that failed to start is exactly when an
+	// orphan is most likely to be left behind.
 	log.Printf("bomclaw gateway starting on %s", addr)
 	if err := srv.Start(ctx); err != nil {
-		log.Fatalf("gateway: %v", err)
+		log.Printf("gateway: %v", err)
 	}
 
+	// A gateway with no Telegram bot at all has no Shutdown to run, and it
+	// spawns the same CLI children as any other.
+	if n := execution.KillSpawned(); n > 0 {
+		log.Printf("bomclaw: killed %d CLI process group(s) still running", n)
+	}
 	sessions.SaveNow()
 	log.Println("bomclaw: shutdown complete")
 }

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -277,7 +277,17 @@ func (b *Bot) Run() {
 }
 
 // Shutdown performs graceful cleanup.
+//
+// The CLI children go first, and before engine.Close: a turn still running is
+// blocked on reading its child's stdout, so killing the child is what lets the
+// engine drain instead of waiting out a process that has no reason left to
+// finish. Leaving them alive is what produced the Telegram conflict this
+// repo's CLAUDE.md documents — an orphaned `claude -p --resume` keeps the long
+// poll, and the next gateway to start is refused by a bot it cannot see.
 func (b *Bot) Shutdown() {
+	if n := execution.KillSpawned(); n > 0 {
+		log.Printf("bot: killed %d CLI process group(s) still running", n)
+	}
 	b.typing.Close()
 	b.indicator.Close()
 	b.queue.Close()

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/credentials"
+	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -177,6 +178,9 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	args := buildArgs(modelID, sessionID, isNewSession, systemPrompt)
 
 	cmd := exec.CommandContext(ctx, claudeBin, args...)
+	// Its own process group, so cancelling this turn — or shutting the
+	// gateway down — reaches whatever the CLI went on to spawn as well.
+	execution.Detach(cmd)
 
 	// Set working directory so Claude creates files in the workspace,
 	// not in the bot's own source directory.
@@ -205,13 +209,14 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start claude: %w", err)
 	}
+	defer execution.Track(cmd)()
 
 	// Drain stderr concurrently; join it before examining diagnostics or returning.
 	waited := false
 	var stderrText bytes.Buffer
 	stderrDone := make(chan struct{})
 	defer func() {
-		_ = cmd.Process.Kill()
+		_ = execution.KillGroup(cmd.Process)
 		<-stderrDone
 		if !waited {
 			_ = cmd.Wait()
@@ -236,7 +241,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 
 	for scanner.Scan() {
 		if ctx.Err() != nil {
-			_ = cmd.Process.Kill()
+			_ = execution.KillGroup(cmd.Process)
 			break
 		}
 		line := scanner.Text()
@@ -322,7 +327,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 			}
 			if ev.IsError {
 				// Error results are terminal. Kill/wait even if the CLI leaves pipes open.
-				_ = cmd.Process.Kill()
+				_ = execution.KillGroup(cmd.Process)
 				<-stderrDone
 				return cliError(sessionID, ev.Result, ev.Errors, stderrText.String())
 			}

--- a/internal/codex/client.go
+++ b/internal/codex/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/credentials"
+	"github.com/ngocp/goterm-control/internal/execution"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -123,6 +124,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	args := buildArgs(modelID, threadID, isNewThread)
 
 	cmd := exec.CommandContext(ctx, codexBin, args...)
+	execution.Detach(cmd)
 	// codex has always inherited the ambient environment; the account layers
 	// CODEX_HOME on top so each login keeps its own threads.
 	cmd.Env = credentials.ApplyEnv(os.Environ(), acct)
@@ -144,6 +146,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start codex: %w", err)
 	}
+	defer execution.Track(cmd)()
 
 	// Drain stderr to logs. Codex logs auth/model diagnostics here; the last
 	// lines are the only clue when a turn dies before emitting any event.
@@ -180,7 +183,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 	// kill first so Wait cannot block on a subprocess still producing output.
 	abort := func(err error) error {
 		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
+			_ = execution.KillGroup(cmd.Process)
 		}
 		_ = reap()
 		return err
@@ -197,7 +200,7 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 
 	for scanner.Scan() {
 		if ctx.Err() != nil {
-			_ = cmd.Process.Kill()
+			_ = execution.KillGroup(cmd.Process)
 			break
 		}
 		line := strings.TrimSpace(scanner.Text())

--- a/internal/codex/provider.go
+++ b/internal/codex/provider.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ngocp/goterm-control/internal/agent"
+	"github.com/ngocp/goterm-control/internal/execution"
 )
 
 // CLIProvider implements agent.ModelProvider using the codex CLI subprocess.
@@ -61,6 +62,7 @@ func (p *CLIProvider) Stream(ctx context.Context, params agent.StreamParams) (<-
 	args = append(args, "-")
 
 	cmd := exec.CommandContext(ctx, codexBin, args...)
+	execution.Detach(cmd)
 	_ = os.MkdirAll(p.workspace, 0755)
 	cmd.Dir = p.workspace
 	cmd.Stdin = strings.NewReader(prompt)
@@ -77,6 +79,7 @@ func (p *CLIProvider) Stream(ctx context.Context, params agent.StreamParams) (<-
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start codex: %w", err)
 	}
+	defer execution.Track(cmd)()
 
 	go func() {
 		s := bufio.NewScanner(stderr)
@@ -95,7 +98,7 @@ func (p *CLIProvider) Stream(ctx context.Context, params agent.StreamParams) (<-
 
 		for scanner.Scan() {
 			if ctx.Err() != nil {
-				_ = cmd.Process.Kill()
+				_ = execution.KillGroup(cmd.Process)
 				return
 			}
 			line := strings.TrimSpace(scanner.Text())

--- a/internal/execution/children.go
+++ b/internal/execution/children.go
@@ -1,0 +1,102 @@
+package execution
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// The CLI processes this gateway has spawned, and how they die.
+//
+// Every turn shells out to `claude` or `codex`. exec.CommandContext kills the
+// child when that turn's context ends, which covers the normal case and misses
+// the one that hurt: the gateway itself going away. A process that outlives its
+// parent keeps whatever the parent was holding — for the Telegram backend that
+// means the long poll, and the next gateway to start is answered with
+// "Conflict: terminated by other getUpdates request" by a bot it cannot see.
+//
+// Two things are needed, not one. A registry, because nothing kept a list of
+// children to kill on the way out. And a process GROUP, because Process.Kill
+// reaches the child and not the child's own children — a CLI that spawned a
+// helper leaves the helper holding the socket.
+//
+// Registration is by pid rather than by *exec.Cmd so nothing here can block on
+// or race with the goroutine doing Wait.
+var spawned = &children{procs: map[int]*os.Process{}}
+
+type children struct {
+	mu    sync.Mutex
+	procs map[int]*os.Process
+}
+
+// Detach puts a command in its own process group and, when it has a context,
+// makes cancelling that context kill the whole group rather than the leader
+// alone. Call it before Start.
+//
+// The Cancel hook is only installed on a command that already has one:
+// CommandContext sets a default that calls Process.Kill, and Start refuses a
+// Cancel on a command built with plain Command. Testing for it is how this
+// tells the two apart without asking the caller to say which it used.
+//
+// On Windows the process group is a no-op — there is nothing to put a child in
+// — and KillGroup falls back to killing the process alone, as before.
+func Detach(cmd *exec.Cmd) {
+	detach(cmd)
+	if cmd.Cancel == nil {
+		return
+	}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return KillGroup(cmd.Process)
+	}
+}
+
+// Track records a started process and returns the function that forgets it.
+// Call it right after Start, and defer the result:
+//
+//	Detach(cmd)
+//	cmd.Start()
+//	defer Track(cmd)()
+func Track(cmd *exec.Cmd) func() {
+	if cmd.Process == nil {
+		return func() {}
+	}
+	pid, p := cmd.Process.Pid, cmd.Process
+	spawned.mu.Lock()
+	spawned.procs[pid] = p
+	spawned.mu.Unlock()
+	return func() {
+		spawned.mu.Lock()
+		delete(spawned.procs, pid)
+		spawned.mu.Unlock()
+	}
+}
+
+// KillSpawned kills every CLI process this gateway started, and their
+// descendants, returning how many it signalled. Shutdown calls it; nothing
+// else should, because a live turn's child is in here too.
+func KillSpawned() int {
+	spawned.mu.Lock()
+	procs := make([]*os.Process, 0, len(spawned.procs))
+	for pid, p := range spawned.procs {
+		procs = append(procs, p)
+		delete(spawned.procs, pid)
+	}
+	spawned.mu.Unlock()
+
+	killed := 0
+	for _, p := range procs {
+		if err := KillGroup(p); err != nil {
+			// Already gone is the common case and not worth a line.
+			if !isGone(err) {
+				log.Printf("execution: kill %d: %v", p.Pid, err)
+			}
+			continue
+		}
+		killed++
+	}
+	return killed
+}

--- a/internal/execution/children_test.go
+++ b/internal/execution/children_test.go
@@ -1,0 +1,118 @@
+//go:build unix
+
+package execution
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// alive reports whether a pid still exists. Signal 0 checks without sending.
+func alive(pid int) bool { return syscall.Kill(pid, 0) == nil }
+
+func waitGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !alive(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pid %d survived", pid)
+}
+
+// TestKillSpawnedKillsATrackedChild is the plain case: the gateway goes away
+// and the CLI it started goes with it.
+func TestKillSpawnedKillsATrackedChild(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	untrack := Track(cmd)
+	defer untrack()
+	pid := cmd.Process.Pid
+	go cmd.Wait()
+
+	if n := KillSpawned(); n != 1 {
+		t.Fatalf("expected to kill 1 process, killed %d", n)
+	}
+	waitGone(t, pid)
+}
+
+// TestKillSpawnedReachesGrandchildren is the half that Process.Kill misses: a
+// CLI that spawned a helper leaves the helper holding whatever the CLI held.
+func TestKillSpawnedReachesGrandchildren(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	cmd := exec.Command("sh", "-c", "sleep 30 & echo $! > "+pidFile+"; sleep 30")
+	Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer Track(cmd)()
+	go cmd.Wait()
+
+	var grandchild int
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(pidFile); err == nil {
+			if n, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil && n > 0 {
+				grandchild = n
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		t.Fatal("grandchild never reported its pid")
+	}
+
+	KillSpawned()
+	waitGone(t, cmd.Process.Pid)
+	waitGone(t, grandchild)
+}
+
+// TestUntrackedProcessIsNotKilled: a finished turn's child must not be in the
+// list, or a later shutdown would signal a pid the OS has since reused.
+func TestUntrackedProcessIsNotKilled(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	untrack := Track(cmd)
+	untrack()
+	defer func() { _ = KillGroup(cmd.Process); cmd.Wait() }()
+
+	if n := KillSpawned(); n != 0 {
+		t.Fatalf("killed %d processes after untracking the only one", n)
+	}
+	if !alive(cmd.Process.Pid) {
+		t.Fatal("an untracked process was killed anyway")
+	}
+}
+
+// TestCancelKillsTheGroup: cancelling one turn must not need shutdown to clean
+// up after it — and must reach the grandchildren too.
+func TestCancelKillsTheGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+	Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer Track(cmd)()
+	pid := cmd.Process.Pid
+	go cmd.Wait()
+
+	cancel()
+	waitGone(t, pid)
+}

--- a/internal/execution/children_unix.go
+++ b/internal/execution/children_unix.go
@@ -1,0 +1,37 @@
+//go:build unix
+
+package execution
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// detach gives the child its own process group, so one signal reaches it and
+// everything it went on to spawn.
+func detach(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// KillGroup kills a process and its descendants. The negative pid is the
+// group — the whole point of Setpgid above. If the group is gone the process
+// may still be there (Setpgid can fail, or the caller never detached), so fall
+// back to killing it alone rather than leaving it running.
+func KillGroup(p *os.Process) error {
+	if p == nil {
+		return nil
+	}
+	if err := syscall.Kill(-p.Pid, syscall.SIGKILL); err == nil || isGone(err) {
+		return err
+	}
+	return p.Kill()
+}
+
+func isGone(err error) bool {
+	return errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone)
+}

--- a/internal/execution/children_windows.go
+++ b/internal/execution/children_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package execution
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// Windows has no fork/exec process group to put a child in; a job object would
+// be the equivalent and nothing on this platform has needed it yet.
+func detach(*exec.Cmd) {}
+
+// KillGroup kills the process alone. Descendants survive, which is the
+// pre-existing behaviour on this platform.
+func KillGroup(p *os.Process) error {
+	if p == nil {
+		return nil
+	}
+	return p.Kill()
+}
+
+func isGone(err error) bool { return errors.Is(err, os.ErrProcessDone) }


### PR DESCRIPTION
Closes #113 — TODO còn mở trong `CLAUDE.md`, nguyên nhân 1 của lỗi `Conflict: terminated by other getUpdates request`.

## Vấn đề

`Bot.Shutdown()` chỉ đóng những thứ trong tiến trình của mình. Không dòng nào đụng tới tiến trình con, nên `claude -p --resume` mồ côi vẫn giữ long-poll Telegram và gateway mới bị từ chối bởi một con bot nó không nhìn thấy.

Hai lỗ, không phải một:

1. **Không có sổ đăng ký** để mà giết.
2. **`Process.Kill()` chỉ tới đứa con trực tiếp** — CLI tự sinh helper thì helper sống sót và vẫn giữ socket.

## Cách làm

`internal/execution/children.go`: con được sinh vào **nhóm tiến trình riêng** (`Setpgid`), đăng ký theo pid, `KillSpawned()` bắn tín hiệu cho cả nhóm.

## Hai lỗ nữa lộ ra khi làm, và chúng giải thích vì sao orphan luôn là của agent 2/3

- `defer tgBot.Shutdown()` **nằm trong nhánh `telegram.poll`**. Agent 2 và 3 đặt `poll=false` nhưng vẫn chạy mọi lượt qua object đó — tức có con, không có dọn. Giờ defer áp cho mọi bot tồn tại, và gateway hoàn toàn không có bot cũng tự dọn con lúc thoát.
- `log.Fatalf` khi start hỏng **bỏ qua toàn bộ defer** — đúng lúc dễ để lại orphan nhất. Đổi thành `log.Printf` + trả về.

Ngoài ra huỷ một lượt giờ giết cả nhóm của lượt đó, nên timeout tự dọn thay vì chờ tới shutdown.

## Một ràng buộc do test tìm ra

`Detach` ban đầu luôn gán `cmd.Cancel`. `Start` từ chối `Cancel` trên command tạo bằng `exec.Command` thuần — ba test fail ngay. Giờ chỉ ghi đè khi đã có sẵn một cái: `CommandContext` đặt mặc định, `Command` thì không, nên chính nó là cách phân biệt hai loại mà không bắt caller phải khai báo.

## Test (`internal/execution/children_test.go`, build tag unix)

- `TestKillSpawnedKillsATrackedChild`
- `TestKillSpawnedReachesGrandchildren` — nửa mà `Process.Kill` bỏ sót
- `TestUntrackedProcessIsNotKilled` — con của lượt đã xong phải rời danh sách, nếu không shutdown sau này bắn vào pid OS đã tái dùng
- `TestCancelKillsTheGroup`

`go build ./...` và `go test ./...` sạch.

## Không với tay tới

`kill -9` gateway: không gì trong tiến trình chạy được nữa. Checklist trong `CLAUDE.md` vẫn để cho ca đó; TODO đã gỡ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)