### PR TITLE
feat(opencode): a third backend, and internal/bot did not change

### DIFF
--- a/internal/bot/registry_test.go
+++ b/internal/bot/registry_test.go
@@ -95,3 +95,18 @@ func TestPoolsAreBuiltPerProvider(t *testing.T) {
 		t.Fatalf("PoolFromConfig should return this agent's provider pool, got %v", one.Names())
 	}
 }
+
+// TestAThirdBackendNeedsNoChangeHere is what #125 was for. opencode is
+// registered by its own package and reached through the registry; if this test
+// ever needs a branch added to internal/bot to pass, the registry has stopped
+// doing its job.
+func TestAThirdBackendNeedsNoChangeHere(t *testing.T) {
+	c := cfgFor(config.ProviderOpenCode, "oc-sonnet")
+	c.Models.Custom = []models.Model{{
+		ID: "oc-sonnet", Name: "opencode", API: models.APIOpenCodeCLI,
+	}}
+	client := NewChatClientWithPool(c, nil, nil)
+	if got := client.Name(); got != "opencode" {
+		t.Fatalf("the opencode config resolved to %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	// not left to whoever happens to import a provider for another reason.
 	_ "github.com/ngocp/goterm-control/internal/claude"
 	_ "github.com/ngocp/goterm-control/internal/codex"
+	_ "github.com/ngocp/goterm-control/internal/opencode"
 	"gopkg.in/yaml.v3"
 )
 
@@ -449,8 +450,9 @@ func Load(path string) (*Config, error) {
 
 // Supported provider keys.
 const (
-	ProviderClaude = "claude"
-	ProviderCodex  = "codex"
+	ProviderClaude   = "claude"
+	ProviderCodex    = "codex"
+	ProviderOpenCode = "opencode"
 )
 
 func (c *Config) Validate() error {
@@ -493,6 +495,8 @@ func providerFor(api models.ModelAPI) string {
 		return ProviderClaude
 	case models.APICodexCLI:
 		return ProviderCodex
+	case models.APIOpenCodeCLI:
+		return ProviderOpenCode
 	}
 	return ""
 }

--- a/internal/models/catalog.go
+++ b/internal/models/catalog.go
@@ -4,10 +4,11 @@ package models
 type ModelAPI string
 
 const (
-	APIClaudeCLI ModelAPI = "claude-cli" // Claude Code CLI subprocess
-	APICodexCLI  ModelAPI = "codex-cli"  // OpenAI Codex CLI subprocess
-	APIAnthropic ModelAPI = "anthropic"  // Anthropic Messages API (future)
-	APIOpenAI    ModelAPI = "openai"     // OpenAI-compatible completions (future)
+	APIClaudeCLI   ModelAPI = "claude-cli"   // Claude Code CLI subprocess
+	APICodexCLI    ModelAPI = "codex-cli"    // OpenAI Codex CLI subprocess
+	APIOpenCodeCLI ModelAPI = "opencode-cli" // opencode CLI subprocess
+	APIAnthropic   ModelAPI = "anthropic"    // Anthropic Messages API (future)
+	APIOpenAI      ModelAPI = "openai"       // OpenAI-compatible completions (future)
 )
 
 // InputType describes what a model can accept.
@@ -21,16 +22,16 @@ const (
 
 // Model describes an AI model's capabilities, cost, and routing info.
 type Model struct {
-	ID            string    `yaml:"id" json:"id"`                         // canonical ID (e.g. "claude-opus-4-6")
-	Name          string    `yaml:"name" json:"name"`                     // display name
-	Provider      string    `yaml:"provider" json:"provider"`             // provider key (e.g. "anthropic", "openai")
-	API           ModelAPI  `yaml:"api" json:"api"`                       // wire protocol
-	Aliases       []string  `yaml:"aliases,omitempty" json:"aliases"`     // shorthand names (e.g. "opus", "o4")
-	ContextWindow int       `yaml:"context_window" json:"context_window"` // max input tokens
-	MaxTokens     int       `yaml:"max_tokens" json:"max_tokens"`         // max output tokens
-	Reasoning     bool      `yaml:"reasoning" json:"reasoning"`           // extended thinking support
-	Input         []InputType `yaml:"input" json:"input"`                 // supported modalities
-	Cost          ModelCost `yaml:"cost" json:"cost"`                     // pricing per 1M tokens
+	ID            string      `yaml:"id" json:"id"`                         // canonical ID (e.g. "claude-opus-4-6")
+	Name          string      `yaml:"name" json:"name"`                     // display name
+	Provider      string      `yaml:"provider" json:"provider"`             // provider key (e.g. "anthropic", "openai")
+	API           ModelAPI    `yaml:"api" json:"api"`                       // wire protocol
+	Aliases       []string    `yaml:"aliases,omitempty" json:"aliases"`     // shorthand names (e.g. "opus", "o4")
+	ContextWindow int         `yaml:"context_window" json:"context_window"` // max input tokens
+	MaxTokens     int         `yaml:"max_tokens" json:"max_tokens"`         // max output tokens
+	Reasoning     bool        `yaml:"reasoning" json:"reasoning"`           // extended thinking support
+	Input         []InputType `yaml:"input" json:"input"`                   // supported modalities
+	Cost          ModelCost   `yaml:"cost" json:"cost"`                     // pricing per 1M tokens
 }
 
 // ModelCost holds per-1M-token pricing.
@@ -134,5 +135,19 @@ func BuiltinModels() []Model {
 			Reasoning:     true,
 			Input:         []InputType{InputText, InputImage},
 		},
+
+		// opencode ships no builtin on purpose. Its --model takes a
+		// provider/model pair resolved against whatever the user has
+		// authenticated in opencode itself, so any id invented here would be
+		// right for one install and a 400 for the next. Add your own:
+		//
+		//   models:
+		//     default: "anthropic/claude-opus-5"
+		//     custom:
+		//       - id: "anthropic/claude-opus-5"
+		//         name: "Opus 5 via opencode"
+		//         api: "opencode-cli"
+		//
+		// The id is passed to --model verbatim.
 	}
 }

--- a/internal/opencode/client.go
+++ b/internal/opencode/client.go
@@ -1,0 +1,336 @@
+// Package opencode runs a turn through the opencode CLI
+// (https://github.com/anomalyco/opencode) as a subprocess, the way the claude
+// and codex packages do.
+//
+// opencode also has a `serve` mode with an HTTP API, and it is deliberately not
+// used. A subprocess is the shape the other two already have, so it inherits
+// the process-group cleanup that keeps a CLI from outliving the gateway; a
+// server is a second lifetime to supervise, and nothing here needs one yet.
+package opencode
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/credentials"
+	"github.com/ngocp/goterm-control/internal/execution"
+	"github.com/ngocp/goterm-control/internal/models"
+	"github.com/ngocp/goterm-control/internal/session"
+	"github.com/ngocp/goterm-control/internal/tools"
+)
+
+// opencodeBin is the name of the opencode CLI binary.
+const opencodeBin = "opencode"
+
+// ProviderName is the session-storage key for this provider.
+const ProviderName = "opencode"
+
+// Client wraps the opencode CLI subprocess.
+type Client struct {
+	systemPrompt string
+	pool         *credentials.Pool
+	workspace    string
+}
+
+// New creates an opencode client. The CLI owns its own auth and its own tool
+// loop, exactly as codex does.
+func New(systemPrompt string) *Client {
+	log.Printf("opencode: subprocess client initialized")
+	return &Client{systemPrompt: systemPrompt}
+}
+
+// SetPool attaches the credential pool this client rotates sessions across.
+func (c *Client) SetPool(p *credentials.Pool) { c.pool = p }
+
+// SetWorkspace sets the working directory for spawned CLI processes.
+func (c *Client) SetWorkspace(dir string) { c.workspace = dir }
+
+// Name identifies this provider in session storage.
+func (c *Client) Name() string { return ProviderName }
+
+func (c *Client) account(sess *session.Session) (credentials.Account, error) {
+	if c.pool == nil || c.pool.Empty() {
+		return credentials.Account{}, nil
+	}
+	acct, err := c.pool.Pick(sess.GetAccount())
+	if err != nil {
+		return credentials.Account{}, err
+	}
+	sess.SetAccount(acct.Name)
+	c.pool.MarkStarted(acct.Name)
+	return acct, nil
+}
+
+func (c *Client) recordOutcome(acct credentials.Account, err error) {
+	if c.pool == nil || acct.Name == "" {
+		return
+	}
+	switch {
+	case err == nil:
+		c.pool.MarkSuccess(acct.Name)
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	default:
+		c.pool.MarkFailure(acct.Name, err)
+	}
+}
+
+// SendMessage runs one turn and streams its events through cb.
+//
+// opencode has no flag for an extra system prompt, so like codex the prompt and
+// memory are folded into the first message of a session; the session carries
+// them from then on.
+func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID string,
+	userText string, memoryContext string, cb chat.StreamCallbacks) (err error) {
+
+	acct, err := c.account(sess)
+	if err != nil {
+		return err
+	}
+	defer func() { c.recordOutcome(acct, err) }()
+
+	sessionID := sess.GetSessionID()
+	// A session belonging to another CLI cannot be resumed here. Starting a
+	// fresh one is the only option that does not fail every turn after a
+	// provider switch.
+	isNew := sessionID == "" || sess.GetProvider() != ProviderName
+
+	prompt := userText
+	if isNew {
+		prompt = c.firstTurnPrompt(userText, memoryContext)
+	}
+
+	cmd := exec.CommandContext(ctx, opencodeBin, buildArgs(modelID, sessionID, isNew)...)
+	execution.Detach(cmd)
+	cmd.Env = credentials.ApplyEnv(os.Environ(), acct)
+	if c.workspace != "" {
+		_ = os.MkdirAll(c.workspace, 0755)
+		cmd.Dir = c.workspace
+	}
+	// The message goes on stdin rather than argv: a prompt with a newline, a
+	// quote or a leading dash is ordinary here and would be a quoting bug there.
+	cmd.Stdin = strings.NewReader(prompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start opencode: %w", err)
+	}
+	defer execution.Track(cmd)()
+
+	var lastErrLine string
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		s := bufio.NewScanner(stderr)
+		for s.Scan() {
+			if line := s.Text(); line != "" {
+				lastErrLine = line
+				log.Printf("opencode stderr: %s", line)
+			}
+		}
+	}()
+
+	// Every exit path reaps the child: returning on a stream error without
+	// waiting leaves a zombie and a goroutine blocked on a pipe that never
+	// closes, one per failed turn.
+	var (
+		waitOnce sync.Once
+		waitErr  error
+	)
+	reap := func() error {
+		waitOnce.Do(func() {
+			waitErr = cmd.Wait()
+			<-stderrDone
+		})
+		return waitErr
+	}
+	abort := func(err error) error {
+		if cmd.Process != nil {
+			_ = execution.KillGroup(cmd.Process)
+		}
+		_ = reap()
+		return err
+	}
+	defer reap()
+
+	sawText := false
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			_ = execution.KillGroup(cmd.Process)
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var ev event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue // the CLI also prints non-JSON diagnostics on stdout
+		}
+
+		// Every event carries the session id, so the first one is enough — and
+		// taking it from any event rather than a dedicated "started" type means
+		// a turn whose opening event we do not handle still records where to
+		// resume from.
+		if isNew && ev.SessionID != "" && sess.GetSessionID() == "" {
+			sess.SetSessionID(ev.SessionID)
+			sess.SetProvider(ProviderName)
+			log.Printf("opencode: session_id=%s", ev.SessionID)
+		}
+
+		switch ev.Type {
+		case "text":
+			if ev.Part == nil || ev.Part.Text == "" {
+				continue
+			}
+			sawText = true
+			if cb.OnText != nil {
+				cb.OnText(ev.Part.Text)
+			}
+
+		case "tool_use":
+			if ev.Part == nil || ev.Part.State == nil {
+				continue
+			}
+			name := ev.Part.Tool
+			if name == "" {
+				name = "tool"
+			}
+			// opencode reports a tool once, already finished — there is no
+			// started event to pair with. So the call and its result are
+			// announced together rather than the sink being told about a call
+			// that, as far as it knows, never came back.
+			if cb.OnToolCall != nil {
+				cb.OnToolCall(name, ev.Part.State.inputJSON())
+			}
+			if cb.OnToolResult != nil {
+				cb.OnToolResult(name, toolResult(ev.Part.State))
+			}
+
+		case "error":
+			return abort(fmt.Errorf("opencode error: %s", errorText(ev.Error, lastErrLine)))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return abort(fmt.Errorf("read opencode output: %w", err))
+	}
+
+	if err := reap(); err != nil {
+		// A named session the CLI does not know is the one failure the bot
+		// layer handles rather than surfaces: it starts a fresh session instead
+		// of leaving the conversation permanently broken.
+		if !isNew && sessionNotFound(lastErrLine) {
+			return chat.ErrSessionNotFound
+		}
+		if lastErrLine != "" {
+			return fmt.Errorf("opencode: %w (%s)", err, lastErrLine)
+		}
+		return fmt.Errorf("opencode: %w", err)
+	}
+	if !sawText {
+		log.Printf("opencode: turn produced no text (stderr: %s)", lastErrLine)
+	}
+	sess.IncrementMessages()
+	return nil
+}
+
+// buildArgs assembles the CLI invocation. The message itself is not here: it
+// arrives on stdin.
+func buildArgs(modelID, sessionID string, isNew bool) []string {
+	args := []string{"run", "--format", "json"}
+	if modelID != "" {
+		args = append(args, "--model", modelID)
+	}
+	if !isNew && sessionID != "" {
+		args = append(args, "--session", sessionID)
+	}
+	return args
+}
+
+// firstTurnPrompt folds the system prompt and memory into the opening message,
+// because opencode has no flag that carries them separately. Later turns resume
+// a session that already holds them.
+func (c *Client) firstTurnPrompt(userText, memoryContext string) string {
+	var b strings.Builder
+	if p := strings.TrimSpace(c.systemPrompt); p != "" {
+		b.WriteString(p)
+		b.WriteString("\n\n")
+	}
+	if m := strings.TrimSpace(memoryContext); m != "" {
+		b.WriteString(m)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(userText)
+	return b.String()
+}
+
+func toolResult(s *toolState) tools.ToolResult {
+	if s.Status == "error" || s.Error != "" {
+		msg := s.Error
+		if msg == "" {
+			msg = "tool failed"
+		}
+		return tools.ToolResult{Output: msg, IsError: true}
+	}
+	return tools.ToolResult{Output: s.Output}
+}
+
+func errorText(raw json.RawMessage, fallback string) string {
+	if len(raw) > 0 {
+		var msg struct {
+			Message string `json:"message"`
+			Name    string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &msg); err == nil {
+			if msg.Message != "" {
+				return msg.Message
+			}
+			if msg.Name != "" {
+				return msg.Name
+			}
+		}
+		return string(raw)
+	}
+	if fallback != "" {
+		return fallback
+	}
+	return "unknown error"
+}
+
+// sessionNotFound recognises the CLI's own words for a session id it cannot
+// resume. Matched loosely on purpose: the alternative is treating a stale id as
+// a hard failure, which breaks a conversation permanently rather than for one
+// turn.
+func sessionNotFound(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "session not found") || strings.Contains(s, "no such session")
+}
+
+// Registering here is what lets internal/bot stay ignorant of this package;
+// config imports it for the side effect.
+func init() {
+	chat.Register(models.APIOpenCodeCLI, func(d chat.Deps) chat.Client {
+		c := New(d.SystemPrompt)
+		c.SetWorkspace(d.Workspace)
+		c.SetPool(d.Pool)
+		return c
+	})
+}

--- a/internal/opencode/client_test.go
+++ b/internal/opencode/client_test.go
@@ -1,0 +1,146 @@
+package opencode
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/tools"
+)
+
+func TestBuildArgsNewSession(t *testing.T) {
+	got := strings.Join(buildArgs("anthropic/claude-opus-5", "", true), " ")
+	want := "run --format json --model anthropic/claude-opus-5"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildArgsResume(t *testing.T) {
+	got := strings.Join(buildArgs("anthropic/claude-opus-5", "ses_abc", false), " ")
+	if !strings.Contains(got, "--session ses_abc") {
+		t.Errorf("resume did not pass the session id: %q", got)
+	}
+}
+
+// A session id must never be passed on a new session: --session with an id the
+// CLI has not created is a failure, not a fresh start.
+func TestBuildArgsIgnoresTheIDWhenStartingFresh(t *testing.T) {
+	got := strings.Join(buildArgs("m", "ses_stale", true), " ")
+	if strings.Contains(got, "--session") {
+		t.Errorf("a new session carried an old id: %q", got)
+	}
+}
+
+func TestBuildArgsOmitsEmptyModel(t *testing.T) {
+	got := strings.Join(buildArgs("", "", true), " ")
+	if strings.Contains(got, "--model") {
+		t.Errorf("empty model reached the CLI: %q", got)
+	}
+}
+
+// The shapes below are the CLI's own, from
+// packages/opencode/src/cli/cmd/run.ts: one JSON object per line, always
+// {type, timestamp, sessionID, ...}.
+const realTextEvent = `{"type":"text","timestamp":1757000000000,"sessionID":"ses_01","part":` +
+	`{"id":"prt_1","sessionID":"ses_01","type":"text","text":"Đã xong.","time":{"start":1,"end":2}}}`
+
+const realToolEvent = `{"type":"tool_use","timestamp":1757000000001,"sessionID":"ses_01","part":` +
+	`{"id":"prt_2","type":"tool","tool":"bash","state":{"status":"completed",` +
+	`"title":"ls","input":{"command":"ls -la"},"output":"total 0"}}}`
+
+const realToolError = `{"type":"tool_use","timestamp":1757000000002,"sessionID":"ses_01","part":` +
+	`{"id":"prt_3","type":"tool","tool":"read","state":{"status":"error","error":"file not found"}}}`
+
+func TestParseRealTextEvent(t *testing.T) {
+	var ev event
+	if err := json.Unmarshal([]byte(realTextEvent), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Type != "text" || ev.Part == nil || ev.Part.Text != "Đã xong." {
+		t.Fatalf("unexpected parse: %+v", ev)
+	}
+	// Every event carries it, which is why resuming needs no separate lookup.
+	if ev.SessionID != "ses_01" {
+		t.Errorf("session id lost: %q", ev.SessionID)
+	}
+}
+
+func TestParseRealToolEvent(t *testing.T) {
+	var ev event
+	if err := json.Unmarshal([]byte(realToolEvent), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Part.Tool != "bash" || ev.Part.State.Status != "completed" {
+		t.Fatalf("unexpected parse: %+v", ev.Part)
+	}
+	if in := ev.Part.State.inputJSON(); !strings.Contains(in, "ls -la") {
+		t.Errorf("tool input lost: %q", in)
+	}
+	if got := toolResult(ev.Part.State); got.IsError || got.Output != "total 0" {
+		t.Errorf("tool result: %+v", got)
+	}
+}
+
+func TestToolErrorIsAnError(t *testing.T) {
+	var ev event
+	if err := json.Unmarshal([]byte(realToolError), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := toolResult(ev.Part.State)
+	if !got.IsError || !strings.Contains(got.Output, "file not found") {
+		t.Errorf("a failed tool came back as success: %+v", got)
+	}
+}
+
+// A call with no arguments must not look like a parse failure downstream.
+func TestEmptyToolInputIsAnEmptyObject(t *testing.T) {
+	if got := (&toolState{}).inputJSON(); got != "{}" {
+		t.Errorf("got %q, want %q", got, "{}")
+	}
+}
+
+func TestFirstTurnPromptCarriesInstructionsAndMemory(t *testing.T) {
+	c := New("You are terse.")
+	got := c.firstTurnPrompt("what time is it", "The user is in Hanoi.")
+	for _, want := range []string{"You are terse.", "The user is in Hanoi.", "what time is it"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("first-turn prompt is missing %q:\n%s", want, got)
+		}
+	}
+	// And a resumed session must not get them again.
+	if again := c.firstTurnPrompt("next", ""); strings.Contains(again, "Hanoi") {
+		t.Error("memory leaked into a prompt that was not given any")
+	}
+}
+
+func TestErrorTextPrefersTheMessage(t *testing.T) {
+	if got := errorText(json.RawMessage(`{"name":"ProviderError","message":"rate limited"}`), ""); got != "rate limited" {
+		t.Errorf("got %q", got)
+	}
+	if got := errorText(nil, "auth failed"); got != "auth failed" {
+		t.Errorf("fallback to stderr: got %q", got)
+	}
+	if got := errorText(nil, ""); got == "" {
+		t.Error("an error with nothing in it still has to say something")
+	}
+}
+
+func TestSessionNotFoundIsRecognised(t *testing.T) {
+	for _, line := range []string{"Error: session not found", "no such session: ses_9"} {
+		if !sessionNotFound(line) {
+			t.Errorf("not recognised: %q", line)
+		}
+	}
+	if sessionNotFound("model provider returned 500") {
+		t.Error("an unrelated failure was read as a missing session")
+	}
+}
+
+// The client has to keep satisfying the interface the whole gateway is built
+// on; a signature drift would otherwise only show up at the registry.
+func TestClientSatisfiesChatClient(t *testing.T) {
+	var _ chat.Client = New("")
+	var _ tools.ToolResult = toolResult(&toolState{})
+}

--- a/internal/opencode/events.go
+++ b/internal/opencode/events.go
@@ -1,0 +1,48 @@
+package opencode
+
+import "encoding/json"
+
+// The shape of `opencode run --format json`.
+//
+// Read off the CLI itself (packages/opencode/src/cli/cmd/run.ts), not guessed:
+// every line is one JSON object of {type, timestamp, sessionID, ...data}, and
+// the data for the interesting types is a single `part`.
+//
+// Two things about it decide how the client below is written. Every event
+// carries sessionID, so resuming needs no separate lookup — the first line of
+// the first turn is enough. And a text part is only emitted once it is
+// finished (the CLI gates on part.time.end), so "streaming" here means whole
+// paragraphs, not tokens: the sink sees fewer, larger writes than it does from
+// claude, which is a difference in feel, not in correctness.
+type event struct {
+	Type      string          `json:"type"`
+	SessionID string          `json:"sessionID"`
+	Part      *part           `json:"part,omitempty"`
+	Error     json.RawMessage `json:"error,omitempty"`
+}
+
+type part struct {
+	Type  string     `json:"type"`  // text | tool | step-start | step-finish | reasoning
+	Text  string     `json:"text,omitempty"`
+	Tool  string     `json:"tool,omitempty"`
+	State *toolState `json:"state,omitempty"`
+}
+
+type toolState struct {
+	Status string          `json:"status"` // completed | error | running | pending
+	Title  string          `json:"title,omitempty"`
+	Input  json.RawMessage `json:"input,omitempty"`
+	Output string          `json:"output,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+// inputJSON renders a tool's arguments for the callback, which takes a string.
+// An absent input is "{}" rather than "": the bot layer logs this verbatim and
+// an empty string there reads like a parse failure rather than a call with no
+// arguments.
+func (s *toolState) inputJSON() string {
+	if s == nil || len(s.Input) == 0 {
+		return "{}"
+	}
+	return string(s.Input)
+}


### PR DESCRIPTION
Closes #137

## Đây là bài kiểm tra thật của #125

opencode vào cùng hàng với claude và codex. Điều đáng nói không phải là nó chạy, mà là **không đụng một file nào trong `internal/bot`** — và có test ghim điều đó (`TestAThirdBackendNeedsNoChangeHere`), vì "một backend là một file, không phải một nhánh if" là lời tuyên bố sẽ mục ngay khi không còn gì kiểm tra nó.

## Format sự kiện: đọc mã nguồn, không đoán

Doc chỉ nói "raw JSON events" rồi dừng. Nên tôi đọc thẳng `packages/opencode/src/cli/cmd/run.ts` trong bản anh đã có ở `~/Documents/projects/opencode`. Nó emit mỗi dòng một object `{type, timestamp, sessionID, ...}`, và hai chi tiết đó quyết định cách viết client:

- **Mọi event đều mang `sessionID`** → resume không cần tra cứu riêng, và id được lấy từ event **đầu tiên đến**, không phải từ một event "started" mà code này có thể không xử lý.
- **Text part chỉ emit khi đã xong** (`part.time.end`) → sink nhận **cả đoạn** thay vì từng token như claude. Khác về cảm giác, không khác về tính đúng.

**Tool chỉ được báo một lần, đã hoàn tất**, không có event "started" để ghép cặp. Nên call và result được báo **cùng lúc**, thay vì nói với sink về một lời gọi mà theo nó thì không bao giờ quay lại.

## Không có builtin model — cố ý

`--model` nhận cặp `provider/model` phân giải theo những gì **người dùng đã auth bên trong opencode**. Bịa một id ở đây thì đúng cho một máy và 400 cho máy kế tiếp. Catalog ghi rõ cách tự thêm:

```yaml
models:
  default: "anthropic/claude-opus-5"
  custom:
    - id: "anthropic/claude-opus-5"
      api: "opencode-cli"
```

## Không dùng `serve`

Subprocess là hình dạng hai backend kia đã có, nên nó **thừa hưởng cơ chế giết-theo-nhóm** (#113) giữ cho CLI không sống lâu hơn gateway. Một server chạy nền là thêm một vòng đời phải trông, và chưa có gì cần tới.

## Một chỗ còn hở, nói rõ chứ không giấu

Titler (`agent.ModelProvider`, đường một-lần cho đặt tên session) **vẫn là if/else riêng** và rơi về claude cho mọi provider lạ — tức một máy chỉ cài opencode sẽ đặt tên session bằng một CLI nó không có. Đó là một seam khác với `chat.Client`, nên tôi để ngoài PR này và mở issue riêng thay vì nhét vào đây.

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)