### PR TITLE
fix(channel): a thread's turn had nowhere to write its history

### DIFF
--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -173,6 +173,12 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 
 	sess := session.New(channelChatID)
 	sess.ID = "ch_" + key
+	// The manager owns the database row, and messages has a foreign key to it.
+	// Without this the turn ran, the reply arrived, and both the question and
+	// the answer were dropped on the floor with a log line nobody was reading.
+	if w.deps.Sessions != nil {
+		sess = w.deps.Sessions.Adopt(sess)
+	}
 	// Resuming is what makes turn 2 remember turn 1. A ref from the other CLI
 	// — after a provider switch — is simply not used; only the CLI that owns
 	// a session can resume it.

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -232,3 +232,74 @@ func TestPlainLineWakesNobody(t *testing.T) {
 		t.Fatal("a line with no @ woke an agent")
 	}
 }
+
+// TestTheChannelSessionIsRegistered: sessions built with session.New have no
+// database row, and the messages table has a foreign key to it — so every
+// channel turn logged "FOREIGN KEY constraint failed" and dropped both the
+// question and the answer. The turn still worked, which is exactly why it went
+// unnoticed: the only symptom was a conversation with nothing behind it.
+func TestTheChannelSessionIsRegistered(t *testing.T) {
+	turn := &recordingTurn{reply: "ừ", newID: "sess-1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 chào",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if turn.calls != 1 {
+		t.Fatalf("expected one turn, got %d", turn.calls)
+	}
+	var found *session.Session
+	for _, s := range deps.Sessions.List() {
+		if s.ID == turn.sessions[0] {
+			found = s
+		}
+	}
+	if found == nil {
+		t.Fatalf("the session the turn ran on (%s) was never registered", turn.sessions[0])
+	}
+	if found.ChatID != channelChatID {
+		t.Errorf("channel session should sit on chat %d, got %d", channelChatID, found.ChatID)
+	}
+}
+
+// TestAdoptingTwiceKeepsOneSession: the second turn in a thread must not
+// register a second session under the same id, or the two halves of one
+// conversation end up in different rows.
+func TestAdoptingTwiceKeepsOneSession(t *testing.T) {
+	turn := &recordingTurn{reply: "ừ", newID: "sess-1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+	w := NewMentionWatcher(deps)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 lần một",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.sweep(context.Background())
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID, Body: "@bomclaw2 lần hai",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	w.sweep(context.Background())
+
+	n := 0
+	for _, s := range deps.Sessions.List() {
+		if s.ChatID == channelChatID {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("one thread produced %d sessions", n)
+	}
+}

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -303,7 +303,17 @@ func handleSessionsList(deps Deps) (json.RawMessage, error) {
 	// Reload sessions from disk to pick up sessions created by other processes (Telegram bot)
 	deps.Sessions.ReloadFromDisk()
 
-	all := deps.Sessions.List()
+	// Chat sessions only. Task runs (chat id -1) and channel threads (-2) are
+	// conversations the agent holds with the queue and with a room, not with
+	// the person reading this list — they are shown on the task board and in
+	// the channel, and putting them here buries the real ones. The negative
+	// chat id is what marks them; see taskrunner and gateway/mentions.
+	all := make([]*session.Session, 0)
+	for _, s := range deps.Sessions.List() {
+		if s.ChatID >= 0 {
+			all = append(all, s)
+		}
+	}
 
 	// Also scan transcript directory for sessions not in the store
 	transcriptDir := filepath.Join(deps.DataDir, "transcripts")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -188,6 +188,43 @@ func (m *Manager) NewSession(chatID int64) (*Session, error) {
 	return s, err
 }
 
+// Adopt registers a session the caller built itself and persists it now.
+//
+// Sessions created with New() outside the manager have no row in the database,
+// and the messages table has a foreign key to it — so every turn run on such a
+// session logged "FOREIGN KEY constraint failed" and dropped both the user
+// message and the reply. The turn still worked, because the reply reaches the
+// caller through the sink, which is why it stayed invisible: the only symptom
+// was a conversation with no history behind it.
+//
+// Idempotent: adopting the same session twice keeps the one already registered,
+// so a caller does not have to remember whether this is the first turn.
+func (m *Manager) Adopt(s *Session) *Session {
+	if s == nil {
+		return nil
+	}
+	m.mu.Lock()
+	cs, ok := m.chats[s.ChatID]
+	if !ok {
+		cs = &ChatState{NextSeq: 1, Sessions: map[string]*Session{}}
+		m.chats[s.ChatID] = cs
+	}
+	if existing, ok := cs.Sessions[s.ID]; ok {
+		m.mu.Unlock()
+		return existing
+	}
+	cs.Sessions[s.ID] = s
+	if cs.ActiveSessionID == "" {
+		cs.ActiveSessionID = s.ID
+	}
+	m.mu.Unlock()
+
+	// Now, not on the debounce: the row has to exist before the turn writes
+	// its first message, which is the next thing the caller does.
+	m.SaveNow()
+	return s
+}
+
 // newSession does NewSession's locked work.
 func (m *Manager) newSession(chatID int64) (*Session, error) {
 	m.mu.Lock()


### PR DESCRIPTION
Tìm ra khi ngồi xem lượt opencode đầu tiên của agent 3 chạy.

## Triệu chứng

```
handler: message store user error: constraint failed: FOREIGN KEY constraint failed (787)
handler: message store assistant error: constraint failed: FOREIGN KEY constraint failed (787)
```

Chỉ xuất hiện ở **lượt trả lời mention**, và đã có từ lúc #112 bắt đầu chạy.

## Nguyên nhân — của tôi

Watcher dựng session bằng `session.New`, thứ tạo ra một **object** chứ không phải một **hàng**, mà bảng `messages` có foreign key trỏ tới `sessions`. Nên **cả câu hỏi lẫn câu trả lời** của mọi lượt trong kênh đều bị từ chối và rơi mất.

Không có gì trông như hỏng: câu trả lời về tới phòng qua **sink**, không qua message store. Triệu chứng duy nhất là một cuộc nói chuyện **không có lịch sử phía sau** — transcript rỗng, và `buildHistoryContext` không có gì để mang sang session sau. Đúng kiểu lỗi chỉ lộ ra khi ngồi nhìn log một lượt chạy thật.

## Sửa

`Manager.Adopt` nhận một session dựng ở nơi khác và **persist ngay**, không đợi debounce — hàng phải tồn tại **trước** khi lượt ghi tin nhắn đầu tiên, mà đó là việc kế tiếp caller làm. Idempotent, nên lượt thứ hai trong cùng thread không đẻ ra session thứ hai.

## Hệ quả phải xử lý kèm

Adopt nghĩa là những session này lọt vào `sessions.list`. Nên list giờ lọc `chat_id >= 0`: task run (-1) và thread kênh (-2) là hội thoại với hàng đợi và với một căn phòng — chúng thuộc về TaskBoard và tab Messages, xếp cạnh chat của người thì chôn mất cái thật.

Ghi chú thiết kế P0 đã đề nghị đúng bộ lọc này (`sessions-and-workspaces` Q3); tới giờ mới cần tới.

## Test

- `TestTheChannelSessionIsRegistered` — session mà lượt chạy trên đó phải có mặt trong manager
- `TestAdoptingTwiceKeepsOneSession` — một thread, một session

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)