### PR TITLE
feat(coord): work product ages out, reports do not

### DIFF
--- a/cmd/bomclaw/artifactcmd.go
+++ b/cmd/bomclaw/artifactcmd.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/ngocp/goterm-control/internal/coord"
 )
@@ -164,6 +165,46 @@ func runArtifact(args []string) {
 		}
 		fmt.Printf("%s is now an %s of %s\n", *id, *role, *taskID)
 
+	case "purge":
+		fs := flag.NewFlagSet("artifact purge", flag.ExitOnError)
+		dbPath := dbFlag(fs)
+		days := fs.Int("older-than-days", 30, "Delete work product of task trees finished more than this many days ago")
+		dry := fs.Bool("dry-run", false, "List what would go, delete nothing")
+		fs.Parse(rest)
+
+		db := openCoord(*dbPath)
+		defer db.Close()
+		cutoff := time.Now().AddDate(0, 0, -*days)
+
+		if *dry {
+			list, err := db.PurgeableArtifacts(cutoff)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "artifact purge: %v\n", err)
+				os.Exit(1)
+			}
+			if len(list) == 0 {
+				fmt.Printf("nothing to purge older than %d days\n", *days)
+				return
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tKIND\tSIZE\tCONTEXT\tTITLE")
+			var bytes int64
+			for _, a := range list {
+				bytes += a.Bytes
+				fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", a.ID, a.Kind, a.Bytes, a.ContextID, a.Title)
+			}
+			w.Flush()
+			fmt.Printf("\n%d artifacts, %d bytes — documents are never purged\n", len(list), bytes)
+			return
+		}
+
+		rows, files, err := db.PurgeArtifacts(cutoff)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "artifact purge: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("purged %d artifacts (%d files) from task trees finished over %d days ago\n", rows, files, *days)
+
 	default:
 		artifactUsage()
 		os.Exit(1)
@@ -206,6 +247,7 @@ Usage: bomclaw artifact <command>
   list  (--task <id> [--tree] | --context <id>)
   get   <artifact-id> [--out FILE]
   link  --id <artifact> --task <id> [--role input|output]
+  purge [--older-than-days 30] [--dry-run]
 
 An artifact is how work crosses a task boundary. Put what you produced against
 your task; a parent gathering children sees the index and reads only what it

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -810,7 +810,8 @@ func startCoordUpkeep(ctx context.Context, cdb *coord.DB, cfg *config.Config, bi
 	// tasks and task_runs are the work ledger and are kept. Every gateway runs
 	// this — a DELETE below a cutoff is idempotent, so two of them are harmless.
 	traceDays, scheduleDays := cfg.Coord.TraceRetentionDays, cfg.Schedules.RunRetentionDays
-	if traceDays > 0 || scheduleDays > 0 {
+	artifactDays := cfg.Coord.ArtifactRetentionDays
+	if traceDays > 0 || scheduleDays > 0 || artifactDays > 0 {
 		go func() {
 			purge := func() {
 				if traceDays > 0 {
@@ -827,6 +828,14 @@ func startCoordUpkeep(ctx context.Context, cdb *coord.DB, cfg *config.Config, bi
 						log.Printf("coord: purge schedule runs: %v", err)
 					} else if n > 0 {
 						log.Printf("coord: purged %d schedule runs older than %d days", n, scheduleDays)
+					}
+				}
+				if artifactDays > 0 {
+					rows, files, err := cdb.PurgeArtifacts(time.Now().AddDate(0, 0, -artifactDays))
+					if err != nil {
+						log.Printf("coord: purge artifacts: %v", err)
+					} else if rows > 0 {
+						log.Printf("coord: purged %d artifacts (%d files) from task trees finished over %d days ago", rows, files, artifactDays)
 					}
 				}
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,14 @@ type CoordConfig struct {
 	ArtifactsDir       string `yaml:"artifacts_dir"`        // default ~/goterm-shared/artifacts
 	TraceRetentionDays int    `yaml:"trace_retention_days"` // default 7; 0 disables the purge
 
+	// ArtifactRetentionDays is how long the work product of a FINISHED task
+	// tree is kept (default 30; 0 disables). Deliberately not the same number
+	// as traces: a trace answers "how did that run go", which stops mattering
+	// within the week, while an artifact is the thing the run produced. Tying
+	// them together means one of the two is always wrong. kind=document is
+	// never purged.
+	ArtifactRetentionDays int `yaml:"artifact_retention_days"`
+
 	// ReplyToMentions is whether being named in a channel makes this agent run
 	// a turn and answer. Pointer for the same reason as Enabled: absent means
 	// on. Turning it off leaves the room readable and the mention recorded —
@@ -318,6 +326,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Coord.TraceRetentionDays == 0 {
 		cfg.Coord.TraceRetentionDays = 7
+	}
+	if cfg.Coord.ArtifactRetentionDays == 0 {
+		cfg.Coord.ArtifactRetentionDays = 30
 	}
 	if cfg.Tasks.PollIntervalSeconds == 0 {
 		cfg.Tasks.PollIntervalSeconds = 60

--- a/internal/coord/artifacts.go
+++ b/internal/coord/artifacts.go
@@ -2,6 +2,7 @@ package coord
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -355,6 +356,136 @@ func scanArtifactsWithRole(rows interface {
 		}
 		a.CreatedAt = parseTS(created)
 		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// PurgeArtifacts deletes the work product of task trees that finished more
+// than `before` ago, and reports how many rows and files went.
+//
+// Three rules, each with a reason:
+//
+//   - Only contexts where EVERY task has reached a terminal state. A tree with
+//     one task still open is work in progress, however old the rest of it is.
+//   - kind=document is kept. Patches, files and results are intermediate — the
+//     bytes a parent handed a child — while a document is the report someone
+//     asked for, and disk is cheaper than deleting that.
+//   - The row goes first, then the file. The other order is tempting because
+//     the bytes are the bulk, but a row whose file is gone is a broken read for
+//     anything that lists artifacts, while a file with no row is only disk.
+//
+// Safe to run from several gateways at once: the SELECT and the DELETE are one
+// transaction, so a second caller finds nothing left to take.
+func (db *DB) PurgeArtifacts(before time.Time) (rows, files int, err error) {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return 0, 0, fmt.Errorf("purge artifacts: %w", err)
+	}
+	defer tx.Rollback()
+
+	// A context qualifies when it has no non-terminal task left and its last
+	// movement is older than the cutoff. updated_at on a terminal task is when
+	// it stopped moving.
+	cur, err := tx.Query(`SELECT id, path FROM artifacts WHERE `+purgeableWhere,
+		purgeableArgs(before)...)
+	if err != nil {
+		return 0, 0, fmt.Errorf("purge artifacts: %w", err)
+	}
+	var ids, paths []string
+	for cur.Next() {
+		var id, path string
+		if err := cur.Scan(&id, &path); err != nil {
+			cur.Close()
+			return 0, 0, fmt.Errorf("purge artifacts: %w", err)
+		}
+		ids = append(ids, id)
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	cur.Close()
+	if err := cur.Err(); err != nil {
+		return 0, 0, fmt.Errorf("purge artifacts: %w", err)
+	}
+	if len(ids) == 0 {
+		return 0, 0, nil
+	}
+
+	for _, id := range ids {
+		if _, err := tx.Exec(`DELETE FROM artifact_links WHERE artifact_id = ?`, id); err != nil {
+			return 0, 0, fmt.Errorf("purge artifact links: %w", err)
+		}
+		if _, err := tx.Exec(`DELETE FROM artifacts WHERE id = ?`, id); err != nil {
+			return 0, 0, fmt.Errorf("purge artifact %s: %w", id, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, 0, fmt.Errorf("purge artifacts: %w", err)
+	}
+
+	root := db.ArtifactsDir()
+	for _, rel := range paths {
+		full, ok := underRoot(root, rel)
+		if !ok {
+			// A stored path that climbs out of the artifacts root is not ours
+			// to delete, whatever put it there.
+			log.Printf("coord: refusing to delete artifact path outside %s: %q", root, rel)
+			continue
+		}
+		if err := os.Remove(full); err != nil && !os.IsNotExist(err) {
+			log.Printf("coord: delete artifact file %s: %v", full, err)
+			continue
+		}
+		files++
+		// The task directory, and then the context directory, if this was the
+		// last thing in them. Non-empty ones fail and are left alone.
+		dir := filepath.Dir(full)
+		os.Remove(dir)
+		os.Remove(filepath.Dir(dir))
+	}
+	return len(ids), files, nil
+}
+
+// underRoot resolves a stored relative path against the artifacts root and
+// reports whether it stayed inside. Filenames are sanitised on the way in, so
+// this guards the rows that predate that or were written by hand.
+func underRoot(root, rel string) (string, bool) {
+	full := filepath.Clean(filepath.Join(root, rel))
+	cleanRoot := filepath.Clean(root)
+	if full == cleanRoot {
+		return "", false
+	}
+	return full, strings.HasPrefix(full, cleanRoot+string(filepath.Separator))
+}
+
+// purgeableWhere is shared by the purge and its dry run, so what `--dry-run`
+// prints can never be a different set from what the purge takes.
+const purgeableWhere = `kind != ? AND context_id IN (
+	SELECT context_id FROM tasks
+	GROUP BY context_id
+	HAVING sum(CASE WHEN state IN (?, ?, ?, ?) THEN 0 ELSE 1 END) = 0
+	   AND max(updated_at) < ?
+)`
+
+func purgeableArgs(before time.Time) []any {
+	return []any{ArtifactDocument, TaskCompleted, TaskFailed, TaskCanceled, TaskRejected, ts(before)}
+}
+
+// PurgeableArtifacts lists what PurgeArtifacts would take, and deletes nothing.
+func (db *DB) PurgeableArtifacts(before time.Time) ([]Artifact, error) {
+	rows, err := db.conn.Query(`SELECT `+artifactCols+` FROM artifacts WHERE `+purgeableWhere+
+		` ORDER BY context_id, created_at`, purgeableArgs(before)...)
+	if err != nil {
+		return nil, fmt.Errorf("purgeable artifacts: %w", err)
+	}
+	defer rows.Close()
+	out := []Artifact{}
+	for rows.Next() {
+		a, err := scanArtifact(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *a)
 	}
 	return out, rows.Err()
 }

--- a/internal/coord/artifacts_test.go
+++ b/internal/coord/artifacts_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func putTestArtifact(t *testing.T, db *DB, taskID, kind, title, name, body string) *Artifact {
@@ -139,5 +140,140 @@ func TestPutArtifactRejectsNonsense(t *testing.T) {
 		if _, err := db.PutArtifact(c.in); err == nil {
 			t.Errorf("%s: accepted, want an error", c.name)
 		}
+	}
+}
+
+// age moves a task's clock back so a test does not have to wait days.
+func age(t *testing.T, db *DB, taskID string, d time.Duration) {
+	t.Helper()
+	when := time.Now().Add(-d).UTC().Format(time.RFC3339Nano)
+	if _, err := db.Conn().Exec(`UPDATE tasks SET updated_at = ? WHERE id = ?`, when, taskID); err != nil {
+		t.Fatalf("age %s: %v", taskID, err)
+	}
+}
+
+// TestPurgeTakesFinishedTreesAndKeepsDocuments covers the three rules at once,
+// because they only make sense against each other.
+func TestPurgeTakesFinishedTreesAndKeepsDocuments(t *testing.T) {
+	db := testDB(t)
+
+	// An old, finished tree: a patch (goes) and a report (stays).
+	done, _ := db.CreateTask(NewTask{CreatedBy: "human", Title: "old work", AssignedTo: "a1"})
+	patch, err := db.PutArtifact(NewArtifact{TaskID: done.ID, Kind: ArtifactPatch, Title: "the diff", Content: []byte("--- a\n+++ b\n")})
+	if err != nil {
+		t.Fatalf("put patch: %v", err)
+	}
+	report, err := db.PutArtifact(NewArtifact{TaskID: done.ID, Kind: ArtifactDocument, Title: "the report", Content: []byte("# findings")})
+	if err != nil {
+		t.Fatalf("put report: %v", err)
+	}
+	if err := db.CancelTask(done.ID, "a1"); err != nil {
+		t.Fatal(err)
+	}
+	age(t, db, done.ID, 60*24*time.Hour)
+
+	// An equally old tree that is still open: nothing of it may go.
+	open, _ := db.CreateTask(NewTask{CreatedBy: "human", Title: "still going", AssignedTo: "a1"})
+	live, err := db.PutArtifact(NewArtifact{TaskID: open.ID, Kind: ArtifactPatch, Title: "wip", Content: []byte("wip")})
+	if err != nil {
+		t.Fatalf("put wip: %v", err)
+	}
+	age(t, db, open.ID, 60*24*time.Hour)
+
+	// A finished tree from this morning: too young.
+	recent, _ := db.CreateTask(NewTask{CreatedBy: "human", Title: "yesterday", AssignedTo: "a1"})
+	fresh, err := db.PutArtifact(NewArtifact{TaskID: recent.ID, Kind: ArtifactPatch, Title: "recent", Content: []byte("new")})
+	if err != nil {
+		t.Fatalf("put recent: %v", err)
+	}
+	if err := db.CancelTask(recent.ID, "a1"); err != nil {
+		t.Fatal(err)
+	}
+
+	patchFile := filepath.Join(db.ArtifactsDir(), patch.Path)
+	if _, err := os.Stat(patchFile); err != nil {
+		t.Fatalf("patch file should exist before the purge: %v", err)
+	}
+
+	// Dry run must name exactly what the purge then takes.
+	preview, err := db.PurgeableArtifacts(time.Now().AddDate(0, 0, -30))
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if len(preview) != 1 || preview[0].ID != patch.ID {
+		t.Fatalf("dry run should list only the old patch, got %+v", preview)
+	}
+
+	rows, files, err := db.PurgeArtifacts(time.Now().AddDate(0, 0, -30))
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if rows != 1 || files != 1 {
+		t.Fatalf("expected 1 row and 1 file, got %d rows and %d files", rows, files)
+	}
+	if _, err := os.Stat(patchFile); !os.IsNotExist(err) {
+		t.Error("the patch file is still on disk")
+	}
+	for _, keep := range []*Artifact{report, live, fresh} {
+		if _, err := db.GetArtifact(keep.ID); err != nil {
+			t.Errorf("%s (%s) should have been kept: %v", keep.Title, keep.Kind, err)
+		}
+	}
+	if _, err := db.GetArtifact(patch.ID); err == nil {
+		t.Error("the purged artifact still has a row")
+	}
+}
+
+// TestDryRunDeletesNothing: the flag is the whole point of the flag.
+func TestDryRunDeletesNothing(t *testing.T) {
+	db := testDB(t)
+	task, _ := db.CreateTask(NewTask{CreatedBy: "human", Title: "old", AssignedTo: "a1"})
+	a, err := db.PutArtifact(NewArtifact{TaskID: task.ID, Kind: ArtifactFile, Title: "thing", Content: []byte("bytes")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.CancelTask(task.ID, "a1")
+	age(t, db, task.ID, 60*24*time.Hour)
+
+	if _, err := db.PurgeableArtifacts(time.Now().AddDate(0, 0, -30)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.GetArtifact(a.ID); err != nil {
+		t.Fatalf("the dry run deleted the row: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(db.ArtifactsDir(), a.Path)); err != nil {
+		t.Fatalf("the dry run deleted the file: %v", err)
+	}
+}
+
+// TestPurgeRefusesPathsOutsideTheRoot: filenames are sanitised on the way in,
+// so this guards a row written before that, or by hand.
+func TestPurgeRefusesPathsOutsideTheRoot(t *testing.T) {
+	db := testDB(t)
+	outside := filepath.Join(t.TempDir(), "precious.txt")
+	if err := os.WriteFile(outside, []byte("not yours"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	task, _ := db.CreateTask(NewTask{CreatedBy: "human", Title: "old", AssignedTo: "a1"})
+	a, err := db.PutArtifact(NewArtifact{TaskID: task.ID, Kind: ArtifactFile, Title: "thing", Content: []byte("bytes")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(db.ArtifactsDir(), outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Conn().Exec(`UPDATE artifacts SET path = ? WHERE id = ?`, rel, a.ID); err != nil {
+		t.Fatal(err)
+	}
+	db.CancelTask(task.ID, "a1")
+	age(t, db, task.ID, 60*24*time.Hour)
+
+	if _, _, err := db.PurgeArtifacts(time.Now().AddDate(0, 0, -30)); err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatal("the purge deleted a file outside the artifacts root")
 	}
 }


### PR DESCRIPTION
Closes #115 — câu hỏi mở số 6 của `docs/design/agent-teams-and-channels.md`.

## Vấn đề

P4 ghi bytes ra `~/goterm-shared/artifacts/<context>/<task>/` và không có gì dọn. Thư mục chỉ có phình.

## Ba quy tắc, và vì sao không phải cái hiển nhiên

- **Chỉ context mà *mọi* task đã terminal.** Một cây còn một task mở là việc đang làm, dù phần còn lại cũ tới đâu.
- **`kind=document` được giữ.** Patch/file/result là đồ trung gian — bytes cha đưa cho con. Document là bản báo cáo ai đó đã yêu cầu, và đĩa rẻ hơn việc xoá nhầm nó.
- **Xoá hàng trước, xoá file sau.** Thứ tự ngược lại nghe hợp lý hơn vì bytes mới là phần nặng, nhưng một hàng trỏ vào file đã mất là **lỗi đọc** cho mọi thứ đang list artifact, còn file không có hàng thì chỉ tốn đĩa.

*(Issue tôi viết lúc đầu ghi "file trước, hàng sau" kèm lý do "hàng mồ côi tệ hơn" — hai vế đó ngược nhau. Lý do mới là cái đúng; thứ tự đổi theo.)*

## Cửa sổ giữ riêng, không dùng chung với trace

Issue đề xuất bám theo `coord.trace_retention_days`. Khi làm thì thấy không nên: trace trả lời *"run đó chạy ra sao"* và hết giá trị trong vòng một tuần; artifact **là thứ run đó tạo ra**. Một con số cho cả hai thì luôn có một cái sai. Trace giữ 7 ngày như cũ, artifact mặc định **30** (`coord.artifact_retention_days`, 0 = tắt).

## CLI

```
bomclaw artifact purge [--older-than-days 30] [--dry-run]
```

Dry-run và purge **dùng chung một mệnh đề WHERE** (`purgeableWhere`), nên danh sách in ra không thể lệch khỏi thứ bị xoá.

## Test

- `TestPurgeTakesFinishedTreesAndKeepsDocuments` — ba quy tắc cùng lúc: cây cũ đã xong (patch đi, report ở lại), cây cũ còn mở (không đụng), cây vừa xong (quá trẻ)
- `TestDryRunDeletesNothing`
- `TestPurgeRefusesPathsOutsideTheRoot` — hàng có `path` trèo ra ngoài artifacts root thì bỏ qua kèm log, không xoá

`go build ./...` và `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)