### PR TITLE
feat(channel): work stays attached to the conversation it came from

### DIFF
--- a/cmd/bomclaw/coordcmd.go
+++ b/cmd/bomclaw/coordcmd.go
@@ -93,18 +93,36 @@ func runTask(args []string) {
 		priority := fs.Int("priority", 0, "Higher is claimed first")
 		depth := fs.Int("depth", 0, "Chain depth when an agent spawns follow-up work")
 		context := fs.String("context", "", "Existing context id to attach this task to")
+		thread := fs.String("thread", "", "Root message id of the conversation this work came out of")
 		fs.Parse(rest)
 
 		db := openCoord(*dbPath)
 		defer db.Close()
 
+		me := requireAgent(*agent)
 		task, err := db.CreateTask(coord.NewTask{
-			CreatedBy: requireAgent(*agent), AssignedTo: *to, Title: *title, Body: *body,
+			CreatedBy: me, AssignedTo: *to, Title: *title, Body: *body,
 			Priority: *priority, Depth: *depth, ContextID: *context,
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "task new: %v\n", err)
 			os.Exit(1)
+		}
+		// Work that came out of a conversation stays attached to it, in both
+		// directions: the thread knows which task it produced, and the task
+		// knows where to report back. Without this the agent does as it is
+		// told — open a task for the big thing — and the context stays behind.
+		if *thread != "" {
+			if err := db.BindThreadToTask(*thread, task.ID); err != nil {
+				fmt.Fprintf(os.Stderr, "task new: created %s but could not bind it to the thread: %v\n", task.ID, err)
+				os.Exit(1)
+			}
+			if _, _, err := db.PostMessage(coord.NewChannelMessage{
+				ChannelID: threadChannel(db, *thread), ThreadRoot: *thread, AuthorID: me,
+				Body: fmt.Sprintf("Đã mở task %s cho việc này: %s", task.ID, *title),
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "task new: bound, but could not say so in the thread: %v\n", err)
+			}
 		}
 		// Ring the agent that can take it. Failure is fine — its poll finds
 		// the task anyway; this only removes the wait.
@@ -767,4 +785,15 @@ func orAny(primary, fallback string) string {
 		return fallback
 	}
 	return "any"
+}
+
+// threadChannel is the room a thread lives in. The caller already named the
+// thread, and making it also name the channel would be asking for a fact the
+// database holds.
+func threadChannel(db *coord.DB, rootID string) string {
+	channelID, err := db.MessageChannel(rootID)
+	if err != nil || channelID == "" {
+		return coord.GeneralChannelID
+	}
+	return channelID
 }

--- a/dashboard/src/admin/AdminView.tsx
+++ b/dashboard/src/admin/AdminView.tsx
@@ -26,6 +26,12 @@ const PANES = ADMIN_PANES.map(key => ({ key, label: LABELS[key] }))
 export default function AdminView({ call, pane, onPane }: { call: Call; pane: Pane; onPane: (p: Pane) => void }) {
   const [data, setData] = useState<OverviewData | null>(null)
   const [err, setErr] = useState<string | null>(null)
+  // Work and the conversation it came out of live in two panes. These carry a
+  // click from one to the other: a task id the board should open, a thread the
+  // room should open. Cleared once handed over, so returning to a pane later
+  // does not reopen what you already closed.
+  const [openTask, setOpenTask] = useState<string>('')
+  const [openThread, setOpenThread] = useState<string>('')
 
   // The overview drives the agent list every other pane filters by, so it is
   // refreshed regardless of which pane is showing.
@@ -92,10 +98,22 @@ export default function AdminView({ call, pane, onPane }: { call: Call; pane: Pa
       <div className="flex-1 min-h-0">
         {pane === 'overview' && <Overview data={data} />}
         {pane === 'traces' && <TraceExplorer call={call} agents={agentIDs} />}
-        {pane === 'tasks' && <TaskBoard call={call} agents={agentIDs} />}
+        {pane === 'tasks' && (
+          <TaskBoard
+            call={call} agents={agentIDs}
+            openTaskID={openTask} onOpenedTask={() => setOpenTask('')}
+            onOpenThread={rootID => { setOpenThread(rootID); onPane('messages') }}
+          />
+        )}
         {pane === 'schedules' && <SchedulesPane call={call} agents={agentIDs} />}
         {pane === 'notes' && <NotesPane call={call} />}
-        {pane === 'messages' && <ChannelView call={call} agents={agentIDs} selfID={selfID} />}
+        {pane === 'messages' && (
+          <ChannelView
+            call={call} agents={agentIDs} selfID={selfID}
+            openThreadID={openThread} onOpenedThread={() => setOpenThread('')}
+            onOpenTask={taskID => { setOpenTask(taskID); onPane('tasks') }}
+          />
+        )}
       </div>
     </div>
   )

--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -13,8 +13,9 @@ type Call = (method: string, params?: any) => Promise<any>
 
 const OWNER = 'owner'
 
-export default function ChannelView({ call, agents, selfID }: {
+export default function ChannelView({ call, agents, selfID, openThreadID, onOpenedThread, onOpenTask }: {
   call: Call; agents: string[]; selfID: string
+  openThreadID?: string; onOpenedThread?: () => void; onOpenTask?: (taskID: string) => void
 }) {
   const [channels, setChannels] = useState<Channel[]>([])
   const [active, setActive] = useState<string>('')
@@ -72,6 +73,20 @@ export default function ChannelView({ call, agents, selfID }: {
   }, [loadChannels])
 
   useEffect(() => { loadMessages(active) }, [active, loadMessages])
+
+  // Arriving from the board: open the conversation the task came out of.
+  useEffect(() => {
+    if (!openThreadID) return
+    call('channels.messages', { thread_root: openThreadID })
+      .then((t: ChannelMessage[]) => {
+        if (!t?.length) return
+        setActive(t[0].channel_id)
+        setThread(t)
+        setThreadRoot(openThreadID)
+      })
+      .catch((e: any) => setErr(String(e?.message ?? e)))
+      .finally(() => onOpenedThread?.())
+  }, [openThreadID, call, onOpenedThread])
 
   // Poll: an agent posting from its own shell has no way to push to this page.
   useEffect(() => {
@@ -164,7 +179,7 @@ export default function ChannelView({ call, agents, selfID }: {
             </div>
           )}
           {ordered.map(m => (
-            <Line key={m.id} m={m} selfID={selfID} onThread={() => loadThread(m.id)} />
+            <Line key={m.id} m={m} selfID={selfID} onThread={() => loadThread(m.id)} onOpenTask={onOpenTask} />
           ))}
           <div ref={bottom} />
         </div>
@@ -189,7 +204,7 @@ export default function ChannelView({ call, agents, selfID }: {
           <div className="flex-1 overflow-y-auto p-3 space-y-3">
             {thread.map((m, i) => (
               <div key={m.id} className={i === 0 ? '' : 'pl-3 border-l border-gray-800'}>
-                <Line m={m} selfID={selfID} compact />
+                <Line m={m} selfID={selfID} compact onOpenTask={onOpenTask} />
               </div>
             ))}
           </div>
@@ -225,8 +240,9 @@ function ChannelRow({ c, active, onPick }: { c: Channel; active: boolean; onPick
   )
 }
 
-function Line({ m, selfID, compact, onThread }: {
-  m: ChannelMessage; selfID: string; compact?: boolean; onThread?: () => void
+function Line({ m, selfID, compact, onThread, onOpenTask }: {
+  m: ChannelMessage; selfID: string; compact?: boolean
+  onThread?: () => void; onOpenTask?: (taskID: string) => void
 }) {
   const mine = m.author_kind === 'user'
   return (
@@ -238,9 +254,14 @@ function Line({ m, selfID, compact, onThread }: {
           {m.author_kind === 'user' ? 'you' : m.author_id}
         </span>
         {m.task_id && (
-          <span className="px-1.5 rounded ring-1 ring-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-300 font-mono">
+          <button
+            onClick={() => onOpenTask?.(m.task_id!)}
+            disabled={!onOpenTask}
+            title="Open this task on the board"
+            className="px-1.5 rounded ring-1 ring-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-300 font-mono enabled:hover:bg-fuchsia-500/20"
+          >
             {m.task_id.slice(0, 10)}
-          </span>
+          </button>
         )}
         {m.mentions?.map(w => (
           <span key={w} className="px-1.5 rounded bg-amber-500/15 text-amber-300 font-mono">@{w}</span>

--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -91,8 +91,9 @@ function TaskCard({ task, kids, onOpen }: { task: Task; kids: { total: number; d
   )
 }
 
-function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask }: {
-  call: Call; id: string; agents: string[]; onClose: () => void; onChanged: () => void; onOpenTask: (id: string) => void
+function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask, onOpenThread }: {
+  call: Call; id: string; agents: string[]; onClose: () => void; onChanged: () => void
+  onOpenTask: (id: string) => void; onOpenThread?: (rootID: string) => void
 }) {
   const [detail, setDetail] = useState<TaskDetail | null>(null)
   const [busy, setBusy] = useState(false)
@@ -262,6 +263,15 @@ function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask }: {
                   </dd>
                 </div>
               </dl>
+
+              {detail.thread_root && onOpenThread && (
+                <button
+                  onClick={() => onOpenThread(detail.thread_root!)}
+                  className="text-xs text-sky-300 hover:underline text-left"
+                >
+                  ← từ cuộc nói chuyện đã mở việc này
+                </button>
+              )}
 
               {t.parent_id && (
                 <div className="text-xs text-gray-500">
@@ -433,13 +443,22 @@ function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask }: {
   )
 }
 
-export default function TaskBoard({ call, agents }: { call: Call; agents: string[] }) {
+export default function TaskBoard({ call, agents, openTaskID, onOpenedTask, onOpenThread }: {
+  call: Call; agents: string[]
+  openTaskID?: string; onOpenedTask?: () => void; onOpenThread?: (rootID: string) => void
+}) {
   const [tasks, setTasks] = useState<Task[]>([])
   const [openID, setOpenID] = useState<string | null>(null)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [to, setTo] = useState('')
   const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!openTaskID) return
+    setOpenID(openTaskID)
+    onOpenedTask?.()
+  }, [openTaskID, onOpenedTask])
 
   const load = useCallback(async () => {
     try {
@@ -534,7 +553,7 @@ export default function TaskBoard({ call, agents }: { call: Call; agents: string
       </div>
 
       {openID && (
-        <TaskDrawer call={call} id={openID} agents={agents} onClose={() => setOpenID(null)} onChanged={load} onOpenTask={setOpenID} />
+        <TaskDrawer call={call} id={openID} agents={agents} onClose={() => setOpenID(null)} onChanged={load} onOpenTask={setOpenID} onOpenThread={onOpenThread} />
       )}
     </div>
   )

--- a/dashboard/src/admin/types.ts
+++ b/dashboard/src/admin/types.ts
@@ -133,7 +133,8 @@ export interface TaskDetail {
   runs: TaskRun[]
   children: Task[]
   context_count?: number
-  context_cap?: number // the tasks it split off (`bomclaw task sub`); empty for a leaf
+  context_cap?: number
+  thread_root?: string // the tasks it split off (`bomclaw task sub`); empty for a leaf
 }
 
 export interface Message {

--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -433,6 +433,59 @@ func (db *DB) PostMessage(n NewChannelMessage) (*ChannelMessage, []string, error
 	return m, wake, nil
 }
 
+// BindThreadToTask makes a thread the conversation about a task. The binding
+// lives on the thread's root message, which is why a task can be attached to a
+// conversation that started as a question — most work does, and until this the
+// only way to bind was to already know the task id when the first line was
+// written, which is never when a conversation becomes work.
+//
+// One thread, one task: a thread that discusses two pieces of work gives the
+// agent finishing either one nowhere unambiguous to report back to.
+func (db *DB) BindThreadToTask(rootID, taskID string) error {
+	root, err := db.getMessage(rootID)
+	if err != nil {
+		return err
+	}
+	if root.ThreadRoot != "" {
+		return fmt.Errorf("coord: %s is a reply, not a thread root — bind %s instead", rootID, root.ThreadRoot)
+	}
+	if root.TaskID != "" && root.TaskID != taskID {
+		return fmt.Errorf("coord: that thread is already about task %s", root.TaskID)
+	}
+	if _, err := db.GetTask(taskID); err != nil {
+		return err
+	}
+	if _, err := db.conn.Exec(`UPDATE channel_messages SET task_id = ? WHERE id = ?`, taskID, rootID); err != nil {
+		return fmt.Errorf("bind %s to %s: %w", rootID, taskID, err)
+	}
+	return nil
+}
+
+// TaskThread finds the thread a task was opened from, or "" when it was not
+// opened from a conversation. The channel comes back with it: a report has to
+// know which room to go to, not just which message.
+func (db *DB) TaskThread(taskID string) (rootID, channelID string, err error) {
+	row := db.conn.QueryRow(`SELECT id, channel_id FROM channel_messages
+		WHERE task_id = ? AND thread_root = '' ORDER BY created_at LIMIT 1`, taskID)
+	switch err := row.Scan(&rootID, &channelID); {
+	case err == sql.ErrNoRows:
+		return "", "", nil
+	case err != nil:
+		return "", "", fmt.Errorf("thread of task %s: %w", taskID, err)
+	}
+	return rootID, channelID, nil
+}
+
+// MessageChannel is the room a message lives in. Callers that already named a
+// message should not have to also name its channel — the database knows.
+func (db *DB) MessageChannel(id string) (string, error) {
+	m, err := db.getMessage(id)
+	if err != nil {
+		return "", err
+	}
+	return m.ChannelID, nil
+}
+
 // threadAgents lists the agents that have spoken in a thread — its root
 // included, since the root is what started it.
 func (db *DB) threadAgents(rootID string) ([]Member, error) {

--- a/internal/coord/channels_test.go
+++ b/internal/coord/channels_test.go
@@ -470,3 +470,84 @@ func TestThreadFollowUpSkipsTheAuthor(t *testing.T) {
 		}
 	}
 }
+
+// TestBindThreadToTask: most work starts as a question, so binding has to be
+// possible after the thread exists — not only when the first line is written.
+func TestBindThreadToTask(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2")
+
+	root, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID,
+		Body: "@bomclaw2 log hôm qua có gì lạ không",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := db.CreateTask(NewTask{CreatedBy: "bomclaw2", Title: "đọc log hôm qua"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Both directions resolve.
+	gotRoot, gotChannel, err := db.TaskThread(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != root.ID || gotChannel != GeneralChannelID {
+		t.Fatalf("TaskThread: got %s in %s, want %s in %s", gotRoot, gotChannel, root.ID, GeneralChannelID)
+	}
+	line, _ := db.ChannelMessages(GeneralChannelID, 10)
+	if line[0].TaskID != task.ID {
+		t.Fatalf("thread root does not carry the task: %q", line[0].TaskID)
+	}
+
+	// Rebinding to the same task is not an error — a retry must not fail.
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatalf("rebinding the same task should be a no-op: %v", err)
+	}
+
+	// One thread, one task: two would leave an agent nowhere unambiguous to
+	// report back to.
+	other, _ := db.CreateTask(NewTask{CreatedBy: "bomclaw2", Title: "việc khác"})
+	err = db.BindThreadToTask(root.ID, other.ID)
+	if err == nil || !strings.Contains(err.Error(), task.ID) {
+		t.Fatalf("second task should be refused and name the first, got %v", err)
+	}
+}
+
+// TestBindRejectsAReply: the binding lives on the root, because the root is
+// what a reader clicks and what a reporter posts under.
+func TestBindRejectsAReply(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw2")
+	root, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "@bomclaw2 hi",
+	})
+	reply, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw2", Body: "ừ",
+	})
+	task, _ := db.CreateTask(NewTask{CreatedBy: "bomclaw2", Title: "việc"})
+
+	err := db.BindThreadToTask(reply.ID, task.ID)
+	if err == nil || !strings.Contains(err.Error(), root.ID) {
+		t.Fatalf("binding a reply should be refused and point at the root, got %v", err)
+	}
+}
+
+// TestTaskWithoutAThread: work queued from the CLI or a schedule has no
+// conversation, and must not invent one.
+func TestTaskWithoutAThread(t *testing.T) {
+	db := testDB(t)
+	task, _ := db.CreateTask(NewTask{CreatedBy: "human", Title: "việc từ lịch"})
+	root, channel, err := db.TaskThread(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != "" || channel != "" {
+		t.Fatalf("a task with no conversation reported one: %s / %s", root, channel)
+	}
+}

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -139,6 +139,10 @@ type TaskDetail struct {
 	// its limit, so counting there would be quietly wrong on a large tree.
 	ContextCount int `json:"context_count"`
 	ContextCap   int `json:"context_cap"`
+
+	// The conversation this work came out of, when it came out of one, so the
+	// board has a way back to the room instead of being a dead end.
+	ThreadRoot string `json:"thread_root,omitempty"`
 }
 
 func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -169,9 +173,14 @@ func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	threadRoot, _, err := deps.Coord.TaskThread(p.ID)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(TaskDetail{
 		Task: task, Events: events, Runs: runs, Children: children,
 		ContextCount: inContext, ContextCap: deps.Coord.MaxTasksPerContext(),
+		ThreadRoot: threadRoot,
 	})
 }
 

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -187,7 +187,7 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 	sink := &replySink{}
 	sess.MarkRunning("channel: " + truncateLine(m.Body, 40))
 	w.live.Store(m.ID, sess)
-	_, err = w.deps.Turn.RunTurn(turnCtx, sess, sess.ChatID, w.model(), w.prompt(m, mem), sink)
+	_, err = w.deps.Turn.RunTurn(turnCtx, sess, sess.ChatID, w.model(), w.prompt(m, mem, key), sink)
 	sess.MarkIdle()
 	w.live.Delete(m.ID)
 	if err != nil {
@@ -236,7 +236,7 @@ func (w *MentionWatcher) model() string {
 // prompt carries the three things the agent cannot look up: what was said and
 // by whom, that its reply is posted into this thread rather than spoken to a
 // user, and what to do when the ask turns out to be bigger than a reply.
-func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession) string {
+func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession, key string) string {
 	var b strings.Builder
 	channel := m.ChannelID
 	if c, err := w.deps.Coord.GetChannel(m.ChannelID); err == nil {
@@ -273,9 +273,12 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 		"about what you are about to do.\n")
 	b.WriteString("Name an agent with @ only when you actually need it to act: @ is a doorbell " +
 		"and wakes that agent.\n")
-	b.WriteString("If this asks for real work — something with steps, or longer than a few " +
-		"minutes — say so briefly and open a task for it with `bomclaw task new`. The board is " +
-		"for work; this room is for talking about it.\n")
+	fmt.Fprintf(&b, "If this asks for real work — something with steps, or longer than a few "+
+		"minutes — say so briefly and open a task for it with `bomclaw task new --thread %s`. "+
+		"The --thread is what keeps the work attached to this conversation: the thread shows "+
+		"the task it produced, and the result is posted back here when it finishes, so nobody "+
+		"has to watch the board for an answer they asked for in a room. The board is for work; "+
+		"this room is for talking about it.\n", key)
 	return b.String()
 }
 

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -170,7 +170,40 @@ func (r *Reporter) Tick() {
 		}
 
 		r.notify(Format(&task))
+		r.reportToThread(&task)
 		log.Printf("reporter: delivered %s (%s) for task %s", task.State, task.ClaimedBy, task.ID)
+	}
+}
+
+// reportToThread puts the outcome back where the work was asked for. A task
+// that came out of a conversation has someone waiting in that conversation,
+// and making them go and watch a board for the answer to a question they asked
+// in a room is how a team stops using the room.
+//
+// Best effort, and deliberately after the owner's notification: the delivery
+// is already claimed by then, so a failure here costs a thread post, never the
+// report itself. It rides on that same claim, so two gateways cannot both post.
+//
+// Authored by the agent that ran the task rather than the one reporting — the
+// reader wants to know who did the work. An agent's line in a thread wakes
+// nobody, which is right: this is an answer, not a summons.
+func (r *Reporter) reportToThread(t *coord.Task) {
+	rootID, channelID, err := r.db.TaskThread(t.ID)
+	if err != nil {
+		log.Printf("reporter: thread of %s: %v", t.ID, err)
+		return
+	}
+	if rootID == "" {
+		return // not work that came out of a conversation
+	}
+	author := t.ClaimedBy
+	if author == "" {
+		author = r.cfg.AgentID
+	}
+	if _, _, err := r.db.PostMessage(coord.NewChannelMessage{
+		ChannelID: channelID, ThreadRoot: rootID, AuthorID: author, Body: Format(t),
+	}); err != nil {
+		log.Printf("reporter: report %s into thread %s: %v", t.ID, rootID, err)
 	}
 }
 

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -241,3 +241,73 @@ func TestFormatTrimsALongResult(t *testing.T) {
 		t.Error("a trimmed result should say so")
 	}
 }
+
+// TestResultGoesBackToTheThread: someone asked in a room and is waiting in that
+// room. Making them watch a board for the answer is how a team stops using the
+// room.
+func TestResultGoesBackToTheThread(t *testing.T) {
+	db := openDB(t)
+	for _, id := range []string{"a1", "a2"} {
+		if err := db.RegisterAgent(coord.Agent{ID: id, DisplayName: id, WSAddr: "ws://127.0.0.1:0/ws"}); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+	}
+	root, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@a1 crawl hộ cái listings",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := delegate(t, db, "crawl listings", coord.TaskCompleted, "62 jobs found")
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var got collector
+	r := New(db, Config{AgentID: "a2"})
+	r.SetNotify(got.add)
+	r.Tick()
+
+	thread, err := db.ThreadMessages(root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(thread) != 2 {
+		t.Fatalf("want the question and one report in the thread, got %d", len(thread))
+	}
+	report := thread[1]
+	if report.AuthorID != "a1" {
+		t.Errorf("the report should come from the agent that ran it, got %q", report.AuthorID)
+	}
+	for _, want := range []string{"crawl listings", "62 jobs found"} {
+		if !strings.Contains(report.Body, want) {
+			t.Errorf("thread report missing %q:\n%s", want, report.Body)
+		}
+	}
+	// The owner still gets it on Telegram: the thread is an addition, not a
+	// redirection.
+	if len(got.all()) != 1 {
+		t.Errorf("want one Telegram delivery too, got %v", got.all())
+	}
+}
+
+// TestNoThreadNoPost: work queued from the CLI or a schedule has no
+// conversation, and must not invent one.
+func TestNoThreadNoPost(t *testing.T) {
+	db := openDB(t)
+	delegate(t, db, "nightly sweep", coord.TaskCompleted, "ok")
+
+	var got collector
+	r := New(db, Config{AgentID: "a2"})
+	r.SetNotify(got.add)
+	r.Tick()
+
+	line, err := db.ChannelMessages(coord.GeneralChannelID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(line) != 0 {
+		t.Fatalf("a task with no conversation posted into one: %+v", line)
+	}
+}


### PR DESCRIPTION
Closes #134 — mảnh nối giữa **hội thoại** và **kanban** trong mô hình ba làn.

## Vấn đề

Agent làm đúng như prompt dặn — việc lớn thì mở task — và **ngữ cảnh ở lại phía sau**:

- `channel_messages.task_id` **chỉ gắn được lúc viết dòng đầu của thread**, mà đó không bao giờ là lúc một cuộc nói chuyện hoá thành việc.
- `task new` không có cách nào nêu tên thread.
- TaskDrawer không có đường về phòng.

Ba hòn đảo, và một trong ba được dặn là hãy tạo ra hai cái kia.

## Sửa

**Gắn được sau.** `BindThreadToTask` — đúng trường hợp thật sự xảy ra. **Một thread, một task**: hai cái sẽ khiến người làm xong một trong hai không biết báo về đâu cho rõ ràng.

**`task new --thread`** gắn và **nói luôn trong thread** ("Đã mở task t_xxx cho việc này"), để phòng thấy việc đã được nhận thay vì phải đi tra bảng. Prompt của lượt trả lời mention giờ đưa sẵn `--thread <id>` kèm lý do.

**Kết quả quay về chỗ đã hỏi.** Reporter vốn đã giải bài "giao đúng một lần giữa nhiều gateway" bằng CAS, nên bài post vào thread **đi nhờ chính cái claim đó** — và đặt *sau* thông báo cho chủ: lúc đó claim đã thắng rồi, nên một cú post hỏng không bao giờ làm mất báo cáo. Tác giả là agent **đã chạy** việc, không phải agent đi báo; và dòng của agent trong thread không đánh thức ai — đây là câu trả lời, không phải lời triệu tập.

**Hai pane có cửa sang nhau.** Badge task trên thread mở board; task sinh ra từ hội thoại có nút quay về phòng.

## Test

- `TestBindThreadToTask` — gắn sau khi thread đã tồn tại, hai chiều resolve, gắn lại cùng task là no-op (retry không được fail), task thứ hai bị từ chối **và nêu tên task thứ nhất**
- `TestBindRejectsAReply` — binding sống trên root, lỗi trỏ đúng root
- `TestResultGoesBackToTheThread` — báo cáo vào thread, tác giả là agent đã chạy, **và Telegram vẫn nhận** (thread là bổ sung, không phải thay thế)
- `TestNoThreadNoPost` / `TestTaskWithoutAThread` — việc từ CLI hay từ lịch không bịa ra một cuộc nói chuyện

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)