### PR TITLE
feat(admin): a Settings tab that changes an agent's backend

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -496,6 +496,8 @@ func runGateway(args []string) {
 		PokeSchedules: sched.Poke,
 		NotesFile:     cfg.Coord.NotesFile,
 		Conversations: conversations,
+		ConfigPath:    absPath(*configPath),
+		Restart:       restartSelf(cfg.Agent.ID),
 	}
 	if tgBot != nil {
 		// Dashboard messages run through the bot's turn engine, so both
@@ -1486,4 +1488,31 @@ func findToolSchema(name string) map[string]any {
 		return s
 	}
 	return map[string]any{"type": "object", "properties": map[string]any{}}
+}
+
+// absPath makes the config path usable from a settings handler that may run
+// long after the process changed directory.
+func absPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	return abs
+}
+
+// restartSelf returns the function the settings screen uses to apply a backend
+// change, or nil when this gateway is not under a service manager — in which
+// case the screen says the config was written and a restart is the operator's
+// to do, rather than pretending the change took effect.
+func restartSelf(agentID string) func() error {
+	svc, err := daemon.Resolve(agentID)
+	if err != nil {
+		log.Printf("settings: no service manager for %s (%v) — backend changes will need a manual restart", agentID, err)
+		return nil
+	}
+	return func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		return svc.Restart(ctx)
+	}
 }

--- a/dashboard/src/admin/AdminView.tsx
+++ b/dashboard/src/admin/AdminView.tsx
@@ -5,6 +5,7 @@ import TraceExplorer from './TraceExplorer'
 import TaskBoard from './TaskBoard'
 import ChannelView from './ChannelView'
 import NotesPane from './NotesPane'
+import SettingsPane from './SettingsPane'
 import SchedulesPane from './SchedulesPane'
 import { ADMIN_PANES, type AdminPane as Pane } from '../lib/route'
 
@@ -19,6 +20,7 @@ const LABELS: Record<Pane, string> = {
   schedules: 'Schedules',
   notes: 'Notes',
   messages: 'Messages',
+  settings: 'Settings',
 }
 
 const PANES = ADMIN_PANES.map(key => ({ key, label: LABELS[key] }))
@@ -107,6 +109,7 @@ export default function AdminView({ call, pane, onPane }: { call: Call; pane: Pa
         )}
         {pane === 'schedules' && <SchedulesPane call={call} agents={agentIDs} />}
         {pane === 'notes' && <NotesPane call={call} />}
+        {pane === 'settings' && <SettingsPane call={call} />}
         {pane === 'messages' && (
           <ChannelView
             call={call} agents={agentIDs} selfID={selfID}

--- a/dashboard/src/admin/SettingsPane.tsx
+++ b/dashboard/src/admin/SettingsPane.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react'
+
+type Call = (method: string, params?: any) => Promise<any>
+
+interface ModelChoice {
+  id: string
+  name: string
+  api: string
+  provider: string
+  current: boolean
+}
+
+interface AgentSettings {
+  agent_id: string
+  agent_name: string
+  provider: string
+  model: string
+  config_path: string
+  choices: ModelChoice[]
+  can_restart: boolean
+  busy: boolean
+}
+
+// Which backend this agent runs on, and changing it.
+//
+// The choice is a MODEL, not a provider: the model's API is what selects the
+// backend, so picking the model and letting the provider follow means the two
+// cannot be set to disagree — which is exactly the mistake this screen would
+// otherwise make easy.
+//
+// Only this agent's own settings. A gateway can read the shared database but
+// not another agent's config file, and a screen that pretended otherwise would
+// be editing a file nobody reloads.
+export default function SettingsPane({ call }: { call: Call }) {
+  const [data, setData] = useState<AgentSettings | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [picked, setPicked] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [note, setNote] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const d: AgentSettings = await call('admin.settings')
+      setData(d)
+      setPicked(p => p || d.model)
+      setErr(null)
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    }
+  }, [call])
+
+  useEffect(() => { load() }, [load])
+
+  const apply = async (force: boolean) => {
+    if (!data || !picked || picked === data.model) return
+    setBusy(true)
+    setNote(null)
+    try {
+      const r = await call('admin.set_model', { model: picked, ...(force ? { force: true } : {}) })
+      setErr(null)
+      setNote(r?.restarted
+        ? `Đã ghi config và khởi động lại ${data.agent_id}. Đợi vài giây rồi tải lại trang.`
+        : (r?.note ?? 'Đã ghi config.'))
+      // The gateway is restarting under us; give it a moment, then re-read.
+      setTimeout(load, 6000)
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (err && !data) return <div className="p-4 text-sm text-red-300">{err}</div>
+  if (!data) return <div className="p-4 text-sm text-gray-500">Loading…</div>
+
+  const changed = picked !== data.model
+  const target = data.choices.find(c => c.id === picked)
+
+  return (
+    <div className="p-4 max-w-2xl space-y-4">
+      <div>
+        <h2 className="text-sm text-gray-200 font-medium">{data.agent_name || data.agent_id}</h2>
+        <p className="text-xs text-gray-500 font-mono">{data.config_path}</p>
+      </div>
+
+      {err && <div className="text-xs text-red-300">{err}</div>}
+      {note && <div className="text-xs text-emerald-300">{note}</div>}
+
+      <dl className="grid grid-cols-2 gap-2 text-xs">
+        <div><dt className="text-gray-600">backend</dt><dd className="font-mono text-gray-200">{data.provider}</dd></div>
+        <div><dt className="text-gray-600">model</dt><dd className="font-mono text-gray-200">{data.model}</dd></div>
+      </dl>
+
+      <div className="space-y-2">
+        <label className="block text-xs text-gray-500">
+          Đổi model — backend đi theo model, không chọn riêng
+        </label>
+        <select
+          value={picked}
+          onChange={e => setPicked(e.target.value)}
+          className="w-full px-2 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 text-gray-200 outline-none"
+        >
+          {data.choices.map(c => (
+            <option key={c.id} value={c.id}>
+              {c.name} — {c.provider} ({c.id})
+            </option>
+          ))}
+        </select>
+        {changed && target && (
+          <p className="text-xs text-amber-300">
+            {data.provider === target.provider
+              ? `Cùng backend ${target.provider}, chỉ đổi model.`
+              : `Đổi backend ${data.provider} → ${target.provider}.`}
+            {' '}Agent sẽ khởi động lại{data.busy ? ' — và đang có việc chạy dở, nó sẽ bị cắt.' : '.'}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => apply(false)}
+          disabled={!changed || busy || !data.can_restart}
+          className="px-3 py-2 text-sm rounded bg-gray-100 text-gray-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {busy ? 'Đang đổi…' : 'Đổi & khởi động lại'}
+        </button>
+        {data.busy && changed && (
+          <button
+            onClick={() => apply(true)}
+            disabled={busy}
+            className="px-3 py-2 text-sm rounded ring-1 ring-amber-500/50 text-amber-300 hover:bg-amber-500/10"
+          >
+            Cắt việc đang chạy và đổi
+          </button>
+        )}
+        {!data.can_restart && (
+          <span className="text-xs text-gray-500">
+            Gateway này không chạy dưới service manager — đổi xong phải tự restart.
+          </span>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-600">
+        Chỉ agent này. Mỗi gateway đọc file config của chính nó, nên đổi backend cho agent khác
+        thì mở dashboard của agent đó.
+      </p>
+    </div>
+  )
+}

--- a/dashboard/src/lib/route.ts
+++ b/dashboard/src/lib/route.ts
@@ -10,9 +10,9 @@
 // easier to test than to debug through a browser.
 
 export type Tab = 'sessions' | 'chat' | 'status' | 'admin'
-export type AdminPane = 'overview' | 'traces' | 'tasks' | 'schedules' | 'notes' | 'messages'
+export type AdminPane = 'overview' | 'traces' | 'tasks' | 'schedules' | 'notes' | 'messages' | 'settings'
 
-export const ADMIN_PANES: AdminPane[] = ['overview', 'traces', 'tasks', 'schedules', 'notes', 'messages']
+export const ADMIN_PANES: AdminPane[] = ['overview', 'traces', 'tasks', 'schedules', 'notes', 'messages', 'settings']
 
 export interface Route {
   tab: Tab

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/ngocp/goterm-control/internal/chat"
+	"github.com/ngocp/goterm-control/internal/models"
+)
+
+// Changing an agent's backend from the dashboard.
+//
+// The write is line-surgery rather than a YAML round-trip, and that is the
+// whole design. These files are hand-maintained and have diverged from the
+// template — agent names, auto_claim, edited system prompts, comments that
+// explain why — and a marshal-and-rewrite would silently reformat all of it to
+// change two scalars. Editing the two lines leaves every other byte identical,
+// which is checkable: the caller can diff.
+//
+// What is chosen is the MODEL, not the provider. The model's API is what
+// selects the backend (chat.Resolve), so picking a model and deriving the
+// provider makes the two agree by construction instead of asking a person to
+// keep them in step.
+var (
+	providerLine = regexp.MustCompile(`(?m)^provider:[ \t]*.*$`)
+	defaultLine  = regexp.MustCompile(`(?m)^([ \t]+)default:[ \t]*.*$`)
+)
+
+// SetModel points a config file at modelID and at whichever provider that
+// model's API implies, then proves the result loads and validates before it
+// replaces the original.
+//
+// Writing a config the binary will refuse at startup is how you lose an agent
+// until somebody reads a log, so the check happens here rather than at the
+// next restart.
+func SetModel(path, modelID string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	current, err := Load(path)
+	if err != nil {
+		return fmt.Errorf("load %s: %w", path, err)
+	}
+
+	m := current.Resolver().Lookup(modelID)
+	if m == nil {
+		return fmt.Errorf("unknown model %q — add it under models.custom first", modelID)
+	}
+	provider := providerFor(m.API)
+	if provider == "" {
+		return fmt.Errorf("model %q speaks %q, which has no provider key", modelID, m.API)
+	}
+
+	out := string(raw)
+	if n := len(providerLine.FindAllString(out, -1)); n != 1 {
+		return fmt.Errorf("expected exactly one top-level provider: line in %s, found %d", path, n)
+	}
+	out = providerLine.ReplaceAllString(out, fmt.Sprintf("provider: %q", provider))
+
+	// models.default is the only indented `default:` in these files; anything
+	// else is a shape this cannot safely edit and must not guess at.
+	if n := len(defaultLine.FindAllString(out, -1)); n != 1 {
+		return fmt.Errorf("expected exactly one models.default line in %s, found %d", path, n)
+	}
+	out = defaultLine.ReplaceAllString(out, fmt.Sprintf("${1}default: %q", modelID))
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config-*.yaml")
+	if err != nil {
+		return fmt.Errorf("temp file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(out); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+
+	// The candidate has to survive exactly what startup does to it.
+	candidate, err := Load(tmp.Name())
+	if err != nil {
+		return fmt.Errorf("the edited config does not load: %w", err)
+	}
+	if err := candidate.Validate(); err != nil {
+		return fmt.Errorf("the edited config would be refused at startup: %w", err)
+	}
+	if candidate.Provider != provider || candidate.Models.Default != modelID {
+		return fmt.Errorf("the edit did not take: provider=%q model=%q", candidate.Provider, candidate.Models.Default)
+	}
+
+	// Keep the original's mode; CreateTemp makes 0600 and these files are read
+	// by the agent's own shell too.
+	if info, err := os.Stat(path); err == nil {
+		_ = os.Chmod(tmp.Name(), info.Mode())
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}
+
+// Resolver builds this config's model resolver — builtins plus whatever the
+// agent added under models.custom.
+func (c *Config) Resolver() *models.Resolver {
+	want := c.Models.Default
+	if want == "" {
+		want = c.Claude.Model
+	}
+	return models.NewResolver(want, c.Models.Custom)
+}
+
+// KnownModels lists what this agent can be switched to: every model it can
+// resolve whose API has a backend registered.
+func (c *Config) KnownModels() []ModelChoice {
+	var out []ModelChoice
+	for _, m := range c.Resolver().List() {
+		if !chat.Supports(m.API) {
+			continue
+		}
+		out = append(out, ModelChoice{
+			ID:       m.ID,
+			Name:     m.Name,
+			API:      string(m.API),
+			Provider: providerFor(m.API),
+			Current:  m.ID == c.Models.Default,
+		})
+	}
+	return out
+}
+
+// ModelChoice is one option on the settings screen.
+type ModelChoice struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	API      string `json:"api"`
+	Provider string `json:"provider"`
+	Current  bool   `json:"current"`
+}

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A config shaped like the real ones: hand-edited, commented, with keys this
+// edit must not touch.
+const sampleConfig = `# BomClaw agent 3
+agent:
+  id: "bomclaw3"
+  name: "BomClaw (agent 3)"   # shown in the tray
+
+provider: "claude"
+
+telegram:
+  token: ""
+
+claude:
+  api_key: ""
+  model: "claude-opus-5"
+  workspace: "~/goterm-workspace-3"
+  system_prompt: |
+    Be terse.
+    Never say "certainly".
+
+models:
+  default: "claude-opus-5"
+
+tasks:
+  auto_claim: true   # agent 3 runs unattended
+`
+
+func write(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSetModelChangesTwoLinesAndNothingElse(t *testing.T) {
+	path := write(t, sampleConfig)
+	t.Setenv("TELEGRAM_TOKEN", "x")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-x")
+
+	if err := SetModel(path, "gpt-6-astra"); err != nil {
+		t.Fatalf("SetModel: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := strings.Split(sampleConfig, "\n")
+	after := strings.Split(string(got), "\n")
+	if len(before) != len(after) {
+		t.Fatalf("line count changed: %d → %d", len(before), len(after))
+	}
+	var changed []int
+	for i := range before {
+		if before[i] != after[i] {
+			changed = append(changed, i)
+		}
+	}
+	if len(changed) != 2 {
+		t.Fatalf("expected exactly 2 changed lines, got %d: %v", len(changed), changed)
+	}
+	// Everything hand-maintained survived byte for byte.
+	for _, keep := range []string{
+		`  name: "BomClaw (agent 3)"   # shown in the tray`,
+		`    Never say "certainly".`,
+		`  auto_claim: true   # agent 3 runs unattended`,
+		`# BomClaw agent 3`,
+	} {
+		if !strings.Contains(string(got), keep) {
+			t.Errorf("the edit destroyed: %s", keep)
+		}
+	}
+	if !strings.Contains(string(got), `provider: "codex"`) {
+		t.Error("provider was not switched")
+	}
+	if !strings.Contains(string(got), `default: "gpt-6-astra"`) {
+		t.Error("model was not switched")
+	}
+}
+
+// The provider is derived, never asked for: the model's API is what actually
+// selects the backend, so the two cannot be set to disagree.
+func TestProviderFollowsTheModel(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "x")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-x")
+	path := write(t, strings.Replace(sampleConfig, `provider: "claude"`, `provider: "codex"`, 1))
+
+	if err := SetModel(path, "claude-opus-5"); err != nil {
+		t.Fatalf("SetModel: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != ProviderClaude {
+		t.Fatalf("provider did not follow the model: %q", cfg.Provider)
+	}
+}
+
+// Writing a config the binary refuses at startup is how an agent disappears
+// until somebody reads a log. The check happens before the file is replaced.
+func TestAConfigThatWouldNotStartIsNotWritten(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "x")
+	path := write(t, sampleConfig)
+	original, _ := os.ReadFile(path)
+
+	err := SetModel(path, "no-such-model")
+	if err == nil {
+		t.Fatal("an unknown model was accepted")
+	}
+	if !strings.Contains(err.Error(), "unknown model") {
+		t.Errorf("error should name the problem: %v", err)
+	}
+	now, _ := os.ReadFile(path)
+	if string(now) != string(original) {
+		t.Fatal("the file was modified despite the failure")
+	}
+}
+
+// A shape this cannot edit safely must be refused, not guessed at.
+func TestRefusesAFileItCannotEditSafely(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "x")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-x")
+	two := sampleConfig + "\nprovider: \"codex\"\n"
+	path := write(t, two)
+	if err := SetModel(path, "gpt-6-astra"); err == nil {
+		t.Fatal("two provider lines were edited anyway")
+	}
+}
+
+func TestKnownModelsOnlyListsBackendsThatExist(t *testing.T) {
+	cfg := &Config{Provider: ProviderClaude}
+	cfg.Claude.Model = "claude-opus-5"
+	cfg.Models.Default = "claude-opus-5"
+	choices := cfg.KnownModels()
+	if len(choices) == 0 {
+		t.Fatal("no models offered at all")
+	}
+	seen := map[string]bool{}
+	for _, c := range choices {
+		if c.Provider == "" {
+			t.Errorf("%s has no provider key", c.ID)
+		}
+		seen[c.Provider] = true
+	}
+	if !seen[ProviderClaude] || !seen[ProviderCodex] {
+		t.Errorf("expected both shipped backends to be offered, got %v", seen)
+	}
+}

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -47,6 +47,15 @@ type Deps struct {
 	ProviderName string          // "claude" | "codex", for trace metadata
 	Trace        *trace.Recorder // nil-safe: nil disables tracing on this path
 
+	// ConfigPath is this agent's own config file. The settings screen edits it;
+	// nothing else writes it.
+	ConfigPath string
+
+	// Restart restarts this agent's own service, for the settings screen. Nil
+	// when the gateway was not started by a service manager, in which case the
+	// screen says so rather than editing a file nothing will reload.
+	Restart func() error
+
 	// PokeTasks asks the local task runner to check the queue immediately.
 	// Nil when this agent does not claim tasks.
 	PokeTasks func()
@@ -153,6 +162,10 @@ func NewMethodHandler(deps Deps) MethodHandler {
 			return handleBrowserCall(ctx, deps, params)
 
 		// --- admin / observability ---
+		case "admin.settings":
+			return handleAdminSettings(deps)
+		case "admin.set_model":
+			return handleAdminSetModel(deps, params)
 		case "admin.overview":
 			return handleAdminOverview(deps)
 		case "traces.list":

--- a/internal/gateway/settings.go
+++ b/internal/gateway/settings.go
@@ -1,0 +1,100 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/ngocp/goterm-control/internal/config"
+)
+
+// The settings screen: which backend this agent runs on, and changing it.
+//
+// Two things make this narrower than it looks. What is chosen is a MODEL —
+// the model's API selects the backend, so picking the model and deriving the
+// provider means they cannot be set to disagree. And the change takes effect
+// by restarting this gateway, because the chat client is built once at
+// startup; the screen says that out loud rather than looking instant and
+// leaving the old backend running.
+
+// AgentSettings is what one agent reports about itself.
+type AgentSettings struct {
+	AgentID    string               `json:"agent_id"`
+	AgentName  string               `json:"agent_name"`
+	Provider   string               `json:"provider"`
+	Model      string               `json:"model"`
+	ConfigPath string               `json:"config_path"`
+	Choices    []config.ModelChoice `json:"choices"`
+	CanRestart bool                 `json:"can_restart"`
+	Busy       bool                 `json:"busy"` // a turn or task is running right now
+}
+
+func handleAdminSettings(deps Deps) (json.RawMessage, error) {
+	if deps.ConfigPath == "" {
+		return nil, fmt.Errorf("this gateway does not know its own config path")
+	}
+	cfg, err := config.Load(deps.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", deps.ConfigPath, err)
+	}
+	busy := false
+	if deps.Runs != nil {
+		busy = len(deps.Runs()) > 0
+	}
+	return json.Marshal(AgentSettings{
+		AgentID:    deps.AgentID,
+		AgentName:  deps.AgentName,
+		Provider:   cfg.Provider,
+		Model:      cfg.Models.Default,
+		ConfigPath: deps.ConfigPath,
+		Choices:    cfg.KnownModels(),
+		CanRestart: deps.Restart != nil,
+		Busy:       busy,
+	})
+}
+
+type setModelParams struct {
+	Model string `json:"model"`
+	// Force skips the busy check. The screen sets it only after the person has
+	// been told a turn is running and said to go ahead.
+	Force bool `json:"force,omitempty"`
+}
+
+func handleAdminSetModel(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	if deps.ConfigPath == "" {
+		return nil, fmt.Errorf("this gateway does not know its own config path")
+	}
+	var p setModelParams
+	if err := decodeParams(params, &p); err != nil {
+		return nil, err
+	}
+	if p.Model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	// Restarting kills whatever is mid-turn. That is a decision, not a
+	// side-effect, so it is refused until someone makes it.
+	if !p.Force && deps.Runs != nil {
+		if n := len(deps.Runs()); n > 0 {
+			return nil, fmt.Errorf("%d run(s) in flight — restarting now cancels them; retry with force to go ahead", n)
+		}
+	}
+	if err := config.SetModel(deps.ConfigPath, p.Model); err != nil {
+		return nil, err
+	}
+	log.Printf("settings: %s switched to model %s; restarting", deps.AgentID, p.Model)
+
+	if deps.Restart == nil {
+		return json.Marshal(map[string]any{
+			"written": true, "restarted": false,
+			"note": "config written, but this gateway has no service manager — restart it yourself for the change to take",
+		})
+	}
+	// Answer before the restart: the reply cannot survive the process it is
+	// being sent from.
+	go func() {
+		if err := deps.Restart(); err != nil {
+			log.Printf("settings: restart failed: %v", err)
+		}
+	}()
+	return json.Marshal(map[string]any{"written": true, "restarted": true})
+}


### PR DESCRIPTION
Closes #138

Ba agent giờ chạy ba CLI khác nhau, và cách duy nhất để chuyển một con là sửa tay YAML rồi nhớ restart đúng service.

## Chọn MODEL, không chọn provider

API của model **là** thứ chọn backend (`chat.Resolve`). Nên suy provider ra từ model khiến hai thứ **không thể** đặt lệch nhau — đúng cái sai mà một dropdown provider sẽ làm cho dễ xảy ra, và cũng chính là cái `config.Validate` sinh ra để bắt *sau khi* đã lỡ.

## Ghi file: sửa đúng dòng, không marshal lại

Đây là phần tôi cẩn thận nhất. Ba file config này **sửa tay** và đã phân kỳ khỏi template — tên agent, `auto_claim`, system prompt nhiều dòng, comment giải thích vì sao. Marshal rồi ghi lại sẽ **định dạng lại toàn bộ** chỉ để đổi hai scalar. `deploy.md` cảnh báo đúng chuyện này.

Nên: đổi **hai dòng**, mọi byte còn lại **y nguyên** — và có test khẳng định đúng điều đó, gồm cả việc comment và system prompt nhiều dòng sống sót.

**File đã sửa được `Load` + `Validate` trước khi thay thế bản gốc**, đúng như startup sẽ làm. Ghi một config mà binary từ chối là cách một agent biến mất cho tới khi ai đó đọc log.

File có **hình dạng không sửa an toàn được** (hai dòng `provider:`, hoặc không có `models.default`) thì **từ chối**, không đoán.

## Restart là một quyết định, không phải hiệu ứng phụ

Chat client dựng một lần lúc khởi động, nên đổi backend phải restart — và restart **cắt ngang việc đang chạy**. Nên nó bị từ chối khi còn run in-flight, kèm số lượng, tới khi người dùng bấm nút thứ hai nói rõ "cắt việc đang chạy và đổi". Màn hình nói ra điều đó thay vì trông như tức thì rồi để backend cũ chạy tiếp.

Gateway không nằm dưới service manager thì màn hình nói "đã ghi config, tự restart giúp" — không giả vờ là đã áp dụng.

## Phạm vi

Chỉ agent của chính gateway đó: một gateway đọc được DB chung nhưng **không** đọc config file của agent khác. Màn hình nói vậy thay vì giả vờ quản được cả ba.

## Test

- `TestSetModelChangesTwoLinesAndNothingElse` — đếm đúng 2 dòng đổi, và comment/system prompt còn nguyên
- `TestProviderFollowsTheModel`
- `TestAConfigThatWouldNotStartIsNotWritten` — file **không** bị sửa khi validate hỏng
- `TestRefusesAFileItCannotEditSafely`
- `TestKnownModelsOnlyListsBackendsThatExist`

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)