### PR TITLE
docs: the design headers say what actually shipped

### DIFF
--- a/docs/design/browser-control.md
+++ b/docs/design/browser-control.md
@@ -1,0 +1,356 @@
+# Browser Control — Gap Analysis vs OpenClaw & Thiết kế nâng cấp
+
+**Trạng thái**: DRAFT — design only, chưa implement.
+**Ngày**: 2026-07-18
+**Câu hỏi gốc**: BomClaw đã hỗ trợ control browser giống OpenClaw chưa?
+
+**Trả lời ngắn**: **Đã có, ở mức cơ bản (~60%)**. BomClaw có sẵn 12 tool `browser_*`
+chạy trên native CDP (không Playwright). Thiếu so với OpenClaw: security guard
+(SSRF/navigation policy), quản lý tab/dialog/download, profiles, trusted input
+events, và config. **Bug nghiêm trọng nhất: không chạy được trên macOS** —
+`chromePaths` chỉ có đường dẫn Linux, trong khi gateway đang deploy trên macOS.
+
+---
+
+## 1. Bối cảnh & mục tiêu
+
+BomClaw là gateway bridge chat channel (Telegram, CLI) → agent loop → tool
+executor chạy local. Browser control cho phép agent thao tác web thay user:
+đọc trang JS-heavy, điền form, thao tác trên session đã đăng nhập.
+
+OpenClaw (open-source assistant cùng phân khúc) được lấy làm **kiến trúc tham
+chiếu** vì browser tool của nó trưởng thành nhất trong nhóm: profiles cách ly,
+SSRF policy, tab management, dialog/upload/download, extension relay.
+
+Mục tiêu tài liệu này:
+1. Chốt hiện trạng browser control của BomClaw (có gì, thiếu gì — evidence cụ thể).
+2. Gap analysis so với OpenClaw.
+3. Thiết kế phần cần bổ sung, kèm roadmap — **không implement trong scope này**.
+
+---
+
+## 2. Hiện trạng BomClaw (verified 2026-07-18)
+
+### 2.1 Cấu trúc code
+
+```
+internal/browser/
+├── chrome.go       # Launcher: tìm binary, spawn với --remote-debugging-port=9222,
+│                   #   user-data-dir ~/.goterm/browser/user-data, poll CDP ready
+├── cdp.go          # WithCdpSocket: mở WebSocket tới tab, multiplex request/response
+└── operations.go   # Navigate, CaptureScreenshot, EvalJS, SnapshotDOM (ref n1,n2...),
+                    #   Click/Fill/TypeText/SelectOption (JS-injection), Scroll,
+                    #   GetText, GoBack, WaitFor
+
+internal/tools/browser.go   # BrowserTool: EnsureChrome() lazy-launch, Shutdown()
+cmd/bomclaw/main.go:507-519 # Đăng ký 12 tool defs
+cmd/bomclaw/main.go:861-903 # JSON schema cho từng tool
+```
+
+Dependencies: `chromedp/cdproto` (chỉ dùng type/protocol constants), `gorilla/websocket`.
+**Không dùng Playwright, không dùng MCP** — tool chạy in-process trong executor.
+
+### 2.2 Tool đã có (12)
+
+| Tool | Chức năng | Cơ chế |
+|------|-----------|--------|
+| `browser_navigate` | Mở URL, auto-launch Chrome | CDP `Page.navigate` |
+| `browser_snapshot` | DOM tree + element refs (n1, n2…) | JS injection |
+| `browser_click` | Click theo ref | JS `element.click()` |
+| `browser_fill` | Clear + gõ text vào input | JS value setter |
+| `browser_type` | Append text | JS value setter |
+| `browser_select` | Chọn option dropdown | JS |
+| `browser_scroll` | Cuộn trang | JS |
+| `browser_screenshot` | Chụp trang (PNG) | CDP `Page.captureScreenshot` |
+| `browser_get_text` | Lấy text/HTML/value/title/URL | JS |
+| `browser_eval` | Chạy JavaScript tùy ý | CDP `Runtime.evaluate` |
+| `browser_wait` | Chờ ref/text/timeout | Poll JS |
+| `browser_back` | Back history | JS `history.back()` |
+
+### 2.3 Vấn đề đã xác nhận trong code hiện tại
+
+1. **Không chạy trên macOS** — `chrome.go:27-37` chỉ liệt kê
+   `/usr/bin/google-chrome`, `/snap/bin/chromium`… (Linux). Fallback
+   `exec.LookPath("google-chrome")` cũng không match trên macOS
+   (binary nằm ở `/Applications/Google Chrome.app/Contents/MacOS/`).
+   Gateway hiện deploy bằng launchd trên macOS → **browser tools đang chết
+   trên môi trường production chính**.
+2. **CDP port cố định 9222** (`chrome.go:17`) — xung đột nếu user/tool khác
+   đang chạy Chrome debug; hai instance BomClaw không chạy song song được.
+3. **Không có bất kỳ guard nào** — agent có thể navigate tới
+   `http://169.254.169.254/`, `http://localhost:8443` (dashboard/gateway của
+   chính BomClaw), `file://` path. Kết hợp prompt-injection từ nội dung web
+   → SSRF/local access. Nghiêm trọng vì gateway chạy daemon với
+   `--permission-mode bypassPermissions`.
+4. **Interaction bằng JS injection, không phải trusted events** — `element.click()`
+   và value-setter fail trên site check `isTrusted` (nhiều SPA, anti-bot,
+   payment form). OpenClaw/Playwright dùng input events thật.
+5. **Chrome orphan** — `chrome.go:98` set `Setpgid: true` (Chrome tách process
+   group để sống sót khi gateway crash giữa launch), nhưng khi gateway crash
+   thật thì không ai kill Chrome → orphan giữ port 9222, instance mới launch
+   fail. Cùng class bug với orphan Claude CLI đã ghi trong `CLAUDE.md`.
+6. **Screenshot path cố định** `/tmp/browser-screenshot.png`
+   (`internal/tools/browser.go:13`) — hai session chụp cùng lúc ghi đè nhau.
+7. **Không có config** — không tắt được browser, không đổi được binary path,
+   không có headless mode. Chrome luôn mở cửa sổ trên desktop của máy chạy
+   gateway.
+8. **Chỉ thao tác 1 tab** — `PageWsURL()` lấy tab "page" đầu tiên; popup/tab
+   mới do site mở ra là agent mất kiểm soát.
+
+---
+
+## 3. Kiến trúc tham chiếu: OpenClaw browser control
+
+Tóm tắt (nguồn: deepwiki openclaw/openclaw, wiki §3.4.4):
+
+- **Hybrid CDP + Playwright**: CDP cho screenshot/eval/ARIA snapshot;
+  Playwright (connect qua CDP) cho click/type/drag/download — trusted input.
+- **Profiles**: `openclaw` (managed, cách ly khỏi profile cá nhân — mặc định),
+  `user` (attach Chrome đang chạy qua CDP), `chrome` (extension relay),
+  custom `cdpUrl` (browserless/grid). Config `browser.profiles.<name>`.
+- **Tool actions**: navigate/open/focus/close tab; snapshot (AI/ARIA format,
+  `--urls`); screenshot (`--full-page`, `--ref`, `--labels`); click/type/press/
+  hover/drag/select/fill; upload/download/dialog; evaluate (tắt được bằng
+  `browser.evaluateEnabled`); set cookies/storage/timezone/locale/media/offline;
+  resize viewport.
+- **Security**: SSRF policy trên mọi navigation target + CDP endpoint
+  (`browser.ssrfPolicy`: chặn private network mặc định, `hostnameAllowlist`);
+  `navigation-guard` kiểm cả redirect chain; loopback HTTP API có
+  shared-secret auth; sandbox agent mặc định không được control host browser.
+- **Ops**: `doctor` health check, `tabCleanup` tự dọn tab idle,
+  `browser.headless`, `browser.executablePath`.
+- **Exposure**: tool là bundled plugin trong agent loop + standalone loopback
+  HTTP API (opt-in) cho CLI/service khác gọi.
+
+---
+
+## 4. Gap analysis
+
+| Năng lực | OpenClaw | BomClaw | Gap |
+|----------|----------|---------|-----|
+| Launch managed Chrome, profile cách ly | ✅ | ✅ (`~/.goterm/browser/user-data`) | — |
+| Hỗ trợ macOS | ✅ | ❌ Linux-only paths | **P0** |
+| Navigate / snapshot có ref / click / fill / select / scroll / eval / wait / back | ✅ | ✅ | — |
+| Screenshot full-page | ✅ | ✅ | — |
+| SSRF / navigation guard | ✅ policy + redirect check | ❌ | **P0** |
+| Tắt `eval` qua config | ✅ | ❌ | **P0** |
+| Config (enabled/headless/executable_path/port) | ✅ | ❌ hardcode | **P0** |
+| Chrome lifecycle sạch (không orphan, health check) | ✅ doctor | ⚠️ orphan risk | **P1** |
+| Trusted input events (click/type thật) | ✅ Playwright | ❌ JS injection | **P1** |
+| Tab management (list/open/focus/close) | ✅ | ❌ 1 tab | **P1** |
+| Dialog (alert/confirm/prompt) handling | ✅ | ❌ dialog treo là kẹt | **P1** |
+| Download / upload file | ✅ | ❌ | **P2** |
+| Hover / press key / drag | ✅ | ❌ | **P2** |
+| Attach Chrome đang chạy của user (`cdp_url`) | ✅ | ❌ | **P2** |
+| Named profiles nhiều cấu hình | ✅ | ❌ | **P3** |
+| Set cookies / storage / viewport / timezone | ✅ | ❌ | **P3** |
+| Extension relay | ✅ | ❌ | Không làm |
+| Standalone loopback HTTP API | ✅ | ❌ | Không làm |
+| AI-format snapshot / PDF export | ✅ | ❌ | Không làm |
+
+Kết luận: **nền tảng đã tương đương** (managed Chrome + CDP + ref-based
+snapshot/act — đúng mô hình OpenClaw dùng), khác biệt nằm ở **độ an toàn,
+độ tương thích và độ bền vận hành**, không phải ở kiến trúc.
+
+---
+
+## 5. Nguyên tắc thiết kế
+
+1. **Giữ native CDP, không thêm Playwright** — Playwright kéo theo Node runtime
+   hoặc playwright-go (kém maintain); mọi thứ Playwright làm qua CDP thì
+   BomClaw gọi CDP trực tiếp được (Input domain, Target domain, Page domain).
+   Trade-off chấp nhận: tự viết nhiều hơn, không có auto-wait tinh vi.
+2. **Không mở HTTP API riêng cho browser** — tool chạy in-process trong
+   executor, không có consumer thứ hai. YAGNI. (Khác OpenClaw vì OpenClaw có
+   CLI/plugin ecosystem cần gọi từ ngoài.)
+3. **Security mặc định chặt** — gateway chạy daemon không có người ngồi cạnh
+   approve; nội dung web là input không tin được (prompt injection). Mặc định:
+   chặn private network, tắt được eval, allowlist opt-in.
+4. **Config-driven, zero-config vẫn chạy** — không có section `browser:` trong
+   `config.yaml` thì behavior như hiện tại (trừ guard bật mặc định).
+5. **Từng phase độc lập ship được** — không big-bang.
+
+---
+
+## 6. Thiết kế đề xuất
+
+### 6.1 Config schema (mới — `internal/config/config.go`)
+
+```yaml
+browser:
+  enabled: true                # false = không đăng ký browser_* tools
+  executable_path: ""          # override; rỗng = auto-detect
+  headless: false              # true = --headless=new
+  cdp_port: 0                  # 0 = chọn port ephemeral (fix xung đột 9222)
+  attach_url: ""               # CDP URL có sẵn (browserless/Chrome user) — P2
+  eval_enabled: true           # false = bỏ đăng ký browser_eval
+  guard:
+    allow_private_network: false   # chặn RFC1918, loopback, link-local, file://
+    hostname_allowlist: []         # ["*.internal.corp"] — bypass guard có chủ đích
+    hostname_blocklist: []         # chặn thêm ngoài private network
+```
+
+### 6.2 P0.a — macOS support + port động
+
+`FindChrome()` thêm nhánh theo `runtime.GOOS`:
+
+```go
+// darwin
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+"/Applications/Chromium.app/Contents/MacOS/Chromium",
+```
+
+Port: bind `net.Listen("tcp", "127.0.0.1:0")` lấy port trống → đóng → truyền
+vào `--remote-debugging-port`. Lưu port vào struct `Chrome` (đã có field).
+`config.browser.cdp_port != 0` thì dùng giá trị cố định (debug).
+
+### 6.3 P0.b — Navigation guard (SSRF policy)
+
+Module mới `internal/browser/guard.go`:
+
+```
+CheckURL(rawURL, policy) error
+  ├─ scheme ∉ {http, https}         → deny (chặn file://, chrome://, javascript:)
+  ├─ hostname match allowlist        → allow
+  ├─ hostname match blocklist        → deny
+  ├─ resolve DNS → mọi IP là private/loopback/link-local/metadata
+  │    && !allow_private_network     → deny
+  └─ else                            → allow
+```
+
+Điểm hook:
+1. `Navigate()` — check trước khi gửi `Page.navigate`.
+2. **Redirect + client-side navigation**: sau navigate và trước mỗi
+   snapshot/act, đọc URL hiện tại; nếu vi phạm policy → trả lỗi
+   `navigation blocked by guard: <url>` và tự navigate về `about:blank`.
+   (Đơn giản hơn OpenClaw — không chặn realtime từng redirect hop, nhưng chặn
+   được việc agent *thao tác tiếp* trên trang cấm; DNS-rebinding nâng cao ghi
+   nhận ở §8.)
+3. `browser_eval` bị loại khỏi tool list khi `eval_enabled: false` — vì eval
+   là con đường vòng qua guard (`fetch()` trong page context).
+
+### 6.4 P1.a — Lifecycle: hết orphan + doctor
+
+- Ghi PID + port vào `~/.goterm/browser/chrome.json` khi launch. Khi
+  `EnsureChrome()` chạy mà file tồn tại: probe `/json/version` — sống thì
+  **adopt** (reuse) thay vì launch mới; chết thì xóa file, kill PID nếu còn.
+  → gateway restart không tạo orphan, không chết vì port bận.
+- `Shutdown()` kill cả process group (`syscall.Kill(-pgid, SIGTERM)`) — hiện
+  chỉ signal process chính.
+- Thêm reachability check vào lệnh `bomclaw doctor`/status hiện có (nếu có):
+  binary tìm thấy?, CDP reachable?, guard config hợp lệ?
+
+### 6.5 P1.b — Trusted input qua CDP Input domain
+
+Thay JS injection bằng CDP thật cho các action tương tác:
+
+| Action | Hiện tại | Đề xuất |
+|--------|----------|---------|
+| click | `el.click()` | scrollIntoView → `DOM.getBoxModel` lấy tọa độ → `Input.dispatchMouseEvent` (moved, pressed, released) |
+| fill/type | value setter + event giả | focus element → `Input.insertText` / `Input.dispatchKeyEvent` từng phím |
+| press (mới) | — | `Input.dispatchKeyEvent` (Enter, Tab, Escape…) |
+| hover (mới) | — | `Input.dispatchMouseEvent` type=mouseMoved |
+
+Ref resolution giữ nguyên cơ chế snapshot hiện có (map ref → node), chỉ đổi
+tầng thực thi. JS-injection giữ làm fallback khi `getBoxModel` fail
+(element ẩn/0-size).
+
+### 6.6 P1.c — Tab + dialog
+
+- Tool mới `browser_tabs` `{action: list|open|focus|close, url?, tab_id?}` —
+  dùng CDP `Target.getTargets / createTarget / activateTarget / closeTarget`.
+  `Chrome` struct thêm `activeTargetID`; mọi operation route theo target đang
+  focus thay vì "tab page đầu tiên".
+- Dialog: subscribe `Page.javascriptDialogOpening` trên socket; auto-dismiss
+  mặc định + ghi message vào tool result (`[dialog dismissed: "..."]`).
+  Tool mới `browser_dialog` `{action: accept|dismiss, text?}` cho case agent
+  cần accept có chủ đích. → hết deadlock khi site bật `confirm()`.
+
+### 6.7 P2 — Download/upload, attach existing browser
+
+- Download: `Browser.setDownloadBehavior` → thư mục
+  `~/.goterm/browser/downloads/<session>/`; event `Browser.downloadProgress`
+  → tool `browser_download_wait` trả path file.
+- Upload: `DOM.setFileInputFiles` theo ref → tool `browser_upload {ref, paths}`.
+  Chỉ cho phép path trong workspace của session (tránh exfil file hệ thống).
+- `attach_url` trong config: skip launch, connect thẳng CDP URL — dùng được
+  browserless/container hoặc Chrome thật của user (user tự mở với
+  `--remote-debugging-port`). Guard vẫn áp dụng.
+
+### 6.8 P3 — Nice-to-have (chưa cam kết)
+
+Named profiles, set cookies/storage/viewport/timezone, snapshot kèm URL list.
+Chỉ làm khi có use case thật từ vận hành.
+
+### 6.9 Những gì KHÔNG làm theo OpenClaw (quyết định chủ động)
+
+| Thứ OpenClaw có | Lý do bỏ |
+|-----------------|----------|
+| Playwright layer | §5.1 — CDP thuần đủ, tránh dependency nặng |
+| Standalone loopback HTTP API | Không có consumer ngoài executor |
+| Chrome extension relay | Phức tạp cao, use case (điều khiển browser user đang mở khi vắng máy) chưa cần |
+| AI-format snapshot, PDF export | Snapshot ref hiện tại đủ cho agent loop |
+
+---
+
+## 7. Tác động lên multi-tenant (agents-as-a-service)
+
+Design AaaS (xem `docs/design/agents-as-a-service.md`) đặt agent trong
+container per-tenant. Browser control khi đó **không được** dùng Chrome trên
+host: mỗi container tự chạy Chromium headless, hoặc trỏ `attach_url` tới
+browserless pool. Config `browser.attach_url` ở §6.1 chính là điểm nối cho
+hướng này — thiết kế phase 2 nên làm sớm hơn nếu AaaS đi tiếp. Guard private
+network càng bắt buộc trong môi trường multi-tenant (chặn tenant A scan mạng
+nội bộ qua browser của data plane).
+
+---
+
+## 8. ⚠️ Rủi ro & trade-off
+
+1. **Prompt injection qua nội dung web** — trang web độc có thể chứa chỉ thị
+   khiến agent dùng browser_eval/navigate làm việc ngoài ý muốn. Guard giảm
+   blast radius (không vào private network) nhưng **không chặn được** hành vi
+   trên public internet (đăng nhập, gửi form). Trade-off chấp nhận, giống
+   OpenClaw; giảm nhẹ bằng: eval tắt được, audit log tool call đã có transcript.
+2. **DNS rebinding** — guard resolve DNS lúc check, Chrome resolve lại lúc
+   navigate; attacker đổi record ở giữa. Fix triệt để cần proxy toàn bộ traffic
+   (nặng). Ghi nhận là known limitation, mitigate một phần bằng re-check URL
+   sau navigate (§6.3.2).
+3. **Trusted input phức tạp hơn tưởng** — element trong iframe, shadow DOM,
+   element che khuất → tọa độ sai. Giữ JS fallback nghĩa là hai code path
+   phải maintain.
+4. **Adopt-orphan có thể adopt nhầm** Chrome debug của user nếu user tự chạy
+   9222 — vì vậy §6.2 chuyển sang ephemeral port + PID file là điều kiện tiên
+   quyết của §6.4.
+5. **Headless bị nhiều site chặn** (anti-bot) — mặc định giữ headful trên
+   máy có display; headless chỉ là option.
+
+---
+
+## 9. Roadmap
+
+| Phase | Nội dung | Phụ thuộc | Cỡ |
+|-------|----------|-----------|-----|
+| **P0** | macOS paths + ephemeral port (§6.2); config `browser:` (§6.1); navigation guard + eval toggle (§6.3) | — | S–M |
+| **P1** | Lifecycle/orphan + doctor (§6.4); trusted input (§6.5); tabs + dialog (§6.6) | P0 | M |
+| **P2** | Download/upload; `attach_url` (§6.7) | P1 | M |
+| **P3** | Profiles, state mgmt (§6.8) | có use case | — |
+
+P0 là điều kiện để nói "browser control hoạt động và an toàn trên môi trường
+deploy thật"; hiện tại tính năng chỉ chạy đúng trên Linux dev box.
+
+---
+
+## 10. Open questions
+
+1. Guard mặc định `allow_private_network: false` có phá use case nội bộ nào
+   đang dùng không (dashboard localhost, dev server)? → cần quyết trước P0.
+2. Trusted input (§6.5) làm toàn bộ hay chỉ click/fill trước, type/hover sau?
+3. Chrome nên là **một instance dùng chung** mọi session (hiện tại) hay
+   per-session (cách ly cookie giữa các chat)? Per-session sạch hơn nhưng tốn
+   RAM đáng kể trên máy cá nhân.
+4. Screenshot path per-session (`/tmp/browser-screenshot-<session>.png` hoặc
+   vào data dir) — sửa luôn ở P0 hay để P1?
+5. Có cần `browser_snapshot` format gọn hơn cho model nhỏ (token budget) không?

--- a/docs/design/production-hosting.md
+++ b/docs/design/production-hosting.md
@@ -1,0 +1,116 @@
+# Research: Hosting production cho ZeroClaw AaaS (Docker single-node)
+
+**Trạng thái**: RESEARCH — phục vụ quyết định deploy sau này, chưa cam kết.
+**Ngày**: 2026-07-18 (giá tham khảo 07/2026 — thị trường đang biến động vì "RAM crisis",
+Hetzner đã tăng 30–40% trong 2026, netcup cũng tăng; **kiểm tra lại giá khi mua**).
+**Liên quan**: `zeroclaw-docker-aaas.md` (kiến trúc v3 — doc này chọn chỗ đặt nó).
+
+---
+
+## 1. Yêu cầu rút ra từ thiết kế v3
+
+1. **Một VM Linux có Docker daemon do ta toàn quyền** — panel điều khiển `docker.sock`
+   trực tiếp ⇒ loại các PaaS container (Cloud Run, Railway, Render…) vì không cấp Docker
+   API. Ứng viên hợp lệ: VPS / dedicated server / (ngoại lệ có chủ đích: Fly.io Machines,
+   xem §4).
+2. **RAM là tài nguyên quyết định mật độ** (v3 §9): tenant idle ~100–150Mi, Chrome burst
+   0.5–1Gi. Quy đổi thô: **16GB ≈ 50–80 tenant idle / 6–8 phiên browse; 64GB ≈ 250+ tenant
+   idle / ~25 phiên browse**. ⇒ tối ưu **giá/GB RAM**.
+3. **Ổn định > rẻ nhất**: bot chạy 24/7 (Telegram long-poll), downtime là user thấy ngay.
+4. Egress: LLM API + Telegram — vài trăm GB/tháng là nhiều ⇒ hầu hết provider đều thừa,
+   không phải yếu tố quyết định.
+5. Latency: Telegram và LLM API không nhạy latency; chỉ dashboard web là user VN cảm nhận
+   ⇒ region EU chấp nhận được, SG là điểm cộng không bắt buộc.
+6. Ưu tiên có **snapshot/backup + API hạ tầng** (đường lên multi-node sau này panel tự
+   provision).
+7. Deploy production = **đổi máy Mac thành VM Linux, kiến trúc không đổi** (còn bỏ được
+   lớp VM macOS — Docker chạy thẳng trên Linux host).
+
+## 2. Bảng so sánh (giá 07/2026, làm tròn)
+
+| Provider | Gói tiêu biểu | Giá/tháng | €/GB RAM | Ổn định | Region | Ghi chú |
+|----------|---------------|-----------|----------|---------|--------|---------|
+| **netcup** (DE) | RS 2000 G12 — 8 core dedicated / 16GB / 512GB NVMe | **€16.89** | ~1.06 | Tốt (cộng đồng self-host tin dùng từ 2011) | EU (US ít gói) | Rẻ nhất trong nhóm "ổn định"; billing tháng, API/snapshot yếu hơn Hetzner |
+| **Hetzner Cloud** | CX53 — 32GB / shared vCPU | €29.49 | ~0.92 | Rất tốt (VPSBenchmarks A, ISO 27001) | DE/FI (CX/CAX chỉ EU); có SG nhưng giá cao hơn | API + snapshot + backup + hourly billing tốt nhất nhóm; 20TB egress |
+| **Hetzner Cloud ARM** | CAX41 — 16 core Ampere / 32GB | €40.99 | ~1.28 | Rất tốt | EU | ARM: cần kiểm chứng Chromium/pinchtab arm64 (§5.3) |
+| **Hetzner Auction (dedicated)** | vd AX41 cũ — Ryzen 3600 / 64GB / NVMe | **từ ~€30–45** | **~0.5–0.7** | Rất tốt (hardware refurbished, tự quản RAID) | DE/FI | **Best giá/GB khi scale**; không hourly, có setup fee (chính sách 2026) |
+| **Contabo** | ~8–12GB | ~€5–9 | ~0.6–0.8 | **Kém** — uptime 91.1%/quý (Pingoru, Q2/2026), CPU steal 20–40%, VPSBenchmarks F | EU/US/SG | Chỉ cân nhắc cho dev/staging vứt đi được; **loại khỏi production** |
+| **DigitalOcean** | 16GB memory-optimized | ~$84 | ~4.8 | Tốt | có **SGP1** | Đắt 3–5× EU; chỉ khi bắt buộc SG + cần hệ sinh thái DO |
+| **Vultr** | 16GB regular | ~$80–96 | ~4.5–5.5 | Tốt | có SG | Tương tự DO |
+| **Fly.io Machines** | per-machine, tính giây | shared-1x/1GB ≈ $5.7/máy always-on | — | Khá (từng có nhiều incident, free tier đã bỏ) | có SIN | Không phải VPS — xem §4, là phương án kiến trúc riêng |
+| **Oracle Cloud Free** | A1 ARM 4 OCPU / 24GB | $0 | 0 | Rủi ro reclaim/khoá account nổi tiếng | có | Chỉ dùng staging/thí nghiệm, không đặt production trả phí của khách |
+| Cloud VN (Viettel/FPT/VNG) | 16GB | thường ≥ $60–100 | cao | trung bình, tooling yếu | VN | Chỉ khi cần data residency VN hoặc latency dashboard là ưu tiên số 1 |
+
+## 3. Khuyến nghị theo giai đoạn
+
+```
+PoC/P0-P1     : máy Mac hiện tại (đúng thiết kế v3) — $0
+                (+ tuỳ chọn: Oracle free ARM làm môi trường thử Linux)
+                        │
+Production v1 : netcup RS 2000 G12 (€16.89, 16GB, core dedicated)
+(20–60 tenant)  — rẻ nhất trong nhóm ổn định, đủ chỗ cho giai đoạn dò sản phẩm
+                HOẶC Hetzner CX53 (€29.49, 32GB) nếu muốn API/snapshot/hourly
+                và đường tự động hoá hạ tầng đẹp hơn ngay từ đầu
+                        │
+Scale         : Hetzner Auction dedicated 64GB (~€35–45) — giá/GB tốt nhất,
+(100+ tenant)   1 máy gánh ~250 tenant idle; mua máy thứ 2 = HA/DR thủ công
+                        │
+Vượt 1 máy    : quay lại design k8s v2 (multi-node) hoặc phương án Fly (§4)
+```
+
+Lý do chọn **netcup làm production v1**: đúng tiêu chí "giá rẻ + ổn định" nhất bảng —
+core dedicated (không CPU steal như Contabo), reputation tốt, €1.06/GB. Trade-off so với
+Hetzner: không hourly billing, API/snapshot hệ sinh thái mỏng hơn — chấp nhận được vì
+single-node, backup đã tự lo bằng restic (v3 §9). Nếu dự tính chắc chắn sẽ multi-node
+trong ~1 năm thì chọn Hetzner ngay từ đầu để panel dùng một API hạ tầng xuyên suốt.
+
+## 4. Phương án kiến trúc thay thế: Fly.io Machines (ghi nhận, chưa khuyến nghị)
+
+Fly Machines = microVM có REST API tạo/dừng/xoá — về vai trò **tương đương docker.sock
+as-a-service**. Nếu thay adapter bollard bằng Fly Machines API:
+- ✅ Mỗi tenant một **microVM riêng** (Firecracker) — cách ly mạnh hơn hẳn container
+  chung kernel; xoá luôn rủi ro tồn dư §10.3-4 của v3.
+- ✅ Tính tiền theo giây khi máy chạy → hibernate = stop machine = gần như $0/tenant idle
+  → hợp mô hình nhiều tenant ngủ.
+- ❌ Always-on (Telegram long-poll) 1GB ≈ $5.7/máy/tháng → 50 tenant always-on ≈ $285/th,
+  đắt hơn hẳn 1 VPS 64GB. Chỉ rẻ khi chuyển được sang webhook + wake-on-demand (câu hỏi
+  mở #5 của v3).
+- ❌ PinchTab shared + private network nội bộ phải thiết kế lại trên 6PN/WireGuard của Fly.
+- ❌ Lịch sử ổn định của Fly không bằng Hetzner/netcup.
+
+Kết luận: giữ làm **option P3** khi tỷ lệ hibernate cao và cần isolation mạnh hơn; thiết
+kế panel nên tách `trait ContainerRuntime` (bollard | fly) để cửa này không bị đóng.
+
+## 5. Việc cần làm trước khi chốt (checklist mua máy)
+
+1. **Đo lại footprint thật ở P0** trên Mac (RAM idle/burst per tenant) → quy ra cỡ máy.
+2. Kiểm tra lại giá tại thời điểm mua (biến động RAM crisis; Hetzner đã tăng 4 lần trong 2026).
+3. **Nếu cân nhắc ARM (CAX/Oracle A1)**: kiểm chứng multi-arch của cả ba image —
+   zeroclaw (Rust, khả năng cao có arm64), pinchtab (Go, khả năng cao), và **Chromium
+   linux/arm64** (Google Chrome không có bản Linux ARM chính thức — pinchtab phải trỏ
+   `browser.binary` sang Chromium). Nếu lằng nhằng → chọn x86 cho đỡ rủi ro.
+4. Hardening VM khi lên production (ngoài scope v3 vì trước giờ là máy cá nhân):
+   SSH key-only + fail2ban, ufw chỉ mở 443 (D8), unattended-upgrades, Docker daemon
+   không expose TCP, panel :443 sau Caddy/traefik có TLS.
+5. Backup offsite: restic → object storage rẻ (Hetzner Storage Box ~€4/1TB hoặc
+   Backblaze B2) — bổ sung đích backup cho v3 §9.
+6. DR drill: khôi phục toàn bộ từ backup lên máy trống trong < 1 giờ (compose + volumes
+   restore) — single-node không HA, DR là lưới an toàn duy nhất.
+
+## 6. Câu hỏi mở
+
+1. Ngân sách tháng mục tiêu cho hạ tầng là bao nhiêu? (quyết netcup 16GB vs Hetzner 32GB
+   vs auction 64GB ngay từ đầu)
+2. Dashboard latency với user VN có là tiêu chí không? (nếu có: cân Hetzner SG/Vultr SG,
+   chấp nhận đắt hơn; nếu không: EU)
+3. Có yêu cầu data residency (dữ liệu hội thoại của khách VN phải ở VN)? — ảnh hưởng
+   pháp lý nhiều hơn kỹ thuật.
+4. Khi nào cần máy staging riêng thay vì Mac cá nhân? (đề xuất: khi có tenant trả phí
+   đầu tiên)
+
+---
+
+*Nguồn: Hetzner pricing/press (đợt điều chỉnh 15/06/2026), bitdoze/comparedge/betterstack
+tổng hợp giá Hetzner 2026, netcup.com gói RS G12, VPSBenchmarks (Hetzner A / Contabo F,
+CPU steal), DanubeData/Pingoru (uptime Contabo 91.11% Q2/2026), fly.io/docs/about/pricing,
+DigitalOcean pricing SGP. Chi tiết link trong PR/commit message.*

--- a/docs/design/scheduling-and-long-tasks.md
+++ b/docs/design/scheduling-and-long-tasks.md
@@ -1,6 +1,6 @@
 # Design: Việc theo lịch, và nhiều agent cùng làm một việc dài
 
-> Trạng thái: DRAFT — thiết kế, chưa triển khai. Kèm kế hoạch P0 chi tiết ở §10.
+> Trạng thái: **đã ship toàn bộ lộ trình** — P0 (PR #88–#91), P1a/P1b/P1c (#103, #104), P2+P3 (#105). Ghi chú triển khai ở §9b/§9c là những chỗ lệch với thiết kế và lý do; bảng §9 là nguồn chính xác.
 > Phạm vi: tầng điều phối (`internal/coord`, `internal/taskrunner`) và gateway. Kế thừa trực tiếp `docs/design/shared-agent-memory.md` (đã ship, PR #66–#70) và **là bản triển khai của S5 "Heartbeat & trạng thái"** trong `docs/design/sessions-and-workspaces.md` §10 — cộng thêm hai thứ S5 chưa có tên: lịch, và task cha–con.
 > Tham chiếu: OpenClaw (heartbeat, automations, background tasks, sub-agents) và Paperclip (heartbeat protocol, tách trạng thái việc khỏi trạng thái run). Chi tiết §3.
 

--- a/docs/design/sessions-and-workspaces.md
+++ b/docs/design/sessions-and-workspaces.md
@@ -1,6 +1,6 @@
 # Design: Hợp nhất session, và không gian làm việc theo session
 
-> Trạng thái: DRAFT — thiết kế, chưa triển khai.
+> Trạng thái: **ship một phần**. S0 (PR #75) và S1 (#76) xong; S5 được triển khai mở rộng ở [scheduling-and-long-tasks.md](./scheduling-and-long-tasks.md) và đã ship. **S2, S3, S4 vẫn mở.** Bảng §10 là nguồn chính xác.
 > Phạm vi: hai kênh vào của agent (Telegram và dashboard web), và chỗ đứng của **session** trong quan hệ với **task** (`docs/design/shared-agent-memory.md`) và **trace**.
 > Tham chiếu: [paperclipai/paperclip](https://github.com/paperclipai/paperclip) — đã clone và đọc để lấy mô hình heartbeat, atomic checkout, và execution workspace.
 

--- a/docs/design/shared-agent-memory.md
+++ b/docs/design/shared-agent-memory.md
@@ -1,6 +1,6 @@
 # Design: Bộ nhớ & điều phối dùng chung cho nhiều agent
 
-> Trạng thái: DRAFT — thiết kế, chưa triển khai.
+> Trạng thái: **đã ship**, trừ P1. P0, P2, P3, P4 xong ở PR #66–#70. P1 (gộp bảng session vào một DB) **cố ý bỏ** — vùng điều phối đã tách sang `~/.goterm-shared/data/coord.db`, nên lý do tồn tại của P1 không còn. Chi tiết §12.
 > Phạm vi: agent 1 (`bomclaw`, :18789) và agent 2 (`bomclaw2`, :18790) chạy song song trên cùng một máy Mac, cùng user, cùng binary.
 > Mục tiêu cuối: hai agent **thấy chung một bộ nhớ** và **giao việc được cho nhau**, thay vì hai ốc đảo như hôm nay.
 

--- a/docs/design/zeroclaw-docker-aaas.md
+++ b/docs/design/zeroclaw-docker-aaas.md
@@ -1,0 +1,359 @@
+# Design: ZeroClaw AaaS trên Docker (Mac, single-node) — PinchTab dùng chung, cô lập bằng tầng ứng dụng
+
+**Trạng thái**: DRAFT v3 — design first, chưa implement.
+**Ngày**: 2026-07-18
+**Lịch sử**: v1 = k8s namespace-per-tenant → v2 = k8s 1 namespace → **v3 = bỏ k8s, Docker
+thuần trên Mac** (quyết định của owner: tiết kiệm ~1-1.5GB overhead k8s control plane) và
+**PinchTab dùng chung cho mọi user, cô lập bằng cơ chế profile riêng** (quyết định của
+owner), gia cố bằng broker ở tầng ứng dụng.
+**Liên quan**: `agents-as-a-service.md` (AaaS trên nền bomclaw), `browser-control.md`
+(guard browser cho bomclaw — v3 tái dùng ý tưởng URL guard ở broker).
+
+---
+
+## 1. Tầm nhìn & ràng buộc
+
+Dịch vụ "personal AI agent": mỗi user một instance **ZeroClaw** chạy trong container
+Docker riêng, chat qua Telegram/dashboard, điều khiển browser qua **PinchTab dùng chung**.
+Đội tàu do **control panel Rust (`clawpanel`)** quản lý qua Docker API.
+
+Ràng buộc cứng (đã chốt với owner):
+1. Chạy trên **máy Mac này, thông qua Docker** (Docker Desktop hoặc OrbStack — khuyến nghị
+   OrbStack vì VM nhẹ hơn). Không Kubernetes.
+2. Mỗi user = 1 container ZeroClaw (`ghcr.io/zeroclaw-labs/zeroclaw`).
+3. **Một PinchTab duy nhất dùng chung** cho mọi user; độc lập dữ liệu browser giữa user
+   dựa trên cơ chế **profile** của PinchTab (mỗi profile = user-data-dir Chrome riêng:
+   cookies, login, storage tách nhau).
+4. Panel Rust điều khiển vòng đời container, network, volume.
+5. Cô lập data & security giữa user là bắt buộc, enforce bằng **tầng logic ứng dụng**
+   (panel là single writer, broker chặn trước PinchTab, egress proxy) — vì Docker thuần
+   không có namespace/NetworkPolicy/admission webhook như k8s.
+
+Ngoài phạm vi: billing chi tiết, token pool/rotation (xem `agents-as-a-service.md` §8,
+§12 — mặc định **BYO API key**).
+
+## 2. Thành phần bên thứ ba — đã khảo sát
+
+### 2.1 ZeroClaw
+
+- Runtime AI assistant **Rust**, RAM idle thấp (~vài chục MB) → mật độ cao trên 1 máy.
+- Config **TOML** `~/.zeroclaw/config.toml`; override bằng env `ZEROCLAW_<path>__<key>`.
+- Channels: Telegram (long-poll outbound), CLI, HTTP/WS gateway + dashboard **:42617**.
+- Image: `:latest` (distroless) / `:debian` (bash/git/curl — chọn bản này cho coding
+  agent). State `/zeroclaw-data` (`memory/`, `sessions/`, `state/`, `.secret_key`).
+- MCP client (`mcp.servers`), có tool `http` sẵn — dùng để gọi browser-broker.
+- ⚠️ Đang tái kiến trúc → pin image theo digest.
+
+### 2.2 PinchTab
+
+- Go binary ~12–15MB, tự quản Chrome, HTTP API mặc định `127.0.0.1:9867`.
+- Mô hình tài nguyên: **profiles** (browser state bền) → **instances** (process Chrome
+  per profile, start/stop theo yêu cầu) → **tabs**. Endpoint chính:
+  `POST /profiles`, `POST /instances/start`, `POST /instances/{id}/tabs/open`,
+  `POST /tabs/{tabId}/action` (`{"kind":"click","ref":"e5"}`), `GET /tabs/{tabId}/snapshot`
+  (a11y-tree, ref ổn định, ~800 token/trang).
+- Chrome chỉ chạy khi instance được start → idle gần như miễn phí. Profile data tại `/data`.
+- **Không có authentication, không có khái niệm tenant**: ai gọi được API là thấy được
+  *mọi* profile/instance/tab. → Dùng chung nhiều user **bắt buộc phải có broker** đứng
+  trước làm tenancy layer (§6). Đây là hệ quả thiết kế quan trọng nhất của v3.
+
+## 3. Nguyên tắc thiết kế
+
+1. **Panel là single writer của Docker**: chỉ `clawpanel` được mount `docker.sock`. Mọi
+   container/network/volume đều do panel tạo từ template, gắn label `com.claw.tenant=<id>`,
+   `com.claw.role=<agent|browser|broker|proxy|panel>`. Không ai `docker run` tay.
+2. **Không có admission webhook trong Docker** → bù bằng **audit-reconcile loop**: panel
+   định kỳ liệt kê toàn bộ container/network/volume, đối chiếu với trạng thái mong muốn
+   trong DB; mọi sai khác (mount lạ, network attach lạ, container không label) → alert +
+   tự sửa/cô lập.
+3. **Tenant không bao giờ nói chuyện trực tiếp với PinchTab.** Toàn bộ browser traffic đi
+   qua **browser-broker** (Rust): xác thực token per-tenant, map tenant → profile, chặn
+   cross-tenant, ép quota, URL guard.
+4. **Network cô lập bằng per-tenant internal network + multi-attach**: mỗi tenant một
+   Docker network `internal: true` (không NAT ra ngoài); các service dùng chung (broker,
+   egress-proxy, panel) được attach vào *từng* network tenant. Tenant A và B không chung
+   network nào → không route tới nhau.
+5. **Egress đi qua proxy có allowlist**: container tenant không có đường internet trực
+   tiếp; ra ngoài qua egress-proxy (FQDN allowlist: LLM providers, Telegram). SSRF/scan
+   LAN bị chặn ở đây.
+6. **Tiết kiệm trước**: PinchTab một bản, Chrome on-demand, hibernate = `docker stop`,
+   SQLite thay Postgres. Nhưng các chốt an ninh logic (broker auth, single-writer, audit
+   loop) không được đánh đổi.
+
+## 4. Kiến trúc tổng thể
+
+```
+ Mac ── Docker Desktop / OrbStack (Linux VM)
+┌──────────────────────────────────────────────────────────────────────────┐
+│                                                                          │
+│  [clawpanel]  Rust ──► /var/run/docker.sock (duy nhất)                   │
+│    ├─ REST API + Web UI  ◄──HTTPS── admin & users                        │
+│    ├─ Reverse proxy dashboard: /t/{tenant}/ ─► agent-{tenant}:42617      │
+│    ├─ Reconciler (bollard): DB desired state → docker containers        │
+│    ├─ Audit loop: docker thực tế ⇄ desired state (phát hiện lệch)        │
+│    └─ SQLite (tenants, secrets mã hoá, usage, audit)                     │
+│                                                                          │
+│  [egress-proxy]        FQDN allowlist (anthropic, openrouter, telegram…) │
+│    attach: net-alice, net-bob, …, bridge(ra internet)                    │
+│                                                                          │
+│  [browser-broker] Rust  ──► [pinchtab] :9867 ──► Chrome (per profile)    │
+│    attach: net-alice,        attach: net-browser (chỉ broker+pinchtab)   │
+│            net-bob, …,       volume: pinchtab-data (profile per tenant)  │
+│            net-browser                                                   │
+│    auth: Bearer token/tenant; map tenant→profile; URL guard; quota       │
+│                                                                          │
+│  net-alice (internal)              net-bob (internal)                    │
+│  ┌────────────────────┐            ┌────────────────────┐                │
+│  │ [agent-alice]      │            │ [agent-bob]        │                │
+│  │  zeroclaw :42617   │            │  zeroclaw :42617   │                │
+│  │  volume data-alice │            │  volume data-bob   │                │
+│  └────────────────────┘            └────────────────────┘                │
+│                                                                          │
+│  Đường đi: agent ──net-tenant──► broker ──net-browser──► pinchtab        │
+│            agent ──net-tenant──► egress-proxy ──bridge──► internet       │
+│            agent-A ⇄ agent-B : KHÔNG TỒN TẠI đường route                 │
+└──────────────────────────────────────────────────────────────────────────┘
+   User Telegram ⇄ long-poll outbound (qua egress-proxy), không cần mở port vào
+```
+
+## 5. Data plane — container per tenant
+
+### 5.1 Container spec (panel render từ template)
+
+```
+docker run (tương đương — panel gọi bollard):
+  name: agent-alice
+  image: ghcr.io/zeroclaw-labs/zeroclaw@sha256:<pinned>     # :debian
+  labels: com.claw.tenant=alice, com.claw.role=agent
+  networks: [net-alice]                                     # internal, duy nhất
+  volumes:  data-alice:/zeroclaw-data                       # named volume, duy nhất
+  env:
+    ZEROCLAW_providers__models__anthropic__default__api_key=…   # từ secret store panel
+    ZEROCLAW_channels__telegram__default__token=…
+    HTTP_PROXY=http://egress-proxy:3128                     # ép mọi egress qua proxy
+    HTTPS_PROXY=http://egress-proxy:3128
+    NO_PROXY=browser-broker,egress-proxy
+    CLAW_BROWSER_URL=http://browser-broker:8700             # cho skill/MCP browser
+    CLAW_BROWSER_TOKEN=<token-alice>                        # bearer per tenant
+  security:
+    user: non-root; no-new-privileges; cap-drop ALL
+    read-only rootfs + tmpfs /tmp (image debian cho phép)
+    memory limit 768m, cpus 1.0, pids-limit 256
+  restart: unless-stopped
+```
+
+Điểm chốt:
+- **Không mount docker.sock, không host network, không privileged** — bất biến (D-series §7.2).
+- Docker **không có Secret object** như k8s → secrets (API key, Telegram token, browser
+  token) sống trong **secret store mã hoá của panel** (SQLite + AES-GCM, master key trong
+  file quyền 0600 hoặc macOS Keychain), chỉ giải mã lúc render env khi tạo container.
+  `docker inspect` thấy env — chấp nhận được vì chỉ panel có socket.
+- Naming convention là bất biến: tenant `alice` ⇒ `agent-alice`, `net-alice`, `data-alice`,
+  token browser riêng. Audit loop đối chiếu đúng bộ ba này.
+- Docker address pool cấu hình sẵn (vd `10.200.0.0/16` chia `/28`) để đủ subnet cho
+  hàng trăm network tenant.
+
+### 5.2 Config injection
+
+Panel render `config.toml` (mount read-only từ thư mục config do panel quản) + env
+override `ZEROCLAW_…` (env thắng file). `.secret_key` của zeroclaw sinh lần đầu trên
+volume tenant.
+
+## 6. Browser plane — PinchTab dùng chung + browser-broker
+
+### 6.1 Phân vai
+
+```
+[zeroclaw alice] ──token alice──► [browser-broker] ──► [pinchtab] ──► Chrome(profile alice)
+[zeroclaw bob]   ──token bob────►        │                         └─► Chrome(profile bob)
+                                         │
+                              tenancy layer (Rust):
+                              1. AuthN: Bearer token → tenant
+                              2. Mapping: tenant → profile pinchtab (tạo lần đầu)
+                              3. AuthZ: mọi instanceId/tabId trong request phải
+                                 thuộc profile của tenant đó (broker giữ bảng sở hữu)
+                              4. Quota: ≤1 instance/tenant, ≤K instance toàn máy,
+                                 idle timeout → stop instance
+                              5. URL guard: chặn navigate tới private CIDR,
+                                 metadata, localhost (như browser-control.md §6.3)
+                              6. Audit: log (tenant, action, url) — không log nội dung
+```
+
+- **Cô lập dữ liệu browser** = profile PinchTab (mỗi profile một user-data-dir Chrome:
+  cookie/login/history tách nhau) — đúng cơ chế owner chọn.
+- **Cô lập truy cập API** = broker. Thiếu broker thì mọi tenant thấy tab của nhau vì
+  PinchTab không auth (§2.2). Broker là thành phần *bắt buộc*, không phải tối ưu.
+- PinchTab container chỉ nằm trên `net-browser` cùng broker — không tenant nào route tới
+  :9867 trực tiếp.
+
+### 6.2 API broker (phác thảo — cố ý hẹp hơn PinchTab)
+
+```
+POST /v1/browser/navigate   {url}                → mở/tái dùng instance+tab của tenant
+GET  /v1/browser/snapshot   ?filter=interactive  → a11y snapshot (ref e1,e2…)
+POST /v1/browser/act        {kind, ref, text?}   → click/fill/press…
+GET  /v1/browser/tabs       / POST open / close  → trong phạm vi profile tenant
+GET  /v1/browser/screenshot
+POST /v1/browser/stop                            → trả Chrome về idle
+```
+
+Không expose endpoint quản trị (`/profiles`, `/instances` của PinchTab) cho tenant.
+Giai đoạn 1: zeroclaw gọi broker bằng tool `http` + skill mô tả API. Giai đoạn 2:
+broker expose thêm **MCP transport** để khai vào `mcp.servers` của zeroclaw → tool
+`browser__*` có schema chuẩn (kiểm chứng transport zeroclaw hỗ trợ ở P0 — câu hỏi mở #2).
+
+### 6.3 Giới hạn thẳng thắn của mô hình dùng chung
+
+Profile cô lập **dữ liệu**, không phải **ranh giới an ninh runtime**: mọi Chrome process
+của mọi tenant chạy chung một container PinchTab. Một trang web độc khai thác được lỗ
+hổng Chrome (RCE) trong phiên của tenant A ⇒ code chạy trong container pinchtab ⇒ đọc
+được profile của *mọi* tenant. Giảm nhẹ:
+- Chrome/PinchTab pin bản mới, cập nhật nhanh (Chrome vá RCE liên tục);
+- container pinchtab: non-root, cap-drop, no-new-privileges, chỉ có `net-browser`
+  + egress qua proxy (hạn chế exfil);
+- **escape hatch trong thiết kế**: schema đã có `browser_mode: shared | dedicated` per
+  tenant — tenant nhạy cảm/trả tiền cao cấp được cấp pinchtab container riêng (panel chỉ
+  cần đổi template, broker trỏ endpoint khác). Mặc định: shared (quyết định owner).
+
+Rủi ro tồn dư này được chấp nhận có chủ đích để đổi lấy mật độ (ghi ở §10.3).
+
+## 7. Cô lập & network — bảng bù cho việc không có k8s
+
+### 7.1 Ma trận cô lập
+
+| Tầng | Cơ chế | Chống gì |
+|------|--------|----------|
+| Compute | container riêng per tenant, non-root, cap-drop, pids/mem/cpu limit | noisy neighbor, leo thang trong container |
+| Disk | named volume per tenant, chỉ mount vào container của chính tenant (audit loop kiểm) | user đụng phân vùng nhau |
+| Browser data | profile PinchTab per tenant | lẫn cookie/session giữa user |
+| Browser API | broker: token per tenant + bảng sở hữu instance/tab | tenant A điều khiển browser tenant B |
+| Network | per-tenant internal net; service chung multi-attach; không ICC chéo | lateral movement |
+| Egress | proxy FQDN allowlist; tenant net không NAT trực tiếp | SSRF, scan LAN/metadata, exfil bừa |
+| Docker API | chỉ panel mount docker.sock | tenant thao túng hạ tầng |
+| Secrets | store mã hoá trong panel, giải mã lúc create container | đọc chéo credential |
+| Host Mac | Docker VM boundary (Desktop/OrbStack) | sự cố tồi nhất bị nhốt trong VM |
+
+### 7.2 Bất biến (D1–D8) — panel enforce khi tạo + audit loop kiểm định kỳ
+
+```
+D1. Container role=agent: đúng 1 label tenant, đúng 1 network net-<tenant>,
+    đúng 1 volume data-<tenant>. Không mount gì khác.
+D2. Không container nào ngoài clawpanel được mount docker.sock.
+D3. Không container tenant nào: privileged, host network/pid/ipc, cap-add,
+    mount đường dẫn host.
+D4. pinchtab chỉ attach net-browser; không publish port nào ra host.
+D5. broker là container duy nhất attach đồng thời net-browser + các net tenant.
+D6. Mọi container thuộc hệ thống phải có label com.claw.* ; container lạ trong
+    phạm vi quản lý → alert.
+D7. Image chỉ từ digest allowlist trong DB panel.
+D8. Port publish ra host: duy nhất clawpanel :443 (API/UI/proxy). Không gì khác.
+```
+
+Audit loop chạy mỗi 30–60s: `list containers/networks/volumes` → so khớp desired state
+→ lệch thì sửa (stop/disconnect) + ghi audit + notify. Đây là "webhook thay thế" của v3.
+
+### 7.3 Egress-proxy
+
+- Squid hoặc proxy Rust nhỏ (ưu tiên viết Rust chung repo — CONNECT proxy + allowlist,
+  ~vài trăm dòng, khỏi kéo image lạ).
+- Per-tenant policy: allowlist mặc định (`api.anthropic.com`, `openrouter.ai`,
+  `api.telegram.org`, registry skill…) + tenant mở rộng qua panel (có audit).
+- Chrome trong pinchtab cũng cần đi qua proxy (container pinchtab nằm trên net nội bộ):
+  PinchTab cho đặt Chrome binary/flags hay proxy per-profile → kiểm chứng ở P0; nếu
+  không đặt được `--proxy-server` per instance thì cho pinchtab attach bridge (egress
+  trực tiếp) và dựa vào URL guard của broker + chấp nhận residual DNS-rebinding
+  (câu hỏi mở #3).
+
+## 8. Control panel — `clawpanel` (Rust)
+
+| Lớp | Chọn | Ghi chú |
+|-----|------|---------|
+| Docker API | **bollard** | async, đầy đủ container/network/volume/events |
+| HTTP API + UI + reverse proxy | **axum** + tower | một framework ba vai |
+| DB | **SQLite + sqlx** (WAL) | repo pattern để lên Postgres khi cần |
+| Secret store | AES-GCM trong SQLite, master key file 0600 / macOS Keychain | Docker không có Secret object |
+| AuthN | password/magic-link tenant; 2FA admin | |
+| Observability | `tracing` + file log xoay vòng; metrics endpoint | không bắt buộc Prometheus |
+
+Một binary, các task: API/UI, reverse proxy dashboard, reconciler (desired state trong DB
+→ Docker qua bollard), audit loop (§7.2), capacity ledger.
+
+- **Capacity ledger**: budget máy (CPU/RAM cấp cho Docker VM) − Σ limits đã cấp; vượt →
+  từ chối provision/resume. Cộng thêm semaphore Chrome toàn máy (≤K instance, K≈6–8).
+- **Reverse proxy dashboard**: user → panel (auth session, scope tenant) → attach sẵn vào
+  net tenant → `agent-<tenant>:42617`. Chỉ panel publish port ra host (D8).
+- **API** (rút gọn): `POST/GET/PATCH/DELETE /api/tenants`, `PUT /api/tenants/{id}/secrets/*`
+  (write-only), `/usage`, `/health`, `/restart`, `GET /api/audit`. DB:
+  `tenants/plans/secrets(enc)/usage_daily/audit_log/images_allowlist`.
+- **Flow provision**: INSERT tenant → reconciler: volume → network → (connect broker+proxy
+  vào net mới) → container agent → broker cấp token + tạo profile pinchtab lần đầu dùng
+  → Ready, hướng dẫn nhập Telegram token/API key. Mục tiêu < 30s (image pre-pulled).
+
+## 9. Vòng đời & vận hành
+
+- **Hibernate** = `docker stop agent-<t>` (volume giữ; Telegram offset trong state → wake
+  đọc backlog). Auto-hibernate sau N giờ idle — đòn bẩy mật độ chính. Chrome instance
+  idle do broker tự stop (timeout).
+- **Delete**: soft-delete → 30 ngày → xoá container/network/volume + profile pinchtab
+  (broker gọi xoá profile) theo label selector; orphan-sweep nằm sẵn trong audit loop.
+- **Upgrade zeroclaw/pinchtab**: đổi digest trong allowlist → reconciler recreate theo
+  ring (vài tenant canary trước). PinchTab nâng bản cần đọc changelog phần bind/auth (§10.2).
+- **Backup**: job định kỳ `docker run --rm -v data-<t>:/src -v backup:/dst tar` + restic
+  ra đĩa ngoài; pinchtab-data backup cả cụm (profile theo thư mục).
+- **Sự cố máy Mac ngủ/restart**: Docker Desktop/OrbStack tự khởi động lại, container
+  `restart: unless-stopped`; panel lên trước (depends) rồi audit loop tự đối soát.
+- **Ước tính mật độ** (VM Docker cấp 8 CPU / 12–16Gi):
+  - Hạ tầng thường trực: panel + broker + proxy + pinchtab idle ≈ **300–400Mi** (so với
+    ~1.5Gi nếu còn k8s).
+  - Tenant idle ≈ zeroclaw ~50–128Mi → **70–100 tenant idle** về RAM.
+  - Chrome ~400Mi–1Gi/phiên → **6–8 phiên browse đồng thời** (semaphore K).
+
+## 10. Threat model & rủi ro chính
+
+| # | Mối đe doạ | Kiểm soát | Tồn dư |
+|---|------------|-----------|--------|
+| 1 | Tenant A điều khiển browser/tab của B | broker auth + bảng sở hữu (§6.1); pinchtab không route trực tiếp (D4/D5) | thấp |
+| 2 | Cross-tenant network | per-tenant internal net, không net chung giữa tenant | thấp |
+| 3 | **Chrome RCE trong pinchtab chung** → đọc mọi profile | pin/update nhanh, hardening container, egress proxy chặn exfil; escape hatch `dedicated` | **trung bình — chấp nhận có chủ đích** (quyết định shared của owner) |
+| 4 | SSRF/scan LAN/metadata (prompt injection) | tenant net internal + egress-proxy allowlist; URL guard broker cho Chrome | DNS-rebinding nếu Chrome không qua proxy (mở #3) |
+| 5 | Tenant đụng volume nhau | D1 + audit loop; named volume chỉ mount bởi panel | thấp |
+| 6 | Chiếm panel = chiếm tất cả (docker.sock = root VM) | panel là bề mặt tấn công chính: 2FA admin, secrets mã hoá, audit, cập nhật deps (cargo-audit), chỉ :443 publish | trung bình — SPOF có chủ đích |
+| 7 | Thao tác docker tay phá bất biến | D-series + audit loop tự sửa + alert | thấp |
+| 8 | Noisy neighbor | mem/cpu/pids limit + capacity ledger + Chrome semaphore | thấp |
+| 9 | Supply chain (image) | D7 digest allowlist | thấp |
+| 10 | ZeroClaw upstream gãy API config | pin digest, canary ring | thấp |
+
+So với k8s (v2): mất PSA/webhook/NetworkPolicy chuẩn → thay bằng D-series + audit loop
++ broker, tất cả nằm trong code panel ⇒ **test suite cho D1–D8 và broker AuthZ là
+deliverable bắt buộc của P1**, không phải nice-to-have.
+
+## 11. Lộ trình
+
+| Phase | Nội dung | Nghiệm thu |
+|-------|----------|------------|
+| **P0 — PoC** (tay, docker compose) | 2 tenant: agent+net+volume; pinchtab + broker stub (auth token cứng); egress-proxy; zeroclaw gọi broker qua tool http | A không gọi được B (:42617), không thấy tab của B, không ra được LAN/private; browse OK; đo RAM idle |
+| **P1 — Panel MVP** | clawpanel: bollard reconciler + audit loop D1–D8 + API/UI + secret store + capacity ledger + hibernate; broker hoàn chỉnh (ownership, quota, URL guard) | provision < 30s không docker tay; test suite D-series + broker AuthZ pass |
+| **P2 — Product hoá** | broker MCP transport; reverse-proxy dashboard + auth; metering; backup restic; Chrome semaphore tinh chỉnh; `browser_mode: dedicated` | 20–50 tenant thật trên máy này |
+| **P3 — Mở rộng** | billing; managed-key proxy; đường lên multi-node (Postgres + quay lại k8s design v2 nếu vượt 1 máy) | theo traction |
+
+## 12. Câu hỏi mở
+
+1. OrbStack hay Docker Desktop? (khuyến nghị OrbStack: VM nhẹ, network nhanh hơn trên Mac;
+   Docker Desktop phổ biến hơn). Budget CPU/RAM cấp cho VM là bao nhiêu?
+2. zeroclaw `mcp.servers` hỗ trợ transport nào (stdio only hay có HTTP/streamable)? Quyết
+   cách broker expose MCP ở P2; P0-P1 dùng tool `http` là đủ.
+3. PinchTab có cho đặt Chrome `--proxy-server` (per profile/instance) không? Quyết việc
+   Chrome đi qua egress-proxy hay chỉ dựa URL guard (§7.3).
+4. Giới hạn profile/instance của PinchTab khi ~50-100 profile trong một container? (RAM
+   map profile registry, tốc độ start Chrome) — đo ở P0.
+5. Telegram long-poll (giữ container luôn chạy) vs webhook qua panel (wake-from-hibernate,
+   tăng mật độ) — MVP long-poll; webhook đáng làm ở P2 nếu mật độ hibernate quan trọng.
+6. Panel có cần chế độ read-only cho owner xem hội thoại tenant không? (mặc định thiết kế:
+   KHÔNG — sessions nằm trong volume tenant, panel không đọc; nếu cần support phải có cơ
+   chế consent per tenant.)
+
+---
+
+*Nguồn khảo sát: deepwiki `zeroclaw-labs/zeroclaw`; `github.com/pinchtab/pinchtab` README
++ pinchtab.com/docs (2026-07); các bản thiết kế trước: `agents-as-a-service.md`,
+`browser-control.md`, và v1/v2 của chính file này (lịch sử git).*


### PR DESCRIPTION
Closes #117

Ba doc mở đầu bằng `DRAFT — thiết kế, chưa triển khai` trong khi bảng lộ trình bên trong đã tick từng PR một. Header là thứ đọc đầu tiên, nên cả cây tài liệu trông như chưa ai làm gì.

| File | Trước | Sau |
|---|---|---|
| `scheduling-and-long-tasks.md` | chưa triển khai | đã ship toàn bộ — P0 (#88–91), P1a/b/c (#103, #104), P2+P3 (#105) |
| `shared-agent-memory.md` | chưa triển khai | đã ship trừ P1, và P1 **cố ý bỏ** vì coord đã tách ra DB riêng |
| `sessions-and-workspaces.md` | chưa triển khai | ship một phần — S0/S1 xong, S5 ship qua doc scheduling, **S2–S4 vẫn mở** |

Không viết gọn thành "done": hai trong ba doc có phần chưa làm, và nói rõ phần đó mới là thứ có ích cho người đọc tiếp theo.

Issue #8 ("Kiến trúc HEARTBEAT") tôi để riêng — đó là thao tác đóng issue, không phải thay đổi code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)