### PR TITLE
feat(chat): a registry, so a backend is a file rather than a branch

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ngocp/goterm-control/internal/bot"
 	"github.com/ngocp/goterm-control/internal/browserbridge"
 	"github.com/ngocp/goterm-control/internal/channel"
+	// Also imported for their init(), which registers each as a chat backend
+	// (internal/chat/registry.go). Used directly here only by the titler.
 	"github.com/ngocp/goterm-control/internal/claude"
 	"github.com/ngocp/goterm-control/internal/codex"
 	"github.com/ngocp/goterm-control/internal/config"

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -78,19 +78,38 @@ func NewChatClient(cfg *config.Config, executor *tools.Executor) chat.Client {
 	return NewChatClientWithPool(cfg, executor, nil)
 }
 
+// modelAPI is the protocol this agent's default model speaks, which is what
+// decides the backend. config.Validate has already checked that it agrees with
+// cfg.Provider, so by the time anything calls this the two cannot disagree.
+func modelAPI(cfg *config.Config) models.ModelAPI {
+	want := cfg.Models.Default
+	if want == "" {
+		want = cfg.Claude.Model
+	}
+	if m := models.NewResolver(want, cfg.Models.Custom).Lookup(want); m != nil {
+		return m.API
+	}
+	return models.APIClaudeCLI
+}
+
 // NewChatClientWithPool is NewChatClient with a credential pool attached. A
 // nil or empty pool leaves the client running on the ambient credentials,
 // which is what every install without an `accounts:` section does.
 func NewChatClientWithPool(cfg *config.Config, executor *tools.Executor, pool *credentials.Pool) chat.Client {
-	if cfg.Provider == config.ProviderCodex {
-		c := codex.New(cfg.Claude.SystemPrompt)
-		c.SetWorkspace(cfg.Claude.Workspace)
-		c.SetPool(pool)
-		return c
+	api := modelAPI(cfg)
+	c, err := chat.Resolve(api, chat.Deps{
+		SystemPrompt: cfg.Claude.SystemPrompt,
+		Workspace:    cfg.Claude.Workspace,
+		Executor:     executor,
+		Pool:         pool,
+	})
+	if err != nil {
+		// Unreachable through config, which validates against the same
+		// registry. Reachable by a caller passing a hand-built Config, and
+		// then loud is the only safe answer: the old code fell back to claude
+		// here, so an agent could report one backend and run another.
+		panic(err)
 	}
-	c := claude.New(cfg.Claude.SystemPrompt, executor)
-	c.SetWorkspace(cfg.Claude.Workspace)
-	c.SetPool(pool)
 	return c
 }
 
@@ -98,18 +117,45 @@ func NewChatClientWithPool(cfg *config.Config, executor *tools.Executor, pool *c
 // the other backend are ignored: an agent runs one CLI, and a codex login is
 // unreadable by claude.
 func PoolFromConfig(cfg *config.Config) (*credentials.Pool, error) {
-	accts := make([]credentials.Account, 0, len(cfg.Accounts.Pool))
+	pools, err := PoolsFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return pools[cfg.Provider], nil
+}
+
+// PoolsFromConfig builds one pool per provider named in accounts.pool, plus an
+// empty one for this agent's own provider so callers never get a nil.
+//
+// The single-pool version silently dropped every account belonging to another
+// backend — fine while an agent could only ever be one of two things, a trap
+// once a machine runs three agents on three CLIs and someone lists all their
+// logins in one file and wonders why half are ignored.
+func PoolsFromConfig(cfg *config.Config) (map[string]*credentials.Pool, error) {
+	byProvider := map[string][]credentials.Account{cfg.Provider: nil}
 	for _, a := range cfg.Accounts.Pool {
-		accts = append(accts, credentials.Account{
+		provider := a.Provider
+		if provider == "" {
+			provider = cfg.Provider
+		}
+		byProvider[provider] = append(byProvider[provider], credentials.Account{
 			Name:      a.Name,
-			Provider:  a.Provider,
+			Provider:  provider,
 			ConfigDir: a.ConfigDir,
 			APIKey:    a.APIKey,
 			APIKeyEnv: a.APIKeyEnv,
 		})
 	}
-	return credentials.NewPool(cfg.Provider, accts,
-		time.Duration(cfg.Accounts.CooldownMinutes)*time.Minute)
+	cooldown := time.Duration(cfg.Accounts.CooldownMinutes) * time.Minute
+	out := make(map[string]*credentials.Pool, len(byProvider))
+	for provider, accts := range byProvider {
+		p, err := credentials.NewPool(provider, accts, cooldown)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", provider, err)
+		}
+		out[provider] = p
+	}
+	return out, nil
 }
 
 func New(cfg *config.Config, db *storage.DB, coordDB *coord.DB, sessions *session.Manager) (*Bot, error) {

--- a/internal/bot/registry_test.go
+++ b/internal/bot/registry_test.go
@@ -1,0 +1,97 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/config"
+	"github.com/ngocp/goterm-control/internal/models"
+)
+
+func cfgFor(provider, model string) *config.Config {
+	c := &config.Config{Provider: provider}
+	c.Claude.Model = model
+	c.Claude.SystemPrompt = "be brief"
+	c.Claude.Workspace = "/tmp/ws"
+	return c
+}
+
+// TestTheRunningConfigStillResolvesToClaude is the characterization test the
+// registry needed: this is what the machine runs today, and a refactor that
+// quietly swapped the backend under it would look exactly like a refactor that
+// worked.
+func TestTheRunningConfigStillResolvesToClaude(t *testing.T) {
+	c := NewChatClientWithPool(cfgFor(config.ProviderClaude, "claude-opus-5"), nil, nil)
+	if got := c.Name(); got != "claude" {
+		t.Fatalf("the claude config resolved to %q", got)
+	}
+}
+
+// And agent 2, which runs codex.
+func TestTheCodexConfigStillResolvesToCodex(t *testing.T) {
+	c := NewChatClientWithPool(cfgFor(config.ProviderCodex, "gpt-6-astra"), nil, nil)
+	if got := c.Name(); got != "codex" {
+		t.Fatalf("the codex config resolved to %q", got)
+	}
+}
+
+// TestAnUnknownBackendIsLoudNotClaude: the old code's else branch made every
+// unrecognised provider run claude, so an agent could report one backend and
+// run another. Failing to start is the better outcome.
+func TestAnUnknownBackendIsLoudNotClaude(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("an unknown model api fell back to a backend instead of failing")
+		}
+		if !strings.Contains(strings.ToLower(err(r)), "no backend") {
+			t.Fatalf("panic should say what is missing, got: %v", r)
+		}
+	}()
+	c := cfgFor("hermes", "hermes-1")
+	c.Models.Custom = []models.Model{{ID: "hermes-1", Name: "Hermes", API: "hermes-cli"}}
+	NewChatClientWithPool(c, nil, nil)
+}
+
+func err(v any) string {
+	if e, ok := v.(error); ok {
+		return e.Error()
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// TestPoolsAreBuiltPerProvider: the single-pool version dropped every account
+// belonging to another backend without a word, which on a machine running
+// three agents on different CLIs means half the logins in one file are ignored
+// and nothing says so.
+func TestPoolsAreBuiltPerProvider(t *testing.T) {
+	c := cfgFor(config.ProviderClaude, "claude-opus-5")
+	c.Accounts.Pool = []config.AccountConfig{
+		{Name: "default", ConfigDir: "~/.claude"},
+		{Name: "tam", ConfigDir: "~/.claude-tam"},
+		{Name: "codex-main", Provider: config.ProviderCodex, ConfigDir: "~/.codex"},
+	}
+	pools, err := PoolsFromConfig(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claudePool := pools[config.ProviderClaude]
+	if claudePool == nil || len(claudePool.Names()) != 2 {
+		t.Fatalf("claude pool should hold the two claude logins, got %v", claudePool.Names())
+	}
+	codexPool := pools[config.ProviderCodex]
+	if codexPool == nil || len(codexPool.Names()) != 1 {
+		t.Fatalf("the codex account was dropped: %v", pools)
+	}
+	// And the old single-pool entry point still answers with this agent's own.
+	one, err := PoolFromConfig(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(one.Names()) != 2 {
+		t.Fatalf("PoolFromConfig should return this agent's provider pool, got %v", one.Names())
+	}
+}

--- a/internal/chat/registry.go
+++ b/internal/chat/registry.go
@@ -1,0 +1,90 @@
+package chat
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/ngocp/goterm-control/internal/credentials"
+	"github.com/ngocp/goterm-control/internal/models"
+	"github.com/ngocp/goterm-control/internal/tools"
+)
+
+// Which CLI backs an agent.
+//
+// This used to be an if/else on one agent-wide config key, with an else branch
+// that turned anything unrecognised into claude without saying so. That shape
+// has two costs. A third backend means editing internal/bot, which is the
+// package that should know least about any particular CLI. And the silent else
+// means loosening the config check without also editing that branch gives you
+// an agent that reports one provider and runs another.
+//
+// The key is the model's API rather than a provider name, because the model
+// catalogue already records which protocol each model speaks and config
+// already cross-checks the two (config.Validate). Choosing a model is
+// something people do every day; choosing a backend is not. Keying on the API
+// makes them one decision instead of two that have to agree.
+type Factory func(Deps) Client
+
+// Deps is what every backend needs to build one. Plain values rather than
+// *config.Config on purpose: config imports this package to validate against
+// the registry, and the reverse import would close the loop.
+type Deps struct {
+	SystemPrompt string
+	Workspace    string
+	Executor     *tools.Executor   // claude runs tools in-process; others may ignore it
+	Pool         *credentials.Pool // nil means the ambient credentials
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[models.ModelAPI]Factory{}
+)
+
+// Register adds a backend. Called from a provider package's init, so adding one
+// is a new file and one line rather than a new branch in internal/bot.
+// Registering the same API twice is a programming error, not a runtime one.
+func Register(api models.ModelAPI, f Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, taken := registry[api]; taken {
+		panic(fmt.Sprintf("chat: two backends registered for %q", api))
+	}
+	registry[api] = f
+}
+
+// Resolve builds the backend for an API, or says which one it could not find.
+// It never falls back: an agent quietly running a different CLI than the one
+// its config names is worse than an agent that does not start.
+func Resolve(api models.ModelAPI, deps Deps) (Client, error) {
+	registryMu.RLock()
+	f, ok := registry[api]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("chat: no backend for model api %q (have: %v) — "+
+			"the provider package may not be imported", api, Registered())
+	}
+	return f(deps), nil
+}
+
+// Supports reports whether a backend exists for an API. config.Validate uses it
+// instead of a hardcoded list of two.
+func Supports(api models.ModelAPI) bool {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	_, ok := registry[api]
+	return ok
+}
+
+// Registered lists the APIs with a backend, sorted so error messages and the
+// settings screen do not reorder themselves between calls.
+func Registered() []models.ModelAPI {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	out := make([]models.ModelAPI, 0, len(registry))
+	for api := range registry {
+		out = append(out, api)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/credentials"
 	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -458,4 +459,15 @@ func cliError(resumeID, result string, details []string, stderr string) error {
 		}
 	}
 	return fmt.Errorf("claude error: %s", message)
+}
+
+// Registering here rather than in internal/bot is what keeps bot from having to
+// know this package exists. The blank import in cmd/bomclaw is what runs it.
+func init() {
+	chat.Register(models.APIClaudeCLI, func(d chat.Deps) chat.Client {
+		c := New(d.SystemPrompt, d.Executor)
+		c.SetWorkspace(d.Workspace)
+		c.SetPool(d.Pool)
+		return c
+	})
 }

--- a/internal/codex/client.go
+++ b/internal/codex/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/credentials"
 	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/models"
 	"github.com/ngocp/goterm-control/internal/session"
 	"github.com/ngocp/goterm-control/internal/tools"
 )
@@ -431,4 +432,15 @@ func formatInput(raw json.RawMessage) string {
 func defaultWorkspace() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "goterm-workspace")
+}
+
+// See the note in internal/claude: the provider knows how to build itself, and
+// internal/bot no longer needs a branch per CLI.
+func init() {
+	chat.Register(models.APICodexCLI, func(d chat.Deps) chat.Client {
+		c := New(d.SystemPrompt)
+		c.SetWorkspace(d.Workspace)
+		c.SetPool(d.Pool)
+		return c
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,16 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/models"
+
+	// Imported for their init(): each registers itself as a chat backend.
+	// Validate asks the registry which backends exist, so a package that used
+	// config without importing a provider would find it empty and reject every
+	// valid config. Registration belongs next to the code that depends on it,
+	// not left to whoever happens to import a provider for another reason.
+	_ "github.com/ngocp/goterm-control/internal/claude"
+	_ "github.com/ngocp/goterm-control/internal/codex"
 	"gopkg.in/yaml.v3"
 )
 
@@ -448,29 +457,44 @@ func (c *Config) Validate() error {
 	if c.Telegram.Token == "" {
 		return fmt.Errorf("telegram.token is required (set TELEGRAM_TOKEN env var or config)")
 	}
-	switch c.Provider {
-	case ProviderClaude:
-		if c.Claude.APIKey == "" {
-			return fmt.Errorf("claude.api_key is required (set ANTHROPIC_API_KEY env var or config)")
-		}
-	case ProviderCodex:
-		// Codex authenticates itself via `codex login`; no key lives here.
-		// Guard the model though: NewResolver silently falls back to the first
-		// builtin (a claude model) when the configured id is unknown, and the
-		// codex CLI would then reject every turn with a 400.
-		want := c.Models.Default
-		if want == "" {
-			want = c.Claude.Model
-		}
-		m := models.NewResolver(want, c.Models.Custom).Lookup(want)
-		if m == nil || m.API != models.APICodexCLI {
-			return fmt.Errorf("provider %q needs a codex model, but models.default/claude.model is %q; "+
-				"use a model with api: codex-cli (e.g. gpt-6-astra)", ProviderCodex, want)
-		}
-	default:
-		return fmt.Errorf("provider must be %q or %q, got %q", ProviderClaude, ProviderCodex, c.Provider)
+	// The provider and the model have to agree, because the model's API is what
+	// actually selects the backend (chat.Resolve). NewResolver falls back to the
+	// first builtin — a claude model — when the configured id is unknown, so a
+	// typo in models.default would otherwise turn a codex agent into a claude
+	// one at startup and reject every turn with a 400 much later.
+	want := c.Models.Default
+	if want == "" {
+		want = c.Claude.Model
+	}
+	m := models.NewResolver(want, c.Models.Custom).Lookup(want)
+	if m == nil {
+		return fmt.Errorf("models.default/claude.model %q is not a known model", want)
+	}
+	if !chat.Supports(m.API) {
+		return fmt.Errorf("no backend for model %q (api %q); registered: %v", want, m.API, chat.Registered())
+	}
+	if want := providerFor(m.API); want != "" && c.Provider != want {
+		return fmt.Errorf("provider is %q but model %q speaks %q — use provider: %s, "+
+			"or a model whose api matches", c.Provider, m.ID, m.API, want)
+	}
+	if c.Provider == ProviderClaude && c.Claude.APIKey == "" {
+		return fmt.Errorf("claude.api_key is required (set ANTHROPIC_API_KEY env var or config)")
 	}
 	return nil
+}
+
+// providerFor maps a model API back to the provider key that config uses, for
+// the two that predate the registry. A backend added later needs no entry: the
+// check above simply does not apply to it, which is better than a list that
+// silently rejects anything not in it.
+func providerFor(api models.ModelAPI) string {
+	switch api {
+	case models.APIClaudeCLI:
+		return ProviderClaude
+	case models.APICodexCLI:
+		return ProviderCodex
+	}
+	return ""
 }
 
 func (c *SecurityConfig) IsAllowed(userID int64) bool {

--- a/internal/config/registry_guard_test.go
+++ b/internal/config/registry_guard_test.go
@@ -1,0 +1,22 @@
+package config
+
+import "testing"
+
+// A package that uses config without importing a provider would otherwise find
+// an empty registry and reject every valid config. The blank imports in this
+// package are what stop that; this test is what notices if they are removed.
+func TestBackendsAreRegisteredWhereverConfigIs(t *testing.T) {
+	cfg := &Config{Provider: ProviderClaude}
+	cfg.Claude.APIKey = "x"
+	cfg.Claude.Model = "claude-opus-5"
+	cfg.Telegram.Token = "t"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("a valid claude config was rejected — is the registry empty? %v", err)
+	}
+	cfg2 := &Config{Provider: ProviderCodex}
+	cfg2.Claude.Model = "gpt-6-astra"
+	cfg2.Telegram.Token = "t"
+	if err := cfg2.Validate(); err != nil {
+		t.Fatalf("a valid codex config was rejected: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #125 — điều kiện cần của #137 (opencode), #138 (tab Settings), #129 (Hermes).

## Vấn đề

Chọn CLI đứng sau một agent là một if/else trên **một khoá config cho cả agent**, và nhánh `else` biến mọi thứ lạ thành claude **mà không nói gì**. Hai cái giá: backend thứ ba phải sửa `internal/bot` — package đáng ra biết ít nhất về từng CLI cụ thể — và nới `Validate` mà quên nhánh đó thì được một agent **báo một backend, chạy một backend khác**.

## Registry khoá theo `ModelAPI`, không theo tên provider

Bảng model **đã** ghi mỗi model nói protocol nào, và config **đã** đối chiếu chéo hai thứ đó. Tức thông tin nằm sẵn ở đấy và chỉ đang dùng để sinh ra một câu lỗi. Khoá theo nó thì "model nào" và "backend nào" là **một** quyết định, thay vì hai thứ phải khớp nhau.

`claude` và `codex` tự đăng ký trong `init()`. Thêm một cái là **một file mới + một dòng**.

`Resolve` **không bao giờ fallback**: một agent lặng lẽ chạy CLI khác với cái config ghi còn tệ hơn một agent không khởi động được.

## Hai thứ lộ ra khi làm

**Pool bỏ im lặng account của backend khác.** `NewPool(cfg.Provider, …)` lọc theo đúng một provider. Vô hại khi agent chỉ có thể là một trong hai thứ; thành bẫy khi ba agent chạy ba CLI và ai đó liệt kê tất cả login vào một file. Giờ có pool cho **từng** provider.

**Config hỏi registry, nhưng không import provider nào** → registry rỗng → **từ chối mọi config hợp lệ**. Toàn bộ suite vẫn pass, vì không test nào chạm đường đó. Test bắt lỗi này nằm trong PR (`TestBackendsAreRegisteredWhereverConfigIs`), và `config` tự import provider thay vì phó mặc cho người tình cờ import một cái vì lý do khác.

## Test đặc tả — thứ quan trọng nhất ở đây

- `TestTheRunningConfigStillResolvesToClaude` / `...CodexConfigStillResolvesToCodex` — đúng cấu hình đang chạy trên máy. Một refactor âm thầm đổi backend bên dưới sẽ trông **y hệt** một refactor chạy đúng, nếu không có hai test này.
- `TestAnUnknownBackendIsLoudNotClaude` — api lạ thì **nổ**, không rơi về claude.
- `TestPoolsAreBuiltPerProvider` — hai login claude + một login codex, không cái nào bị bỏ.

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)