### PR TITLE
feat(channel): an answered message shows its answer

### DIFF
--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -95,14 +95,22 @@ export default function ChannelView({ call, agents, selfID }: {
     if (!text || !active || sending.current) return
     sending.current = true
     try {
-      await call('channels.post', {
+      const posted: ChannelMessage = await call('channels.post', {
         channel_id: active, body: text, as,
         ...(threadRoot ? { thread_root: threadRoot } : {}),
       })
       setBody('')
       await loadMessages(active)
-      if (threadRoot) await loadThread(threadRoot)
-      else bottom.current?.scrollIntoView({ behavior: 'smooth' })
+      if (threadRoot) {
+        await loadThread(threadRoot)
+      } else if (posted?.mentions?.length) {
+        // Naming an agent is asking it something, and its answer goes into this
+        // message's thread. Open that thread now so the reply arrives in view
+        // instead of behind a click nobody knew to make.
+        await loadThread(posted.id)
+      } else {
+        bottom.current?.scrollIntoView({ behavior: 'smooth' })
+      }
     } catch (e: any) {
       setErr(String(e?.message ?? e))
     } finally {
@@ -229,12 +237,31 @@ function Line({ m, selfID, compact, onThread }: {
         <span className="ml-auto" title={ago(m.created_at)}>{clock(m.created_at)}</span>
       </div>
       <div className="mt-1 text-sm text-gray-100 whitespace-pre-wrap break-words">{m.body}</div>
-      {!compact && (
+
+      {/* An answered message shows its answer. A count on its own reads like
+          silence next to a question you asked an agent — which is exactly how
+          the first working reply was missed. */}
+      {!compact && !!m.replies && (
+        <button
+          onClick={onThread}
+          className="mt-2 w-full text-left rounded-md pl-2 py-1 border-l-2 border-sky-500/40 bg-sky-500/5 hover:bg-sky-500/10 group"
+        >
+          <div className="flex items-baseline gap-2 text-[11px]">
+            <span className="font-mono text-sky-300">{m.last_reply_by}</span>
+            <span className="text-gray-600">{ago(m.last_reply_at)}</span>
+            <span className="ml-auto text-gray-500 group-hover:text-sky-300">
+              {m.replies} repl{m.replies === 1 ? 'y' : 'ies'} →
+            </span>
+          </div>
+          <div className="text-xs text-gray-300 line-clamp-2 break-words">{m.last_reply_text}</div>
+        </button>
+      )}
+      {!compact && !m.replies && (
         <button
           onClick={onThread}
           className="mt-1 text-[11px] text-gray-500 hover:text-sky-300"
         >
-          {m.replies ? `${m.replies} repl${m.replies === 1 ? 'y' : 'ies'} · ${ago(m.last_reply_at)}` : 'reply in thread'}
+          reply in thread
         </button>
       )}
     </div>

--- a/dashboard/src/admin/types.ts
+++ b/dashboard/src/admin/types.ts
@@ -251,6 +251,8 @@ export interface ChannelMessage {
   mentions?: string[]
   replies?: number
   last_reply_at?: string
+  last_reply_by?: string
+  last_reply_text?: string
 }
 
 // --- artifacts --------------------------------------------------------------

--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -52,6 +52,11 @@ const (
 	ChannelDM     = "dm"
 )
 
+// ReplyPreviewRunes is how much of the newest reply travels with the main line.
+// Enough to see that an agent answered and roughly what it said; the thread is
+// one click away for the rest.
+const ReplyPreviewRunes = 160
+
 // GeneralChannelID is the room that always exists, so a fresh agent has
 // somewhere to say hello without anyone creating a channel first.
 const GeneralChannelID = "ch_general"
@@ -96,6 +101,13 @@ type ChannelMessage struct {
 	Mentions []string  `json:"mentions,omitempty"`
 	Replies  int       `json:"replies,omitempty"`
 	LastAt   time.Time `json:"last_reply_at,omitempty"`
+
+	// The newest reply, in the main line, so a room shows that it was answered
+	// without anyone opening anything. A count alone says an answer exists; it
+	// does not say what the answer was, and "1 reply" next to a question you
+	// asked an agent reads exactly like silence.
+	LastReplyBy   string `json:"last_reply_by,omitempty"`
+	LastReplyText string `json:"last_reply_text,omitempty"`
 }
 
 // NewChannelMessage is the input to PostMessage.
@@ -501,6 +513,15 @@ func (db *DB) decorate(msgs []ChannelMessage, withReplies bool) ([]ChannelMessag
 			return nil, fmt.Errorf("replies of %s: %w", msgs[i].ID, err)
 		}
 		msgs[i].LastAt = parseTS(last)
+		if msgs[i].Replies == 0 {
+			continue
+		}
+		if err := db.conn.QueryRow(`SELECT author_id, body FROM channel_messages
+			WHERE thread_root = ? ORDER BY created_at DESC LIMIT 1`, msgs[i].ID).
+			Scan(&msgs[i].LastReplyBy, &msgs[i].LastReplyText); err != nil {
+			return nil, fmt.Errorf("last reply of %s: %w", msgs[i].ID, err)
+		}
+		msgs[i].LastReplyText = truncateRunes(msgs[i].LastReplyText, ReplyPreviewRunes)
 	}
 	return msgs, nil
 }

--- a/internal/coord/channels_test.go
+++ b/internal/coord/channels_test.go
@@ -302,3 +302,72 @@ func TestAnAgentCanLeaveItselfANote(t *testing.T) {
 		t.Errorf("wake = %v, want none — nobody rings their own doorbell", wake)
 	}
 }
+
+// TestMainLineCarriesTheNewestReply: a count on its own reads like silence next
+// to a question you asked an agent — which is how the first working reply was
+// missed on the dashboard.
+func TestMainLineCarriesTheNewestReply(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2")
+
+	root, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID,
+		Body: "@bomclaw2 kênh đã thông chưa",
+	})
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+
+	// No replies yet: no preview, and nothing pretending there is one.
+	line, err := db.ChannelMessages(GeneralChannelID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line[0].Replies != 0 || line[0].LastReplyBy != "" || line[0].LastReplyText != "" {
+		t.Fatalf("unanswered message carries a reply preview: %+v", line[0])
+	}
+
+	for _, body := range []string{"đang xem", "rồi nhé, thông rồi"} {
+		if _, _, err := db.PostMessage(NewChannelMessage{
+			ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw2", Body: body,
+		}); err != nil {
+			t.Fatalf("reply: %v", err)
+		}
+	}
+
+	line, err = db.ChannelMessages(GeneralChannelID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line[0].Replies != 2 {
+		t.Fatalf("replies: got %d, want 2", line[0].Replies)
+	}
+	// The NEWEST one — an answer two replies old is worse than none.
+	if line[0].LastReplyBy != "bomclaw2" || line[0].LastReplyText != "rồi nhé, thông rồi" {
+		t.Fatalf("preview should be the newest reply, got %q by %q", line[0].LastReplyText, line[0].LastReplyBy)
+	}
+
+	// Replies stay out of the main line: the room is roots, threads are threads.
+	if len(line) != 1 {
+		t.Fatalf("thread replies leaked into the main line: %d messages", len(line))
+	}
+}
+
+// TestReplyPreviewIsCut keeps one long reply from pushing the room off screen.
+func TestReplyPreviewIsCut(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2")
+	root, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "@bomclaw2 báo cáo đi",
+	})
+	if _, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw2",
+		Body: strings.Repeat("báo cáo rất dài ", 100),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	line, _ := db.ChannelMessages(GeneralChannelID, 10)
+	if n := len([]rune(line[0].LastReplyText)); n > ReplyPreviewRunes {
+		t.Fatalf("preview is %d runes, cap is %d", n, ReplyPreviewRunes)
+	}
+}


### PR DESCRIPTION
Closes #130

## Vấn đề

Sau khi #112 lên production, `bomclaw2` trả lời một mention trong **40 giây**, nằm đúng thread. Nhưng nhìn vào kênh thì như không có gì xảy ra — dòng gốc chỉ có `1 reply · 2m ago` màu xám, còn câu trả lời nằm sau một cú bấm mà không ai biết phải bấm.

Một con số đứng cạnh câu hỏi mình vừa hỏi agent thì **đọc y như im lặng**.

## Sửa

**Câu trả lời mới nhất đi kèm dòng chính** — tên người trả lời, thời gian, và 160 rune đầu — dưới dạng dải trích dẫn có viền trái, bấm vào mở thread.

Mới nhất chứ không phải đầu tiên: một câu trả lời cũ hai lượt còn tệ hơn không có.

Reply vẫn **không** lọt vào dòng chính — phòng là các tin gốc, thread là thread. Có test ghim.

**Hỏi agent thì mở sẵn thread.** Post một tin có `@agent` → mở luôn thread của tin đó, vì câu trả lời sẽ rơi vào đấy và người vừa hỏi là người đang chờ.

## Test

- `TestMainLineCarriesTheNewestReply` — chưa ai trả lời thì không có preview giả; có rồi thì là câu **mới nhất**; reply không lọt vào dòng chính
- `TestReplyPreviewIsCut` — reply dài không đẩy phòng trôi khỏi màn hình

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)