### PR TITLE
docs(deploy): the hash is a habit, not a fix

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -32,13 +32,17 @@ artifacts into `~/.bomclaw/` and restart.
    binary swaps. Ad-hoc (`-s -`) is the fallback, but every ad-hoc rebuild is
    a NEW TCC identity and macOS re-asks for folder permissions.
 
-   **Sign by the identity's SHA-1, not its name.** `-s "BomClaw Code Signing"`
-   hung on the keychain dialog three times out of three on 2026-09-13, each
-   time leaving the binary ad-hoc; `-s 5364738D592D096F5F186640C4A41A0AD43D35B6`
-   returned instantly, twice out of twice, with no dialog at all. The identity
-   is the same one — looking it up by name is what asks the keychain a question
-   that can block. Confirm the hash is still current with:
-   `security find-identity -v -p codesigning`
+   **The keychain dialog comes back, and nothing here prevents it.** On
+   2026-09-13 `-s "BomClaw Code Signing"` hung three times running; the same
+   identity by SHA-1 (`-s 5364738D592D096F5F186640C4A41A0AD43D35B6`) then
+   signed instantly four times, and hung on the fifth. So the hash is worth
+   trying first — it has been faster more often — but treat it as a habit, not
+   a fix. What actually clears it is clicking **Always Allow** on the dialog
+   macOS is showing, which only the person at the machine can do.
+   `security find-identity -v -p codesigning` confirms the hash is current.
+
+   Whatever you sign with, the rule below does not change: verify before
+   restarting. A hang leaves the binary ad-hoc and exits 124.
 
    **Verify the signature landed BEFORE restarting.** `codesign` can hang on a
    keychain "allow access" dialog; a `timeout` kills it, and the file is left


### PR DESCRIPTION
Ghi chú thêm sáng nay nói ký bằng SHA-1 tránh được hộp thoại keychain, dựa trên **hai** lần chạy. Sau đó nó chạy ngon thêm hai lần nữa rồi **treo ở lần thứ năm**.

Điều đó làm câu khẳng định kia sai theo đúng kiểu gây hại: người đọc sẽ kết luận là hộp thoại đã được giải quyết, rồi bị bất ngờ giữa lúc deploy.

Cái bằng chứng thực sự chống đỡ được chỉ là: **hash nhanh hơn, thường xuyên hơn**. Thứ duy nhất thật sự dọn sạch prompt là bấm **Always Allow**, và chỉ người ngồi trước máy làm được.

Luật phía dưới không đổi: **verify trước khi restart**. Treo thì để lại binary ad-hoc và exit 124.