### PR TITLE
feat(channel): keep talking inside the thread

### DIFF
--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -22,6 +22,9 @@ export default function ChannelView({ call, agents, selfID }: {
   const [thread, setThread] = useState<ChannelMessage[] | null>(null)
   const [threadRoot, setThreadRoot] = useState<string>('')
   const [body, setBody] = useState('')
+  // The thread keeps its own draft. One shared box meant typing a reply in the
+  // panel on the right while the words appeared in the box on the left.
+  const [threadBody, setThreadBody] = useState('')
   const [as, setAs] = useState<string>(OWNER)
   const [err, setErr] = useState<string | null>(null)
   const sending = useRef(false)
@@ -90,18 +93,21 @@ export default function ChannelView({ call, agents, selfID }: {
   // One post per press. The body is only cleared once the round trip is over,
   // so without this latch a second Enter arriving before the reply re-sends the
   // same text — which is how the room ended up with a line in it twice.
-  const post = async () => {
-    const text = body.trim()
+  // One sender for two boxes: the channel's main line, and a thread. Which one
+  // is decided by the caller, not by a mode the composer is left sitting in.
+  const post = async (inThread: boolean) => {
+    const text = (inThread ? threadBody : body).trim()
     if (!text || !active || sending.current) return
+    if (inThread && !threadRoot) return
     sending.current = true
     try {
       const posted: ChannelMessage = await call('channels.post', {
         channel_id: active, body: text, as,
-        ...(threadRoot ? { thread_root: threadRoot } : {}),
+        ...(inThread ? { thread_root: threadRoot } : {}),
       })
-      setBody('')
+      if (inThread) setThreadBody(''); else setBody('')
       await loadMessages(active)
-      if (threadRoot) {
+      if (inThread) {
         await loadThread(threadRoot)
       } else if (posted?.mentions?.length) {
         // Naming an agent is asking it something, and its answer goes into this
@@ -164,10 +170,9 @@ export default function ChannelView({ call, agents, selfID }: {
         </div>
 
         <Composer
-          value={body} onChange={setBody} onSend={post}
+          value={body} onChange={setBody} onSend={() => post(false)}
           as={as} setAs={setAs} agents={agents}
-          replyingTo={threadRoot ? thread?.[0] : undefined}
-          onCancelReply={() => { setThread(null); setThreadRoot('') }}
+          placeholder="Message the channel — @agent to wake one"
         />
       </div>
 
@@ -188,6 +193,12 @@ export default function ChannelView({ call, agents, selfID }: {
               </div>
             ))}
           </div>
+          {/* Typing happens where you are reading. */}
+          <Composer
+            value={threadBody} onChange={setThreadBody} onSend={() => post(true)}
+            as={as} setAs={setAs} agents={agents}
+            placeholder="Reply in thread"
+          />
         </aside>
       )}
     </div>
@@ -268,20 +279,12 @@ function Line({ m, selfID, compact, onThread }: {
   )
 }
 
-function Composer({ value, onChange, onSend, as, setAs, agents, replyingTo, onCancelReply }: {
+function Composer({ value, onChange, onSend, as, setAs, agents, placeholder }: {
   value: string; onChange: (s: string) => void; onSend: () => void
-  as: string; setAs: (s: string) => void; agents: string[]
-  replyingTo?: ChannelMessage; onCancelReply: () => void
+  as: string; setAs: (s: string) => void; agents: string[]; placeholder: string
 }) {
   return (
     <div className="border-t border-gray-800 bg-gray-900/40">
-      {replyingTo && (
-        <div className="px-3 pt-2 text-[11px] text-gray-500 flex items-center gap-2">
-          <span>replying in thread:</span>
-          <span className="truncate text-gray-400">{replyingTo.body.slice(0, 60)}</span>
-          <button onClick={onCancelReply} className="ml-auto hover:text-gray-300">cancel</button>
-        </div>
-      )}
       <div className="p-3 flex gap-2">
         <select
           value={as}
@@ -302,7 +305,7 @@ function Composer({ value, onChange, onSend, as, setAs, agents, replyingTo, onCa
             if (e.nativeEvent.isComposing || e.keyCode === 229) return
             if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend() }
           }}
-          placeholder="Message the channel — @agent to wake one"
+          placeholder={placeholder}
           className="flex-1 px-3 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
         />
         <button

--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -393,6 +393,27 @@ func (db *DB) PostMessage(n NewChannelMessage) (*ChannelMessage, []string, error
 		}
 	}
 
+	// A person answering inside a thread is talking to the agents already in
+	// it, and having to retype @bomclaw2 under its own reply is not a
+	// conversation. Following a thread you have spoken in is Slack's rule and
+	// the right one here.
+	//
+	// Only a PERSON's reply does this. An agent's reply waking every other
+	// agent in the thread is the loop the mention rule exists to prevent —
+	// three agents in one room answering each other's answers. An agent that
+	// means to summon a peer still writes @, which is a decision it made.
+	if n.ThreadRoot != "" && n.AuthorKind == MemberUser {
+		followers, err := db.threadAgents(n.ThreadRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, who := range followers {
+			if !containsMember(addressed, who.Kind, who.ID) {
+				addressed = append(addressed, who)
+			}
+		}
+	}
+
 	var wake []string
 	for _, who := range addressed {
 		if err := db.JoinChannel(m.ChannelID, who.Kind, who.ID); err != nil {
@@ -410,6 +431,26 @@ func (db *DB) PostMessage(n NewChannelMessage) (*ChannelMessage, []string, error
 		}
 	}
 	return m, wake, nil
+}
+
+// threadAgents lists the agents that have spoken in a thread — its root
+// included, since the root is what started it.
+func (db *DB) threadAgents(rootID string) ([]Member, error) {
+	rows, err := db.conn.Query(`SELECT DISTINCT author_id FROM channel_messages
+		WHERE (id = ? OR thread_root = ?) AND author_kind = ?`, rootID, rootID, MemberAgent)
+	if err != nil {
+		return nil, fmt.Errorf("agents in thread %s: %w", rootID, err)
+	}
+	defer rows.Close()
+	var out []Member
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, Member{Kind: MemberAgent, ID: id})
+	}
+	return out, rows.Err()
 }
 
 // resolveMentions maps @names in a body to real members. An @name that is not

--- a/internal/coord/channels_test.go
+++ b/internal/coord/channels_test.go
@@ -371,3 +371,102 @@ func TestReplyPreviewIsCut(t *testing.T) {
 		t.Fatalf("preview is %d runes, cap is %d", n, ReplyPreviewRunes)
 	}
 }
+
+// TestHumanReplyWakesTheThread: answering inside a thread is talking to the
+// agents already in it. Having to retype @bomclaw2 under its own reply is not
+// a conversation.
+func TestHumanReplyWakesTheThread(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2", "bomclaw3")
+
+	root, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID,
+		Body: "@bomclaw2 xem hộ log",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw2", Body: "xong rồi",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A follow-up with no @ at all.
+	_, wake, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "thế còn dòng cuối?",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake) != 1 || wake[0] != "bomclaw2" {
+		t.Fatalf("a person's follow-up should wake the agent in the thread, got %v", wake)
+	}
+	// And it must be readable as a summons, or the watcher never sees it.
+	unread, err := db.UnreadMentions(MemberAgent, "bomclaw2", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unread) != 2 {
+		t.Fatalf("bomclaw2 should have the original mention and the follow-up, got %d", len(unread))
+	}
+
+	// An agent that never spoke in the thread stays out of it.
+	if u, _ := db.UnreadMentions(MemberAgent, "bomclaw3", 10); len(u) != 0 {
+		t.Fatalf("bomclaw3 was pulled into a thread it is not in: %v", u)
+	}
+}
+
+// TestAgentReplyDoesNotWakeTheThread guards the loop the mention rule exists to
+// prevent: three agents in one room answering each other's answers forever.
+func TestAgentReplyDoesNotWakeTheThread(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2")
+
+	root, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID,
+		Body: "@bomclaw2 bắt đầu đi",
+	})
+	if _, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw2", Body: "ok",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// bomclaw speaks in the thread without naming anyone.
+	_, wake, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw", Body: "mình cũng đang xem",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake) != 0 {
+		t.Fatalf("an agent's thread reply woke %v — that is the ping-pong loop", wake)
+	}
+}
+
+// TestThreadFollowUpSkipsTheAuthor: nobody rings their own doorbell, and the
+// owner is not an agent to be woken.
+func TestThreadFollowUpSkipsTheAuthor(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw2")
+
+	root, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "@bomclaw2 hi",
+	})
+	_, wake, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "còn đó không",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the agent that spoke... and here none has, so nobody is woken: the
+	// root is the owner's own line.
+	for _, w := range wake {
+		if w == OwnerUserID {
+			t.Fatal("the owner was queued as an agent to wake")
+		}
+	}
+}


### PR DESCRIPTION
Closes #132

## Hai thứ khiến thread không phải là một cuộc nói chuyện

**Hộp gõ nằm sai chỗ.** Đọc thread bên phải thì gõ vào composer bên trái — nó tự chuyển sang "reply mode" kèm dòng `cancel`, và trong lúc ở mode đó thì **không nói gì vào kênh chính được nữa**. Giờ thread có composer riêng với draft riêng; composer của kênh quay về chỉ post vào kênh.

**Và hỏi tiếp thì không ai thức.** Chỉ `@` trong body mới rung chuông, nên hỏi "thế còn dòng cuối?" ngay dưới câu trả lời của agent là **rơi vào im lặng** — phải gõ lại `@bomclaw2` bên dưới đúng câu mà bomclaw2 vừa nói.

Người trả lời trong thread giờ đánh thức các agent đã ở trong thread đó. Theo dõi một thread mình đã nói là luật của Slack, và ở đây nó đúng.

## Chỉ reply của NGƯỜI

Reply của agent mà đánh thức mọi agent khác trong thread **chính là** vòng lặp mà luật `@` sinh ra để chặn: ba agent trong một phòng trả lời câu trả lời của nhau. Agent muốn gọi đồng nghiệp thì vẫn gõ `@` — đó là một quyết định nó tự ra, không phải hệ quả của việc có mặt trong phòng.

## Test

- `TestHumanReplyWakesTheThread` — follow-up không `@` vẫn đánh thức agent trong thread, và ghi thành summons để watcher nhìn thấy
- `TestAgentReplyDoesNotWakeTheThread` — reply của agent đánh thức **0** người
- `TestThreadFollowUpSkipsTheAuthor` — không ai tự rung chuông của mình; owner không bị xếp vào danh sách agent
- Agent chưa từng nói trong thread thì không bị kéo vào

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)