### PR TITLE
fix(opencode): record what a turn actually carried

### DIFF
--- a/internal/opencode/client.go
+++ b/internal/opencode/client.go
@@ -225,6 +225,16 @@ func (c *Client) SendMessage(ctx context.Context, sess *session.Session, modelID
 				cb.OnToolResult(name, toolResult(ev.Part.State))
 			}
 
+		case "step_finish":
+			// Not bookkeeping: the threshold memory flush reads what the turn
+			// actually carried, so a backend that stays silent here never
+			// flushes. Cached input counts — it is context the model saw.
+			if ev.Part != nil && ev.Part.Tokens != nil {
+				u := ev.Part.Tokens
+				sess.AddTokens(u.Input, u.Output)
+				sess.SetLastContextTokens(u.Input + u.Cache.Read)
+			}
+
 		case "error":
 			return abort(fmt.Errorf("opencode error: %s", errorText(ev.Error, lastErrLine)))
 		}

--- a/internal/opencode/client_test.go
+++ b/internal/opencode/client_test.go
@@ -144,3 +144,41 @@ func TestClientSatisfiesChatClient(t *testing.T) {
 	var _ chat.Client = New("")
 	var _ tools.ToolResult = toolResult(&toolState{})
 }
+
+// Captured verbatim from `opencode run --format json --model
+// opencode/muse-spark-1.3-contributor-free` on 2026-09-13. Tests written
+// against invented JSON prove only that the invention parses.
+const realStepFinish = `{"type":"step_finish","timestamp":1789268656890,"sessionID":"ses_f67470e8bffebibXTlEg4Cbl0g",` +
+	`"part":{"id":"prt_098b902f000175NXg2AXKm824D","reason":"stop","type":"step-finish",` +
+	`"tokens":{"total":12726,"input":12491,"output":15,"reasoning":107,"cache":{"write":0,"read":113}},"cost":0}}`
+
+const realTextFromTheCLI = `{"type":"text","timestamp":1789268656815,"sessionID":"ses_f67470e8bffebibXTlEg4Cbl0g",` +
+	`"part":{"id":"prt_098b9027a001VV81yVfE1HiT0j","type":"text","text":"Tôi chạy được rồi.",` +
+	`"time":{"start":1789268656762,"end":1789268656813}}}`
+
+func TestParseCapturedStepFinish(t *testing.T) {
+	var ev event
+	if err := json.Unmarshal([]byte(realStepFinish), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Part == nil || ev.Part.Tokens == nil {
+		t.Fatal("token usage was dropped — the memory flush reads this")
+	}
+	u := ev.Part.Tokens
+	if u.Input != 12491 || u.Output != 15 || u.Cache.Read != 113 {
+		t.Fatalf("usage parsed wrong: %+v", u)
+	}
+}
+
+func TestParseCapturedText(t *testing.T) {
+	var ev event
+	if err := json.Unmarshal([]byte(realTextFromTheCLI), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Part.Text != "Tôi chạy được rồi." {
+		t.Fatalf("text: %q", ev.Part.Text)
+	}
+	if ev.SessionID != "ses_f67470e8bffebibXTlEg4Cbl0g" {
+		t.Fatalf("session id: %q", ev.SessionID)
+	}
+}

--- a/internal/opencode/events.go
+++ b/internal/opencode/events.go
@@ -22,10 +22,25 @@ type event struct {
 }
 
 type part struct {
-	Type  string     `json:"type"`  // text | tool | step-start | step-finish | reasoning
-	Text  string     `json:"text,omitempty"`
-	Tool  string     `json:"tool,omitempty"`
-	State *toolState `json:"state,omitempty"`
+	Type   string     `json:"type"` // text | tool | step-start | step-finish | reasoning
+	Text   string     `json:"text,omitempty"`
+	Tool   string     `json:"tool,omitempty"`
+	State  *toolState `json:"state,omitempty"`
+	Tokens *usage     `json:"tokens,omitempty"` // step-finish only
+}
+
+// usage rides on the step-finish part. It matters beyond bookkeeping: the
+// memory flush fires on how much context a turn actually carried
+// (session.LastContextTokens), so a backend that reports nothing here never
+// flushes and its agent's memory grows until the CLI truncates it.
+type usage struct {
+	Input     int `json:"input"`
+	Output    int `json:"output"`
+	Reasoning int `json:"reasoning"`
+	Cache     struct {
+		Read  int `json:"read"`
+		Write int `json:"write"`
+	} `json:"cache"`
 }
 
 type toolState struct {


### PR DESCRIPTION
Chạy thật lộ ra thứ mà đọc mã nguồn không thấy.

## Vấn đề

`step_finish` mang theo token count, và client **vứt đi**:

```json
{"type":"step_finish", ..., "part":{"tokens":{"total":12726,"input":12491,"output":15,
 "reasoning":107,"cache":{"write":0,"read":113}},"cost":0}}
```

Đây không phải chuyện sổ sách. **Memory flush theo ngưỡng** đọc `session.LastContextTokens` (`bot/handler.go:573`), nên một backend im lặng ở đây thì **không bao giờ flush** — và bộ nhớ của agent đó phình cho tới khi CLI tự cắt. Lặng lẽ, và chỉ trên đúng agent chạy backend này.

Cached input được tính vào con số context: đó **là** context model đã thấy, mà đó chính là câu hỏi ngưỡng đang hỏi.

## Test dùng output thật

Hai test mới dán **nguyên văn** output của một lượt chạy thật với `opencode/muse-spark-1.3-contributor-free`, không phải JSON viết sao cho khớp parser. Test dựng từ event bịa ra chỉ chứng minh được rằng cái bịa đó parse được.

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)