### PR TITLE
feat(coord): cap how big one task tree may get

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -301,6 +301,9 @@ func runGateway(args []string) {
 		if err == nil && cfg.Coord.ArtifactsDir != "" {
 			coordDB.SetArtifactsDir(cfg.Coord.ArtifactsDir)
 		}
+		if err == nil && cfg.Tasks.MaxPerContext > 0 {
+			coordDB.SetMaxTasksPerContext(cfg.Tasks.MaxPerContext)
+		}
 		if err != nil {
 			log.Printf("coord: disabled — %v", err)
 			coordDB = nil

--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -250,7 +250,17 @@ function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask }: {
                 <div><dt className="text-gray-600">created by</dt><dd className="font-mono text-gray-300">{t.created_by}</dd></div>
                 <div><dt className="text-gray-600">claimed by</dt><dd className="font-mono text-gray-300">{t.claimed_by || '—'}</dd></div>
                 <div><dt className="text-gray-600">assigned to</dt><dd className="font-mono text-gray-300">{t.assigned_to || 'any'}</dd></div>
-                <div><dt className="text-gray-600">context</dt><dd className="font-mono text-gray-300 truncate">{t.context_id}</dd></div>
+                <div>
+                  <dt className="text-gray-600">context</dt>
+                  <dd className="font-mono text-gray-300 truncate">
+                    {t.context_id}
+                    {!!detail.context_cap && (
+                      <span className={detail.context_count! >= detail.context_cap ? 'ml-1 text-amber-400' : 'ml-1 text-gray-500'}>
+                        {detail.context_count}/{detail.context_cap}
+                      </span>
+                    )}
+                  </dd>
+                </div>
               </dl>
 
               {t.parent_id && (

--- a/dashboard/src/admin/types.ts
+++ b/dashboard/src/admin/types.ts
@@ -131,7 +131,9 @@ export interface TaskDetail {
   task: Task
   events: TaskEvent[]
   runs: TaskRun[]
-  children: Task[] // the tasks it split off (`bomclaw task sub`); empty for a leaf
+  children: Task[]
+  context_count?: number
+  context_cap?: number // the tasks it split off (`bomclaw task sub`); empty for a leaf
 }
 
 export interface Message {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,11 @@ type TasksConfig struct {
 	PollIntervalSeconds int  `yaml:"poll_interval_seconds"` // default 60
 	TimeoutMinutes      int  `yaml:"timeout_minutes"`       // default 15
 	Concurrency         int  `yaml:"concurrency"`           // default 1: tasks run at once (chat has its own lane)
+
+	// MaxPerContext caps how many tasks one tree may hold, finished ones
+	// included (default 50). MaxOpenChildren and MaxDepth are local caps and
+	// cannot see the size of the tree they are building between them.
+	MaxPerContext int `yaml:"max_per_context"`
 }
 
 // SchedulesConfig tunes the scheduler (docs/design/scheduling-and-long-tasks.md

--- a/internal/coord/children.go
+++ b/internal/coord/children.go
@@ -18,6 +18,39 @@ import (
 // fans out without bound is a loop with extra steps.
 const MaxOpenChildren = 8
 
+// DefaultMaxTasksPerContext caps a whole task tree, which MaxOpenChildren and
+// MaxDepth together do not: eight open children five levels deep is 32768 tasks
+// on paper, and handing a child to another agent made that easier to reach, not
+// harder. The two existing caps are local — how wide one parent may fan out,
+// how deep the tree may go — and neither can see the size of what they are
+// building between them.
+//
+// It counts finished tasks too. The cap is about how big one piece of work was
+// allowed to become, and a tree that produced fifty tasks has answered that
+// whether or not they are still open.
+const DefaultMaxTasksPerContext = 50
+
+// MaxTasksPerContext is the cap in force, from config or the default.
+func (db *DB) MaxTasksPerContext() int {
+	if db.maxTasksPerContext <= 0 {
+		return DefaultMaxTasksPerContext
+	}
+	return db.maxTasksPerContext
+}
+
+// SetMaxTasksPerContext overrides the cap. Config calls it at startup.
+func (db *DB) SetMaxTasksPerContext(n int) { db.maxTasksPerContext = n }
+
+// TasksInContext counts every task in one tree, finished ones included.
+func (db *DB) TasksInContext(contextID string) (int, error) {
+	var n int
+	if err := db.conn.QueryRow(
+		`SELECT count(*) FROM tasks WHERE context_id = ?`, contextID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count tasks in %s: %w", contextID, err)
+	}
+	return n, nil
+}
+
 // ChildrenDoneEvent is the task_events note that marks a parent waking.
 const ChildrenDoneEvent = "children-done"
 
@@ -58,6 +91,18 @@ func (db *DB) CreateSubTask(parentID, byAgent string, n NewTask) (*Task, error) 
 	}
 	if open >= MaxOpenChildren {
 		return nil, fmt.Errorf("coord: task %s already has %d unfinished children (max %d) — wait for some to finish", parentID, open, MaxOpenChildren)
+	}
+	// The tree-wide cap. The error says the number because the agent reading it
+	// is the one who has to decide what to drop or merge — "too many tasks" it
+	// cannot act on, "47 of 50" it can.
+	inContext, err := db.TasksInContext(parent.ContextID)
+	if err != nil {
+		return nil, err
+	}
+	if cap := db.MaxTasksPerContext(); inContext >= cap {
+		return nil, fmt.Errorf("coord: context %s already holds %d tasks (max %d) — "+
+			"this piece of work has grown past what one tree should carry: finish or merge "+
+			"some of it, or start a separate task rather than another child", parent.ContextID, inContext, cap)
 	}
 	if utf8.RuneCountInString(strings.TrimSpace(n.Body)) < MinSubTaskBody {
 		return nil, fmt.Errorf("coord: a child needs a brief of its own (at least %d characters). "+

--- a/internal/coord/children_test.go
+++ b/internal/coord/children_test.go
@@ -237,3 +237,80 @@ func TestParentWakesWithAnArtifactIndexNotTheContent(t *testing.T) {
 		t.Errorf("checkpoint is %d bytes for one child; the index should be small", n)
 	}
 }
+
+// TestContextCapStopsTheTreeFromSpreading: MaxOpenChildren and MaxDepth are
+// both local — eight wide and five deep is 32768 tasks between them, and
+// neither cap can see that number. This one can.
+func TestContextCapStopsTheTreeFromSpreading(t *testing.T) {
+	db := testDB(t)
+	db.SetMaxTasksPerContext(5) // the root plus four children
+
+	db.CreateTask(NewTask{CreatedBy: "human", Title: "Big piece of work", AssignedTo: "a1"})
+	parent, _ := claimStart(t, db, "a1")
+
+	body := "Placeholder child with a brief long enough to pass the minimum body rule."
+	for i := 0; i < 4; i++ {
+		if _, err := db.CreateSubTask(parent.ID, "a1", NewTask{Title: "child", Body: body}); err != nil {
+			t.Fatalf("child %d: %v", i+1, err)
+		}
+	}
+
+	_, err := db.CreateSubTask(parent.ID, "a1", NewTask{Title: "one too many", Body: body})
+	if err == nil {
+		t.Fatal("the 6th task in the context was allowed")
+	}
+	// The agent reading this has to decide what to drop, so the numbers matter.
+	for _, want := range []string{"5 tasks", "max 5"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should say %q, got: %v", want, err)
+		}
+	}
+
+	// Finishing one must NOT free a slot: the cap is about how big this piece
+	// of work was allowed to become, and that is already answered.
+	children, _ := db.Children(parent.ID)
+	if err := db.CancelTask(children[0].ID, "a1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateSubTask(parent.ID, "a1", NewTask{Title: "still too many", Body: body}); err == nil {
+		t.Error("cancelling a child reopened the tree-wide cap")
+	}
+}
+
+// TestContextCapIsPerTree: one piece of work hitting the cap must not stop
+// another. Separate databases because ClaimTask takes the oldest claimable
+// task, which in one database would be a child of the tree being filled.
+func TestContextCapIsPerTree(t *testing.T) {
+	body := "Placeholder child with a brief long enough to pass the minimum body rule."
+	fill := func(db *DB, agent string) *Task {
+		db.SetMaxTasksPerContext(2)
+		db.CreateTask(NewTask{CreatedBy: "human", Title: "work", AssignedTo: agent})
+		parent, _ := claimStart(t, db, agent)
+		if _, err := db.CreateSubTask(parent.ID, agent, NewTask{Title: "child", Body: body}); err != nil {
+			t.Fatalf("first child: %v", err)
+		}
+		return parent
+	}
+
+	full := testDB(t)
+	parent := fill(full, "a1")
+	if _, err := full.CreateSubTask(parent.ID, "a1", NewTask{Title: "over", Body: body}); err == nil {
+		t.Fatal("the first tree was not capped")
+	}
+
+	fresh := testDB(t)
+	fill(fresh, "a1") // its own tree, its own count
+}
+
+// TestContextCapDefaultsWhenUnset guards the knob: config absent means 50, not
+// zero, and zero would refuse every child.
+func TestContextCapDefaultsWhenUnset(t *testing.T) {
+	db := testDB(t)
+	if got := db.MaxTasksPerContext(); got != DefaultMaxTasksPerContext {
+		t.Fatalf("cap with no config: got %d, want %d", got, DefaultMaxTasksPerContext)
+	}
+	db.SetMaxTasksPerContext(0)
+	if got := db.MaxTasksPerContext(); got != DefaultMaxTasksPerContext {
+		t.Fatalf("cap set to 0: got %d, want the default %d", got, DefaultMaxTasksPerContext)
+	}
+}

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -35,6 +35,8 @@ type DB struct {
 	// artifactsDir is the root artifact bytes are written under; empty means
 	// DefaultArtifactsDir. Config overrides it, tests point it at t.TempDir.
 	artifactsDir string
+	// maxTasksPerContext caps the size of one task tree; 0 means the default.
+	maxTasksPerContext int
 }
 
 // DefaultPath is where the shared database lives when config says nothing.

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -133,6 +133,12 @@ type TaskDetail struct {
 	Events   []coord.TaskEvent `json:"events"`
 	Runs     []coord.TaskRun   `json:"runs"`
 	Children []coord.Task      `json:"children"` // the tasks it split off; empty for a leaf
+
+	// How big this piece of work has grown, against the cap that refuses the
+	// next child. Counted server-side: the board's own list is truncated by
+	// its limit, so counting there would be quietly wrong on a large tree.
+	ContextCount int `json:"context_count"`
+	ContextCap   int `json:"context_cap"`
 }
 
 func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -159,7 +165,14 @@ func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(TaskDetail{Task: task, Events: events, Runs: runs, Children: children})
+	inContext, err := deps.Coord.TasksInContext(task.ContextID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(TaskDetail{
+		Task: task, Events: events, Runs: runs, Children: children,
+		ContextCount: inContext, ContextCap: deps.Coord.MaxTasksPerContext(),
+	})
 }
 
 type taskResumeParams struct {


### PR DESCRIPTION
Closes #116 — câu hỏi mở số 5 của `docs/design/agent-teams-and-channels.md`.

## Vấn đề

`MaxOpenChildren` (8) và `MaxDepth` (5) đều là cap **cục bộ**: một cái đếm bề ngang của một cha, một cái đếm chiều sâu. Không cái nào nhìn thấy con số chúng tạo ra cùng nhau — 8^5 = 32768 task trên lý thuyết. R3 (giao con cho agent khác) làm việc này **dễ hơn** trước chứ không khó hơn.

## Cách làm

`CreateSubTask` đếm cả cây (`context_id`) và từ chối khi chạm cap — mặc định 50, chỉnh bằng `tasks.max_per_context`.

**Đếm cả task đã xong.** Cap nói về việc *một mảnh việc được phép phình tới đâu*, và một cây đã đẻ ra 50 task thì đã trả lời câu đó rồi, bất kể còn mở hay không. Có test ghim đúng điểm này, vì "huỷ một con để lấy chỗ" là cách hiểu sai hiển nhiên nhất.

Lỗi mang theo cả hai con số: agent đọc nó là kẻ phải quyết bỏ gì gộp gì — *"quá nhiều task"* thì không hành động được, *"50/50"* thì được.

## Dashboard

Drawer hiện `ctx_xxx 47/50` (vàng khi chạm cap). Đếm ở **server** trong `tasks.get`, không đếm ở client: danh sách của board bị cắt theo `limit`, nên đếm phía client sẽ sai đúng vào những cây lớn — tức đúng trường hợp mà cap này sinh ra để lo.

## Test

- `TestContextCapStopsTheTreeFromSpreading` — chặn ở 6/5, lỗi có số, và huỷ một con **không** mở lại chỗ
- `TestContextCapIsPerTree` — cây này đầy không chặn cây khác
- `TestContextCapDefaultsWhenUnset` — không cấu hình → 50, không phải 0 (0 sẽ từ chối mọi con)

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)