### PR TITLE
feat(accounts): choose which login a conversation runs on

### DIFF
--- a/dashboard/src/components/SessionList.tsx
+++ b/dashboard/src/components/SessionList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useStore, Session } from '../stores/store'
 import { eventsToMessages } from '../lib/transcript'
 
@@ -11,7 +12,36 @@ function timeAgo(dateStr: string): string {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
+interface AccountInfo {
+  name: string
+  sessions: number
+  cooling_until?: string
+  current?: boolean
+}
+
 export default function SessionList({ call }: { call: (m: string, p?: any) => Promise<any> }) {
+  // Which logins this agent can run a conversation on. Empty on the usual
+  // install — one ambient login — and the picker stays out of the way then.
+  const [accounts, setAccounts] = useState<AccountInfo[]>([])
+  useEffect(() => {
+    call('accounts.list').then((a: AccountInfo[]) => setAccounts(a || [])).catch(() => {})
+  }, [call])
+
+  // An account belongs to a conversation, not to a setting on one: both CLIs
+  // keep their conversation store inside the credential directory, so this
+  // starts a new session rather than repointing a live one.
+  const startOn = async (account: string) => {
+    try {
+      const r = await call('accounts.use', { account, chat_id: 0 })
+      await call('sessions.list').then(useStore.getState().setSessions)
+      useStore.getState().setActiveSessionId(r.session_id)
+      useStore.getState().setMessages([])
+      useStore.getState().setTab('chat')
+    } catch (e: any) {
+      alert(String(e?.message ?? e))
+    }
+  }
+
   const rawSessions = useStore(s => s.sessions)
   // Newest first — the server already sorts, but keep the invariant client-side too.
   const sessions = [...rawSessions].sort(
@@ -71,6 +101,21 @@ export default function SessionList({ call }: { call: (m: string, p?: any) => Pr
     <div className="h-full overflow-y-auto p-4">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-medium text-gray-300">Sessions</h2>
+        {accounts.length > 1 && (
+          <select
+            value=""
+            onChange={e => { if (e.target.value) startOn(e.target.value) }}
+            title="Start a new conversation on another login"
+            className="ml-auto mr-2 px-2 py-1.5 text-sm bg-gray-950 rounded ring-1 ring-gray-800 text-gray-300 outline-none"
+          >
+            <option value="">new chat on…</option>
+            {accounts.map(a => (
+              <option key={a.name} value={a.name}>
+                {a.name}{a.cooling_until ? ' (cooling)' : ''}
+              </option>
+            ))}
+          </select>
+        )}
         <button
           onClick={() => {
             const id = 'chat_' + Date.now()
@@ -97,6 +142,7 @@ export default function SessionList({ call }: { call: (m: string, p?: any) => Pr
               </div>
               <div className="text-xs text-gray-500 mt-0.5 truncate">
                 {timeAgo(s.updated_at)} · {s.input_tokens + s.output_tokens} tokens
+                {s.account ? <span className="text-sky-400"> · {s.account}</span> : null}
                 {s.label ? <span className="font-mono"> · {s.id}</span> : null}
               </div>
             </div>

--- a/dashboard/src/stores/store.ts
+++ b/dashboard/src/stores/store.ts
@@ -11,6 +11,7 @@ export type Session = {
   updated_at: string
   label?: string
   seq?: number
+  account?: string
 }
 
 export type TranscriptEvent = {

--- a/internal/gateway/accounts.go
+++ b/internal/gateway/accounts.go
@@ -1,0 +1,102 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ngocp/goterm-control/internal/credentials"
+)
+
+// Choosing which login a conversation runs on.
+//
+// The pool already rotates sessions across logins and already takes a pinned
+// name (credentials.Pool.Pick), and a session already records the one it used
+// (session.SetAccount). What was missing was any way to say which — the choice
+// was the pool's alone.
+//
+// It is a per-SESSION choice and cannot be anything else: both CLIs keep their
+// conversation store inside the credential directory, so moving a live session
+// to another login does not switch accounts, it loses the conversation. So the
+// answer to "use Tâm's account" is a new session, and this says so rather than
+// appearing to switch and quietly starting over.
+
+// AccountInfo is one login, and what the pool knows about it.
+type AccountInfo struct {
+	credentials.Status
+	Current bool `json:"current"` // the account this chat's active session is on
+}
+
+type accountsListParams struct {
+	ChatID int64 `json:"chat_id,omitempty"`
+}
+
+func handleAccountsList(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	var p accountsListParams
+	if err := decodeParams(params, &p); err != nil {
+		return nil, err
+	}
+	if deps.Accounts == nil || deps.Accounts.Empty() {
+		// Not an error: most installs run on the ambient credentials, and an
+		// empty list is the honest description of that.
+		return json.Marshal([]AccountInfo{})
+	}
+	var current string
+	if deps.Sessions != nil {
+		if sess := deps.Sessions.Get(p.ChatID); sess != nil {
+			current = sess.GetAccount()
+		}
+	}
+	statuses := deps.Accounts.Status()
+	out := make([]AccountInfo, 0, len(statuses))
+	for _, s := range statuses {
+		out = append(out, AccountInfo{Status: s, Current: s.Name == current})
+	}
+	return json.Marshal(out)
+}
+
+type useAccountParams struct {
+	ChatID  int64  `json:"chat_id"`
+	Account string `json:"account"`
+}
+
+// handleAccountsUse starts a new session pinned to a login.
+//
+// Deliberately a new session rather than a change to the current one. The CLI
+// stores its conversation inside the credential directory, so repointing a
+// session that already has one would hand the next turn an id its new account
+// has never heard of — the conversation would restart anyway, only without
+// anyone having said so.
+func handleAccountsUse(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	var p useAccountParams
+	if err := decodeParams(params, &p); err != nil {
+		return nil, err
+	}
+	if p.Account == "" {
+		return nil, fmt.Errorf("account is required")
+	}
+	if deps.Accounts == nil || deps.Accounts.Empty() {
+		return nil, fmt.Errorf("no credential pool configured — add accounts.pool to this agent's config")
+	}
+	known := false
+	for _, name := range deps.Accounts.Names() {
+		if name == p.Account {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return nil, fmt.Errorf("unknown account %q; this agent has %v", p.Account, deps.Accounts.Names())
+	}
+
+	sess, err := deps.Sessions.NewSession(p.ChatID)
+	if err != nil {
+		return nil, fmt.Errorf("start a session on %s: %w", p.Account, err)
+	}
+	sess.SetAccount(p.Account)
+	deps.Sessions.MarkDirty()
+	return json.Marshal(map[string]any{
+		"session_id": sess.ID,
+		"account":    p.Account,
+		"note":       "new session — an account is part of a conversation, not a setting on one",
+	})
+}

--- a/internal/gateway/accounts_test.go
+++ b/internal/gateway/accounts_test.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/credentials"
+	"github.com/ngocp/goterm-control/internal/session"
+)
+
+func poolOf(t *testing.T, names ...string) *credentials.Pool {
+	t.Helper()
+	accts := make([]credentials.Account, 0, len(names))
+	for _, n := range names {
+		accts = append(accts, credentials.Account{Name: n, Provider: "claude", ConfigDir: "/tmp/" + n})
+	}
+	p, err := credentials.NewPool("claude", accts, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// Most installs run on one ambient login. An empty list is the honest
+// description of that, not an error the dashboard has to special-case.
+func TestNoPoolListsNothingRatherThanFailing(t *testing.T) {
+	raw, err := handleAccountsList(Deps{Sessions: session.NewManager(nil)}, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("an install with no pool should not error: %v", err)
+	}
+	var out []AccountInfo
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected an empty list, got %v", out)
+	}
+}
+
+func TestUsingAnAccountStartsANewSession(t *testing.T) {
+	deps := Deps{Sessions: session.NewManager(nil), Accounts: poolOf(t, "default", "tam")}
+
+	// A conversation already under way on the default login.
+	existing := deps.Sessions.Get(0)
+	existing.SetSessionID("claude-session-1")
+
+	raw, err := handleAccountsUse(deps, json.RawMessage(`{"chat_id":0,"account":"tam"}`))
+	if err != nil {
+		t.Fatalf("accounts.use: %v", err)
+	}
+	var out struct {
+		SessionID string `json:"session_id"`
+		Account   string `json:"account"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Account != "tam" {
+		t.Fatalf("account: %q", out.Account)
+	}
+	// A NEW session, not the old one repointed: the CLI keeps its conversation
+	// inside the credential directory, so repointing would hand the next turn
+	// an id the new account has never seen.
+	if out.SessionID == existing.ID {
+		t.Fatal("the live session was repointed instead of a new one being started")
+	}
+	fresh := deps.Sessions.GetByID(out.SessionID)
+	if fresh == nil {
+		t.Fatal("the new session was not registered")
+	}
+	if fresh.GetAccount() != "tam" {
+		t.Fatalf("the new session is not pinned: %q", fresh.GetAccount())
+	}
+	if fresh.GetSessionID() != "" {
+		t.Fatal("a fresh session must not carry the old provider session id")
+	}
+	// And the old conversation is untouched, not silently lost.
+	if existing.GetSessionID() != "claude-session-1" {
+		t.Fatal("the previous session was modified")
+	}
+}
+
+func TestUnknownAccountIsRefusedByName(t *testing.T) {
+	deps := Deps{Sessions: session.NewManager(nil), Accounts: poolOf(t, "default", "tam")}
+	_, err := handleAccountsUse(deps, json.RawMessage(`{"chat_id":0,"account":"nope"}`))
+	if err == nil {
+		t.Fatal("an unknown account was accepted")
+	}
+	// The message has to say what there is, or the caller cannot act on it.
+	for _, want := range []string{"nope", "default", "tam"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
+func TestUsingAnAccountWithNoPoolSaysWhy(t *testing.T) {
+	deps := Deps{Sessions: session.NewManager(nil)}
+	_, err := handleAccountsUse(deps, json.RawMessage(`{"chat_id":0,"account":"tam"}`))
+	if err == nil || !strings.Contains(err.Error(), "accounts.pool") {
+		t.Fatalf("should point at the config that is missing, got %v", err)
+	}
+}
+
+// The list marks the login the current conversation is on, so the screen can
+// show it without a second round trip.
+func TestListMarksTheCurrentAccount(t *testing.T) {
+	deps := Deps{Sessions: session.NewManager(nil), Accounts: poolOf(t, "default", "tam")}
+	deps.Sessions.Get(0).SetAccount("tam")
+
+	raw, err := handleAccountsList(deps, json.RawMessage(`{"chat_id":0}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []AccountInfo
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	var current []string
+	for _, a := range out {
+		if a.Current {
+			current = append(current, a.Name)
+		}
+	}
+	if len(current) != 1 || current[0] != "tam" {
+		t.Fatalf("expected tam marked current, got %v", current)
+	}
+}

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -162,6 +162,10 @@ func NewMethodHandler(deps Deps) MethodHandler {
 			return handleBrowserCall(ctx, deps, params)
 
 		// --- admin / observability ---
+		case "accounts.list":
+			return handleAccountsList(deps, params)
+		case "accounts.use":
+			return handleAccountsUse(deps, params)
 		case "admin.settings":
 			return handleAdminSettings(deps)
 		case "admin.set_model":


### PR DESCRIPTION
Closes #128

## Phần lớn đã có sẵn

Pool **đã** xoay session giữa các login, **đã** nhận tham số ghim (`Pool.Pick(pinned)`), và session **đã** ghi lại login nó dùng (`SetAccount`). Thứ duy nhất thiếu là **cách nói ra chọn cái nào** — lựa chọn hoàn toàn thuộc về pool, vốn ổn cho tới khi một trong các login là tài khoản riêng của một người và họ muốn đúng một cuộc nói chuyện chạy trên đó.

## Là lựa chọn theo PHIÊN, không thể khác

Cả hai CLI giữ conversation store **bên trong thư mục credential**. Nên trỏ lại một session đang sống sang login khác sẽ đưa cho lượt kế tiếp một session id mà tài khoản mới **chưa từng thấy**: cuộc nói chuyện khởi động lại bằng cách này hay cách khác, câu hỏi duy nhất là **có ai nói ra hay không**.

Nên `accounts.use` **mở phiên mới** trên login được chọn và nói điều đó ngay trong reply, thay vì trông như một cú chuyển.

## Chi tiết nhỏ nhưng cố ý

`accounts.list` trả **danh sách rỗng**, không phải lỗi, khi chưa cấu hình pool — tức phần lớn máy. Một login mặc định là một **trạng thái cần mô tả**, không phải một thất bại dashboard phải đi bắt ngoại lệ.

Danh sách session hiện login mà mỗi cuộc nói chuyện đang ghim, và ô chọn chỉ xuất hiện khi **có hơn một** cái để chọn.

## Test

- `TestUsingAnAccountStartsANewSession` — phiên mới thật, phiên cũ **không bị đụng**, phiên mới không mang session id cũ
- `TestUnknownAccountIsRefusedByName` — lỗi phải nêu **có những gì**, nếu không caller không hành động được
- `TestNoPoolListsNothingRatherThanFailing`
- `TestUsingAnAccountWithNoPoolSaysWhy` — trỏ đúng vào phần config còn thiếu
- `TestListMarksTheCurrentAccount`

## Chưa làm

Lệnh Telegram `/account` — `Handler` chưa giữ pool, thêm vào là một đợt sửa riêng. Và pool của agent 1 **hiện đang rỗng**: cần thêm mục `accounts:` vào config thì tính năng mới có tác dụng, tôi sẽ đề xuất riêng vì nó đụng file config đang chạy.

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)