### PR TITLE
feat(accounts): a login can be in the pool without being in the rotation

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -177,6 +177,7 @@ func PoolsFromConfig(cfg *config.Config) (map[string]*credentials.Pool, error) {
 			ConfigDir: a.ConfigDir,
 			APIKey:    a.APIKey,
 			APIKeyEnv: a.APIKeyEnv,
+			NoRotate:  a.Rotate != nil && !*a.Rotate,
 		})
 	}
 	cooldown := time.Duration(cfg.Accounts.CooldownMinutes) * time.Minute

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,13 @@ type AccountConfig struct {
 	// so the secret need not sit in config.yaml.
 	APIKey    string `yaml:"api_key"`
 	APIKeyEnv string `yaml:"api_key_env"`
+
+	// Rotate is whether new sessions may land here on their own. Pointer so an
+	// absent key means yes — every pool that exists today is a rotation and
+	// must keep behaving like one. Set false for a login that should be used
+	// only when named: a colleague's account belongs in the pool so it can be
+	// chosen, and out of the rotation so it is never chosen for you.
+	Rotate *bool `yaml:"rotate"`
 }
 
 // BrowserConfig groups browser control. Extension is the Browser Bridge: a

--- a/internal/credentials/pool.go
+++ b/internal/credentials/pool.go
@@ -39,6 +39,16 @@ type Account struct {
 	// the key itself need not sit in config.yaml.
 	APIKey    string
 	APIKeyEnv string
+
+	// NoRotate keeps this account in the pool and out of the rotation: usable
+	// by name and never chosen for you, which is what a colleague's login
+	// needs.
+	//
+	// Negative, so the zero value is the behaviour every pool had before this
+	// existed. A positive Rotate bool would have silently emptied the rotation
+	// of any account built by a caller that had not heard of the field — which
+	// a test caught immediately, and production would have caught at 3am.
+	NoRotate bool
 }
 
 // resolvedKey returns the API key, from the env var when one is named.
@@ -211,6 +221,13 @@ func (p *Pool) Pick(pinned string) (Account, error) {
 	var best *accountState
 	for i := range p.accts {
 		s := p.accts[(p.next+i)%len(p.accts)]
+		// An account can be in the pool without being in the rotation. A
+		// colleague's login is the case that needs it: usable on purpose, and
+		// never the answer to "start a chat" — otherwise every other new
+		// conversation quietly lands on somebody else's quota.
+		if s.acct.NoRotate {
+			continue
+		}
 		if now.Before(s.coolUntil) {
 			continue
 		}
@@ -219,14 +236,24 @@ func (p *Pool) Pick(pinned string) (Account, error) {
 		}
 	}
 	if best == nil {
-		// Everything is cooling down. Hand back whichever recovers soonest and
-		// let the turn try: a cooldown is a guess about someone else's rate
-		// limiter, not a fact, and refusing outright would idle the agent.
+		// Everything in the rotation is cooling down. Hand back whichever
+		// recovers soonest and let the turn try: a cooldown is a guess about
+		// someone else's rate limiter, not a fact, and refusing outright would
+		// idle the agent. Opted-out accounts stay out — being unreachable by
+		// exhaustion is the whole point of opting out.
 		for _, s := range p.accts {
+			if s.acct.NoRotate {
+				continue
+			}
 			if best == nil || s.coolUntil.Before(best.coolUntil) {
 				best = s
 			}
 		}
+	}
+	if best == nil {
+		// Everything is opted out. The ambient credentials are what is left,
+		// and they are what an install with no pool uses anyway.
+		return Account{}, nil
 	}
 	best.lastUsed = now
 	p.next = (p.next + 1) % len(p.accts)

--- a/internal/credentials/pool_test.go
+++ b/internal/credentials/pool_test.go
@@ -293,3 +293,72 @@ func hasPrefix(ss []string, prefix string) bool {
 	}
 	return false
 }
+
+// An account can sit in the pool without being in the rotation. A colleague's
+// login is the case: usable by name, never the answer to "start a chat", or
+// every other new conversation quietly lands on somebody else's quota.
+func TestAnOptedOutAccountIsNeverChosenOnItsOwn(t *testing.T) {
+	p, err := NewPool("claude", []Account{
+		{Name: "default", Provider: "claude", ConfigDir: "/tmp/a"},
+		{Name: "tam", Provider: "claude", ConfigDir: "/tmp/b", NoRotate: true},
+	}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		got, err := p.Pick("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Name == "tam" {
+			t.Fatalf("an opted-out account was picked automatically on try %d", i+1)
+		}
+	}
+	// But naming it still works — that is the whole point of it being here.
+	got, err := p.Pick("tam")
+	if err != nil {
+		t.Fatalf("pinning an opted-out account should work: %v", err)
+	}
+	if got.Name != "tam" {
+		t.Fatalf("got %q", got.Name)
+	}
+}
+
+// Not even by exhaustion: a rate limit on the rotation must not silently
+// promote the account that was kept out of it.
+func TestCooldownDoesNotPromoteAnOptedOutAccount(t *testing.T) {
+	p, err := NewPool("claude", []Account{
+		{Name: "default", Provider: "claude", ConfigDir: "/tmp/a"},
+		{Name: "tam", Provider: "claude", ConfigDir: "/tmp/b", NoRotate: true},
+	}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.MarkFailure("default", errors.New("429 rate limit"))
+	got, err := p.Pick("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name == "tam" {
+		t.Fatal("the opted-out account was reached by exhaustion")
+	}
+}
+
+// The zero value has to mean what every pool meant before the field existed.
+func TestAccountsRotateByDefault(t *testing.T) {
+	p, err := NewPool("claude", []Account{
+		{Name: "a", Provider: "claude", ConfigDir: "/tmp/a"},
+		{Name: "b", Provider: "claude", ConfigDir: "/tmp/b"},
+	}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for i := 0; i < 6; i++ {
+		got, _ := p.Pick("")
+		seen[got.Name] = true
+	}
+	if !seen["a"] || !seen["b"] {
+		t.Fatalf("a pool built without the field stopped rotating: %v", seen)
+	}
+}


### PR DESCRIPTION
Phát hiện khi chuẩn bị cấu hình tài khoản của Tâm cho agent 1.

## Vấn đề

Thêm `tam` vào `accounts.pool` để **chọn được** nó cũng đồng thời đưa nó vào **vòng xoay**: `Pool.Pick("")` chọn account ít dùng gần đây nhất, nên **cứ vài chat mới lại có một cái chạy trên quota của người khác**.

Đó là ngược hẳn với ý "để tôi dùng tài khoản của Tâm **khi tôi cố ý**".

## Sửa

`accounts.pool` nhận `rotate: false`: vẫn nằm đó để gọi tên, **không bao giờ** được chọn thay mình.

Kể cả **bằng đường cạn kiệt**: khi mọi account trong vòng xoay đều đang cooldown, fallback vẫn chỉ tìm **trong vòng xoay** — không với tới được bằng tai nạn chính là toàn bộ mục đích của nó.

## Một chi tiết về kiểu dữ liệu, không phải vặt

Field là **phủ định trong Go** (`NoRotate`) và **khẳng định trong YAML** (`rotate`, vắng mặt = có).

Ban đầu tôi viết `Rotate bool`. Zero value của nó là `false`, nên **mọi caller dựng `Account` mà chưa biết tới field này đều lặng lẽ thành "không xoay"** — tức làm rỗng vòng xoay của mọi pool đang chạy. Một test có sẵn đỏ lên trong vòng một phút; production sẽ bắt được nó lúc 3 giờ sáng.

## Test

- `TestAnOptedOutAccountIsNeverChosenOnItsOwn` — 20 lần Pick, không lần nào ra `tam`; nhưng gọi đích danh thì vẫn được
- `TestCooldownDoesNotPromoteAnOptedOutAccount`
- `TestAccountsRotateByDefault` — zero value phải giữ đúng hành vi cũ

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)