### PR TITLE
docs(design): research — choosing a backend, and what that costs

### DIFF
--- a/docs/design/provider-selection-and-collaboration.md
+++ b/docs/design/provider-selection-and-collaboration.md
@@ -1,0 +1,125 @@
+# Research: Chọn backend cho agent, và giữ nguyên đường Telegram khi mở thêm kênh
+
+> Trạng thái: **RESEARCH** — khảo sát mã nguồn thật, chưa code. Mọi dòng "hiện trạng" dưới đây đều kèm file:dòng đã đọc ngày 2026-09-12, main @ `be68950`.
+> Câu hỏi gốc: (1) Telegram nhắn tin điều khiển máy **như cũ**, (2) agent vào kênh tự thảo luận + giao việc, (3) **trace log đầy đủ**, (4) agent chọn được `claude` / `claude-tam` / `codex`, tương lai `openclaw` + `helmet`.
+> Liên quan: `agent-teams-and-channels.md` (kênh), `scheduling-and-long-tasks.md` (task, lịch, trace).
+
+---
+
+## 1. Kết luận ngắn
+
+Ba trong bốn câu hỏi **không cần kiến trúc mới** — đường nối đã có sẵn, chỉ bị một chỗ thắt:
+
+| Câu hỏi | Trạng thái thật |
+|---|---|
+| Telegram điều khiển máy như cũ | Không có gì phải làm để *giữ*; cần một **test đặc tả** để không ai làm hỏng về sau |
+| Agent thảo luận trong kênh | Phòng đã có (PR #106); hop cuối mention→lượt chat đang ở PR #119 |
+| `claude-tam` | **Rất có thể không phải provider mới** mà là một *account* Claude thứ hai — thứ `accounts.pool` đã làm được hôm nay. Xem §5 |
+| `openclaw`, `helmet` | Cần `chat.Client` mới. Chi phí nằm ở **chỗ thắt** §3, không nằm ở giao diện |
+| Trace đầy đủ | Có ba lỗ thật, §6 |
+
+---
+
+## 2. Hiện trạng (đã verify)
+
+**Đường nối provider đã tồn tại và sạch.** `internal/chat/chat.go:28`:
+
+```go
+type Client interface {
+    SendMessage(ctx, sess, modelID, userText, memoryContext string, cb StreamCallbacks) error
+    Name() string   // khoá provider ghi vào session: "claude" | "codex"
+}
+```
+
+`claude.Client` và `codex.Client` cùng thoả. Turn engine (`bot.Handler`) chỉ biết interface này.
+
+**Chỗ thắt là chỗ chọn, không phải chỗ định nghĩa.** `internal/bot/bot.go:84`:
+
+```go
+func NewChatClientWithPool(cfg, executor, pool) chat.Client {
+    if cfg.Provider == config.ProviderCodex { ... return codex }
+    return claude   // mọi thứ không phải codex đều thành claude
+}
+```
+
+Bốn hệ quả đo được:
+
+1. **`cfg.Provider` là một khoá cho cả agent** (`config.go:16`). Không có chỗ nào chọn theo session, theo task, hay theo lượt.
+2. **`Validate()` từ chối mọi giá trị khác** `claude`/`codex` (`config.go:445`) — một provider thứ ba không khởi động được, chứ không phải chạy sai.
+3. **Pool chỉ dựng cho đúng một provider**: `NewPool(cfg.Provider, accts, cooldown)` và account khác provider bị **bỏ im lặng** (`credentials/pool.go:136`).
+4. **Fallback im lặng**: `else → claude`. Gõ nhầm `provider: cladue` thì `Validate` bắt được; nhưng nếu ai nới `Validate` mà quên `NewChatClientWithPool` thì provider mới sẽ **chạy bằng claude** mà không báo gì.
+
+**Model đã biết mình thuộc protocol nào.** `models/catalog.go:7` có sẵn `claude-cli`, `codex-cli`, và hai giá trị để dành `anthropic`, `openai`. `Validate()` đã đối chiếu chéo provider ↔ `model.API` (`config.go:441`). Tức **model đã đủ thông tin để quyết định provider** — hôm nay thông tin đó chỉ dùng để báo lỗi, không dùng để chọn.
+
+**Session đã mang danh tính backend.** `SetProvider`/`SetAccount` (`session.go:123,142`), và resume bị chặn khi khác CLI: `if ref.Provider == r.llm.Name()` (`taskrunner/runner.go:348`). Nghĩa là đổi provider **không** làm hỏng session cũ — nó chỉ không resume được, và code đã lường.
+
+---
+
+## 3. Đề xuất: registry theo `ModelAPI`, thay cho if/else theo `cfg.Provider`
+
+Một hàm `Resolve(api models.ModelAPI) (chat.Client, bool)` với bảng đăng ký, thay cho if/else. `cfg.Provider` vẫn là mặc định của agent, nhưng thôi là *thứ duy nhất* được phép quyết.
+
+Vì sao theo `ModelAPI` chứ không theo tên provider: bảng model **đã** khai báo `api`, `Validate` **đã** đối chiếu nó, và chọn model là thao tác người dùng đã làm hằng ngày (`/model`, `--model`). Chọn theo API thì "đổi backend" và "đổi model" là một hành động, không phải hai chỗ cấu hình phải khớp tay.
+
+Việc phải làm, theo đúng thứ tự:
+
+1. `chat.Register(api, factory)` + `chat.Resolve(api)`; `NewChatClientWithPool` gọi `Resolve`, **không còn nhánh else im lặng** — không tìm thấy thì lỗi, nói rõ api nào.
+2. `Validate()` hỏi registry thay vì `switch` cứng hai giá trị.
+3. **Pool theo từng provider**: `map[string]*Pool`, dựng từ `accounts.pool` gom theo `provider`. Hôm nay account của backend kia bị bỏ im lặng — với ba backend thì đó là một cái bẫy.
+4. `claude` và `codex` tự đăng ký trong `init()`; thêm `openclaw`/`helmet` sau này là một file mới + một dòng đăng ký, không sửa `bot`.
+
+---
+
+## 4. Telegram: đảm bảo bằng test, không bằng lời hứa
+
+Không có gì trong §3 đụng vào đường Telegram — `bot.Handler.RunTurn` là đường chung của Telegram, dashboard, kênh và task từ PR #75. Nhưng "không đụng" là một lời hứa, và lời hứa cần một cái chốt:
+
+- `TestRunTurnIsTheTelegramPath` (`bot/runturn_test.go:92`) đã chốt rằng dashboard và Telegram đi chung một đường.
+- **Cần thêm**: một test đặc tả rằng với config hiện tại (`provider: claude`, model claude-cli) registry trả về đúng `claude.Client` — để một lần refactor registry không lặng lẽ đổi backend của người đang chạy.
+- Và một test rằng `Resolve` với api lạ **báo lỗi**, không rơi về claude.
+
+---
+
+## 5. `claude-tam`: có thể không phải provider
+
+Hai cách đọc, và chúng dẫn tới hai khối lượng công việc rất khác nhau:
+
+**(a) Một tài khoản Claude thứ hai** — `claude-tam` là login riêng, cùng CLI. Thì **hôm nay đã làm được**: `accounts.pool` với `config_dir` riêng (`CLAUDE_CONFIG_DIR`), và pool xoay theo session (`config.go:116-135`). Việc còn thiếu chỉ là **chọn được account** từ dashboard/CLI thay vì để pool tự xoay — `sess.SetAccount` đã có, `Pool.Pick(pinned)` đã nhận tham số ghim.
+
+**(b) Một CLI khác** (bản fork, binary khác) — thì là provider mới như §3.
+
+Theo dấu vết trên máy (`~/.claude-tam/`) thì (a) nhiều khả năng đúng hơn. **Đây là câu hỏi mở phải chốt trước khi code**, vì (a) là một form chọn + một tham số, còn (b) là cả §3.
+
+`openclaw` và `helmet` thì rõ ràng là (b).
+
+---
+
+## 6. Trace: ba lỗ thật
+
+Hôm nay có ba gốc trace: `turn` (`bot/handler.go:654`), `task` (`taskrunner/runner.go:356`), `gateway.send` (`gateway/methods.go:560,815`). Mỗi gốc mang `SessionID`, `ChatID`, `Model`, `Provider`, `Tags`; `AgentID` do recorder gắn (`trace/trace.go:157`).
+
+| Lỗ | Hệ quả | Đề xuất |
+|---|---|---|
+| **Lịch kiểu `command` không có span nào.** `internal/scheduler` không gọi `StartTrace` lần nào | Một job shell chạy 03:00 hỏng thì chỉ còn `schedule_runs.output` cắt 8KB; không có waterfall, không lọc được ở tab Traces | Gốc `schedule.command`, `RunType` mới `RunTypeCommand` |
+| **Lượt kênh không trỏ ngược về tin nhắn.** Trace có `session_id = ch_<thread>` nhưng không có `channel_id`/`message_id` | Từ một dòng trong kênh không mở thẳng được trace của nó | `Meta.Tags` (đã là JSON array, không cần schema mới) |
+| **Lệnh `bomclaw` agent tự gõ** chỉ hiện dưới dạng tool span `Bash` | Không thấy được "agent này đã tạo task kia" trong trace | Chấp nhận — `task_events` đã ghi; ghi hai nơi thì hai nơi sẽ lệch |
+
+---
+
+## 7. Lộ trình
+
+| | Việc | Vì sao ở đây |
+|---|---|---|
+| **V1** | Registry `ModelAPI → chat.Client`; pool theo provider; bỏ nhánh else im lặng; test đặc tả §4 | Điều kiện cần của mọi backend thứ ba. Không đổi hành vi nào đang chạy — đó là điểm của test đặc tả |
+| **V2** | Chọn account (`claude-tam`) từ dashboard/CLI, ghim vào session | Nhỏ, và nếu §5(a) đúng thì đây **là** toàn bộ yêu cầu "chọn claude-tam" |
+| **V3** | Trace: gốc `schedule.command` + tag kênh | Độc lập với V1/V2, làm lúc nào cũng được |
+| **V4** | `openclaw` / `helmet` là `chat.Client` | Sau V1, mỗi cái là một file. Trước V1 thì mỗi cái là một lần sửa `bot` |
+
+---
+
+## 8. Rủi ro & câu hỏi mở
+
+1. **`claude-tam` là account hay CLI?** Quyết định này đổi khối lượng V2 từ một form thành cả §3. Chưa chốt thì chưa code.
+2. **`helmet` là gì?** Chưa có dữ liệu nào trong repo hay trên máy. Cần một câu mô tả trước khi ước lượng.
+3. **Quota dùng chung.** Ba agent Claude cùng một OAuth vẫn là một quota — `accounts.pool` chia đau chứ không tạo thêm hạn mức. Chọn được account không giải quyết việc này.
+4. **Session không resume được sau khi đổi backend.** Đã lường trong code (`ref.Provider == llm.Name()`), nhưng với người dùng thì nó hiện ra như "agent quên mất cuộc nói chuyện". Có nên báo một dòng khi điều đó xảy ra?


### PR DESCRIPTION
Bản research anh dặn làm trước khi triển khai, cho bốn câu hỏi hỏi cùng lúc: Telegram điều khiển máy **như cũ**, agent thảo luận + giao việc trong kênh, **trace đầy đủ**, và agent chọn được `claude` / `claude-tam` / `codex`, sau này `openclaw` + `helmet`.

Mọi dòng "hiện trạng" đều kèm `file:dòng` đã đọc, không phỏng đoán.

## Ba phát hiện đổi hình dạng câu trả lời

**Đường nối provider đã có sẵn và sạch.** `chat.Client` là đúng hai method (`SendMessage`, `Name`), turn engine chỉ biết interface đó. Cái thiếu **không phải** chỗ định nghĩa mà là chỗ *chọn*: một if/else trên `cfg.Provider` — một khoá cho cả agent — với nhánh `else` biến mọi thứ lạ thành claude **mà không báo gì**, và `credentials.Pool` **bỏ im lặng** mọi account thuộc backend khác.

**Model đã biết nó nói protocol nào.** `models.ModelAPI` có sẵn `claude-cli`, `codex-cli` (+ `anthropic`, `openai` để dành), và `Validate()` **đã** đối chiếu chéo provider ↔ model.API. Tức thông tin để chọn provider đã nằm sẵn đó, hôm nay chỉ dùng để báo lỗi. Nên đề xuất là **registry theo `ModelAPI`**, không phải thêm nhánh thứ ba: đổi model là việc người dùng vẫn làm hằng ngày, đổi backend thì không.

**`claude-tam` rất có thể không phải provider mới.** Dấu vết trên máy (`~/.claude-tam/`) cho thấy đó là **login Claude thứ hai**, mà `accounts.pool` với `config_dir` riêng đã làm được hôm nay — `sess.SetAccount` và `Pool.Pick(pinned)` đều đã nhận tham số ghim. Nếu đúng, "chọn claude-tam" chỉ là một form + một tham số, không phải cả tầng provider. **Doc hỏi trước khi ai đó code**, vì hai cách đọc chênh nhau rất xa về khối lượng.

## Trace: ba lỗ, một cái đáng lo

`internal/scheduler` **không gọi `StartTrace` lần nào**. Một job shell chạy 03:00 mà hỏng thì chỉ còn `schedule_runs.output` cắt 8KB — không waterfall, không lọc được ở tab Traces.

## Telegram

Không có gì trong đề xuất đụng vào đường Telegram — `RunTurn` là đường chung từ PR #75. Nhưng "không đụng" là lời hứa, nên doc yêu cầu **test đặc tả**: config hiện tại phải resolve về đúng `claude.Client`, và api lạ phải **báo lỗi** thay vì rơi về claude.

## Lộ trình V1–V4 và hai câu hỏi mở

`helmet` chưa có dữ liệu nào trong repo hay trên máy — cần một câu mô tả trước khi ước lượng. Issue sẽ mở sau khi anh chốt hai câu hỏi ở §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)