### PR TITLE
fix(channel): the picker chooses who you are talking to, not who you are

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -616,6 +616,11 @@ func runGateway(args []string) {
 		// One doorbell, two listeners: work waiting in the queue and a line
 		// with this agent's name in it arrive the same way, and the ringer
 		// should not have to know which it is.
+		// Peers read and change each other's backend over this, which is why it
+		// sits behind the same rule as the doorbell: a login, or a local
+		// caller. Two agents on one machine are local to each other.
+		srv.Handle("/api/settings", authMgr.RequireAuthExceptLocal(gateway.SettingsHandler(deps)))
+		srv.Handle("/api/settings/model", authMgr.RequireAuthExceptLocal(gateway.SettingsHandler(deps)))
 		srv.Handle("/api/tasks/poke", authMgr.RequireAuthExceptLocal(gateway.PokeHandler(func() {
 			runner.Poke()
 			mentions.Poke()

--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -11,8 +11,6 @@ type Call = (method: string, params?: any) => Promise<any>
 // were not in the history at all. Here the human is an ordinary member: the
 // composer posts as "you" unless you deliberately speak as an agent.
 
-const OWNER = 'owner'
-
 export default function ChannelView({ call, agents, selfID, openThreadID, onOpenedThread, onOpenTask }: {
   call: Call; agents: string[]; selfID: string
   openThreadID?: string; onOpenedThread?: () => void; onOpenTask?: (taskID: string) => void
@@ -26,7 +24,9 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
   // The thread keeps its own draft. One shared box meant typing a reply in the
   // panel on the right while the words appeared in the box on the left.
   const [threadBody, setThreadBody] = useState('')
-  const [as, setAs] = useState<string>(OWNER)
+  // Who the message is addressed to. From a browser the author is always the
+  // person at it; the only choice to make is which agent you are talking to.
+  const [to, setTo] = useState<string>('')
   const [err, setErr] = useState<string | null>(null)
   const sending = useRef(false)
   const bottom = useRef<HTMLDivElement>(null)
@@ -117,7 +117,8 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
     sending.current = true
     try {
       const posted: ChannelMessage = await call('channels.post', {
-        channel_id: active, body: text, as,
+        channel_id: active, body: text,
+        ...(to ? { notify: [to] } : {}),
         ...(inThread ? { thread_root: threadRoot } : {}),
       })
       if (inThread) setThreadBody(''); else setBody('')
@@ -186,8 +187,8 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
 
         <Composer
           value={body} onChange={setBody} onSend={() => post(false)}
-          as={as} setAs={setAs} agents={agents}
-          placeholder="Message the channel — @agent to wake one"
+          to={to} setTo={setTo} agents={agents}
+          placeholder="Message the channel"
         />
       </div>
 
@@ -211,7 +212,7 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
           {/* Typing happens where you are reading. */}
           <Composer
             value={threadBody} onChange={setThreadBody} onSend={() => post(true)}
-            as={as} setAs={setAs} agents={agents}
+            to={to} setTo={setTo} agents={agents}
             placeholder="Reply in thread"
           />
         </aside>
@@ -300,29 +301,28 @@ function Line({ m, selfID, compact, onThread, onOpenTask }: {
   )
 }
 
-function Composer({ value, onChange, onSend, as, setAs, agents, placeholder }: {
+function Composer({ value, onChange, onSend, to, setTo, agents, placeholder }: {
   value: string; onChange: (s: string) => void; onSend: () => void
-  as: string; setAs: (s: string) => void; agents: string[]; placeholder: string
+  to: string; setTo: (s: string) => void; agents: string[]; placeholder: string
 }) {
   return (
     <div className="border-t border-gray-800 bg-gray-900/40">
       <div className="p-3 flex gap-2">
-        {/* Speaking as an agent changes what the room does with the line: an
-            agent's message wakes nobody, by the rule that keeps three agents
-            from answering each other forever. That is the right rule and the
-            wrong thing to leave invisible — a question typed here in the
-            owner's own hand, with the selector left on an agent, simply gets
-            no answer and nothing says why. So the unusual mode looks unusual. */}
+        {/* Who you are talking to. The author is always you — a person at a
+            browser is a person — so the only choice here is which agent the
+            line is addressed at. Picking one rings its doorbell without making
+            anyone type the name a second time; picking nobody leaves the room
+            readable and no one interrupted. */}
         <select
-          value={as}
-          onChange={e => setAs(e.target.value)}
-          title={as === OWNER ? 'Who this is from' : `Speaking as ${as} — an agent's line wakes nobody`}
+          value={to}
+          onChange={e => setTo(e.target.value)}
+          title="Which agent this is for"
           className={`px-2 py-2 text-sm bg-gray-950 rounded ring-1 outline-none ${
-            as === OWNER ? 'ring-gray-800 text-gray-300' : 'ring-amber-500/50 text-amber-300'
+            to ? 'ring-sky-500/50 text-sky-300' : 'ring-gray-800 text-gray-400'
           }`}
         >
-          <option value={OWNER}>you</option>
-          {agents.map(a => <option key={a} value={a}>as {a}</option>)}
+          <option value="">to: everyone</option>
+          {agents.map(a => <option key={a} value={a}>to: {a}</option>)}
         </select>
         <input
           value={value}
@@ -334,18 +334,9 @@ function Composer({ value, onChange, onSend, as, setAs, agents, placeholder }: {
             if (e.nativeEvent.isComposing || e.keyCode === 229) return
             if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend() }
           }}
-          placeholder={as === OWNER ? placeholder : `as ${as} — nobody is woken unless you @name them`}
+          placeholder={to ? `${placeholder} — ${to} will answer` : `${placeholder} — nobody is interrupted`}
           className="flex-1 px-3 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
         />
-        {as !== OWNER && (
-          <button
-            onClick={() => setAs(OWNER)}
-            title="Go back to speaking as yourself"
-            className="px-2 py-2 text-xs rounded ring-1 ring-amber-500/40 text-amber-300 hover:bg-amber-500/10 whitespace-nowrap"
-          >
-            speak as you
-          </button>
-        )}
         <button
           onClick={onSend}
           disabled={!value.trim()}

--- a/dashboard/src/admin/SettingsPane.tsx
+++ b/dashboard/src/admin/SettingsPane.tsx
@@ -19,6 +19,8 @@ interface AgentSettings {
   choices: ModelChoice[]
   can_restart: boolean
   busy: boolean
+  reachable: boolean
+  error?: string
 }
 
 // Which backend this agent runs on, and changing it.
@@ -32,17 +34,12 @@ interface AgentSettings {
 // not another agent's config file, and a screen that pretended otherwise would
 // be editing a file nobody reloads.
 export default function SettingsPane({ call }: { call: Call }) {
-  const [data, setData] = useState<AgentSettings | null>(null)
+  const [agents, setAgents] = useState<AgentSettings[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
-  const [picked, setPicked] = useState('')
-  const [busy, setBusy] = useState(false)
-  const [note, setNote] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     try {
-      const d: AgentSettings = await call('admin.settings')
-      setData(d)
-      setPicked(p => p || d.model)
+      setAgents((await call('admin.settings')) || [])
       setErr(null)
     } catch (e: any) {
       setErr(String(e?.message ?? e))
@@ -51,18 +48,42 @@ export default function SettingsPane({ call }: { call: Call }) {
 
   useEffect(() => { load() }, [load])
 
+  if (err && !agents) return <div className="p-4 text-sm text-red-300">{err}</div>
+  if (!agents) return <div className="p-4 text-sm text-gray-500">Loading…</div>
+
+  return (
+    <div className="p-4 max-w-3xl space-y-4">
+      {err && <div className="text-xs text-red-300">{err}</div>}
+      {agents.map(a => <AgentCard key={a.agent_id} agent={a} call={call} onChanged={load} />)}
+      <p className="text-xs text-gray-600">
+        Mỗi gateway đọc file config của chính nó; những agent khác được hỏi qua loopback,
+        nên một agent đang tắt sẽ hiện là không liên lạc được chứ không biến mất khỏi danh sách.
+      </p>
+    </div>
+  )
+}
+
+function AgentCard({ agent, call, onChanged }: { agent: AgentSettings; call: Call; onChanged: () => void }) {
+  const [picked, setPicked] = useState(agent.model)
+  const [busy, setBusy] = useState(false)
+  const [note, setNote] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => { setPicked(agent.model) }, [agent.model])
+
   const apply = async (force: boolean) => {
-    if (!data || !picked || picked === data.model) return
+    if (!picked || picked === agent.model) return
     setBusy(true)
     setNote(null)
     try {
-      const r = await call('admin.set_model', { model: picked, ...(force ? { force: true } : {}) })
+      const r = await call('admin.set_model', {
+        agent_id: agent.agent_id, model: picked, ...(force ? { force: true } : {}),
+      })
       setErr(null)
       setNote(r?.restarted
-        ? `Đã ghi config và khởi động lại ${data.agent_id}. Đợi vài giây rồi tải lại trang.`
+        ? `Đã ghi config và khởi động lại ${agent.agent_id}.`
         : (r?.note ?? 'Đã ghi config.'))
-      // The gateway is restarting under us; give it a moment, then re-read.
-      setTimeout(load, 6000)
+      setTimeout(onChanged, 6000)
     } catch (e: any) {
       setErr(String(e?.message ?? e))
     } finally {
@@ -70,80 +91,75 @@ export default function SettingsPane({ call }: { call: Call }) {
     }
   }
 
-  if (err && !data) return <div className="p-4 text-sm text-red-300">{err}</div>
-  if (!data) return <div className="p-4 text-sm text-gray-500">Loading…</div>
+  if (!agent.reachable) {
+    return (
+      <div className="rounded-lg ring-1 ring-gray-800 bg-gray-900/40 p-3">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm text-gray-300">{agent.agent_name || agent.agent_id}</span>
+          <span className="text-xs text-amber-300">không liên lạc được</span>
+        </div>
+        {agent.error && <p className="mt-1 text-xs text-gray-500 font-mono truncate">{agent.error}</p>}
+      </div>
+    )
+  }
 
-  const changed = picked !== data.model
-  const target = data.choices.find(c => c.id === picked)
+  const changed = picked !== agent.model
+  const target = agent.choices?.find(c => c.id === picked)
 
   return (
-    <div className="p-4 max-w-2xl space-y-4">
-      <div>
-        <h2 className="text-sm text-gray-200 font-medium">{data.agent_name || data.agent_id}</h2>
-        <p className="text-xs text-gray-500 font-mono">{data.config_path}</p>
+    <div className="rounded-lg ring-1 ring-gray-800 bg-gray-900/40 p-3 space-y-3">
+      <div className="flex items-baseline gap-2 flex-wrap">
+        <span className="text-sm text-gray-200 font-medium">{agent.agent_name || agent.agent_id}</span>
+        <span className="text-xs font-mono px-1.5 rounded bg-sky-500/10 text-sky-300 ring-1 ring-sky-500/30">
+          {agent.provider}
+        </span>
+        <span className="text-xs text-gray-500 font-mono">{agent.model}</span>
+        {agent.busy && <span className="text-xs text-amber-300">đang chạy việc</span>}
+        <span className="ml-auto text-[11px] text-gray-600 font-mono truncate">{agent.config_path}</span>
       </div>
 
       {err && <div className="text-xs text-red-300">{err}</div>}
       {note && <div className="text-xs text-emerald-300">{note}</div>}
 
-      <dl className="grid grid-cols-2 gap-2 text-xs">
-        <div><dt className="text-gray-600">backend</dt><dd className="font-mono text-gray-200">{data.provider}</dd></div>
-        <div><dt className="text-gray-600">model</dt><dd className="font-mono text-gray-200">{data.model}</dd></div>
-      </dl>
-
-      <div className="space-y-2">
-        <label className="block text-xs text-gray-500">
-          Đổi model — backend đi theo model, không chọn riêng
-        </label>
+      <div className="flex items-center gap-2 flex-wrap">
         <select
           value={picked}
           onChange={e => setPicked(e.target.value)}
-          className="w-full px-2 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 text-gray-200 outline-none"
+          className="flex-1 min-w-0 px-2 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 text-gray-200 outline-none"
         >
-          {data.choices.map(c => (
-            <option key={c.id} value={c.id}>
-              {c.name} — {c.provider} ({c.id})
-            </option>
+          {(agent.choices ?? []).map(c => (
+            <option key={c.id} value={c.id}>{c.name} — {c.provider} ({c.id})</option>
           ))}
         </select>
-        {changed && target && (
-          <p className="text-xs text-amber-300">
-            {data.provider === target.provider
-              ? `Cùng backend ${target.provider}, chỉ đổi model.`
-              : `Đổi backend ${data.provider} → ${target.provider}.`}
-            {' '}Agent sẽ khởi động lại{data.busy ? ' — và đang có việc chạy dở, nó sẽ bị cắt.' : '.'}
-          </p>
-        )}
-      </div>
-
-      <div className="flex items-center gap-2">
         <button
           onClick={() => apply(false)}
-          disabled={!changed || busy || !data.can_restart}
+          disabled={!changed || busy || !agent.can_restart}
           className="px-3 py-2 text-sm rounded bg-gray-100 text-gray-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {busy ? 'Đang đổi…' : 'Đổi & khởi động lại'}
+          {busy ? 'Đang đổi…' : 'Đổi & restart'}
         </button>
-        {data.busy && changed && (
+        {agent.busy && changed && (
           <button
             onClick={() => apply(true)}
             disabled={busy}
             className="px-3 py-2 text-sm rounded ring-1 ring-amber-500/50 text-amber-300 hover:bg-amber-500/10"
           >
-            Cắt việc đang chạy và đổi
+            Cắt việc đang chạy
           </button>
-        )}
-        {!data.can_restart && (
-          <span className="text-xs text-gray-500">
-            Gateway này không chạy dưới service manager — đổi xong phải tự restart.
-          </span>
         )}
       </div>
 
-      <p className="text-xs text-gray-600">
-        Chỉ agent này. Mỗi gateway đọc file config của chính nó, nên đổi backend cho agent khác
-        thì mở dashboard của agent đó.
-      </p>
+      {changed && target && (
+        <p className="text-xs text-amber-300">
+          {agent.provider === target.provider
+            ? `Cùng backend ${target.provider}, chỉ đổi model.`
+            : `Đổi backend ${agent.provider} → ${target.provider}.`}
+          {' '}Agent sẽ khởi động lại{agent.busy ? ' — việc đang chạy sẽ bị cắt.' : '.'}
+        </p>
+      )}
+      {!agent.can_restart && (
+        <p className="text-xs text-gray-500">Không chạy dưới service manager — đổi xong phải tự restart.</p>
+      )}
     </div>
   )
 }

--- a/internal/gateway/channels.go
+++ b/internal/gateway/channels.go
@@ -74,8 +74,17 @@ type channelPostParams struct {
 	ThreadRoot string `json:"thread_root,omitempty"`
 	Body       string `json:"body"`
 	TaskID     string `json:"task_id,omitempty"`
-	// As is who the message is from: "user" (default) or an agent id.
+	// As is who the message is from: "user" (default) or an agent id. The
+	// dashboard never sets it — a person at a browser is a person, and the
+	// only callers with a reason to speak as an agent are the agents, through
+	// their own CLI.
 	As string `json:"as,omitempty"`
+
+	// Notify addresses the message at agents without requiring the writer to
+	// spell their names into the prose. Picking "bomclaw2" from a dropdown and
+	// having to also type "@bomclaw2" is asking the same question twice, and
+	// forgetting the second half is silence.
+	Notify []string `json:"notify,omitempty"`
 }
 
 func handleChannelPost(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -87,9 +96,17 @@ func handleChannelPost(deps Deps, params json.RawMessage) (json.RawMessage, erro
 		return nil, err
 	}
 	kind, id := author(deps, p.As)
+	notify := make([]coord.Member, 0, len(p.Notify))
+	for _, who := range p.Notify {
+		if who == "" || who == id {
+			continue // nobody rings their own doorbell
+		}
+		notify = append(notify, coord.Member{Kind: coord.MemberAgent, ID: who})
+	}
 	msg, wake, err := deps.Coord.PostMessage(coord.NewChannelMessage{
 		ChannelID: p.ChannelID, ThreadRoot: p.ThreadRoot,
 		AuthorKind: kind, AuthorID: id, Body: p.Body, TaskID: p.TaskID,
+		Notify: notify,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -301,5 +302,54 @@ func TestAdoptingTwiceKeepsOneSession(t *testing.T) {
 	}
 	if n != 1 {
 		t.Fatalf("one thread produced %d sessions", n)
+	}
+}
+
+// TestAddressingAnAgentWakesItWithoutTyping: picking an agent from a dropdown
+// and then also having to write "@bomclaw2" is asking the same question twice,
+// and forgetting the second half is silence — which is exactly what happened
+// the first time somebody used the picker.
+func TestAddressingAnAgentWakesItWithoutTyping(t *testing.T) {
+	turn := &recordingTurn{reply: "ừ", newID: "s1"}
+	deps, _ := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	raw, err := handleChannelPost(deps, json.RawMessage(
+		`{"channel_id":"`+coord.GeneralChannelID+`","body":"về kinh tế VN 3 tháng qua","notify":["bomclaw2"]}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	var posted coord.ChannelMessage
+	if err := json.Unmarshal(raw, &posted); err != nil {
+		t.Fatal(err)
+	}
+	// The author is the person, not the agent they addressed.
+	if posted.AuthorKind != coord.MemberUser || posted.AuthorID != coord.OwnerUserID {
+		t.Fatalf("a dashboard post was attributed to %s/%s", posted.AuthorKind, posted.AuthorID)
+	}
+	// And the body is untouched: addressing is structure, not prose.
+	if posted.Body != "về kinh tế VN 3 tháng qua" {
+		t.Fatalf("the body was rewritten: %q", posted.Body)
+	}
+
+	NewMentionWatcher(deps).sweep(context.Background())
+	if turn.count() != 1 {
+		t.Fatalf("the addressed agent did not answer (%d turns)", turn.count())
+	}
+}
+
+// Addressing nobody still leaves the room readable and nobody interrupted.
+func TestAddressingNobodyWakesNobody(t *testing.T) {
+	turn := &recordingTurn{reply: "không nên nói gì"}
+	deps, _ := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	if _, err := handleChannelPost(deps, json.RawMessage(
+		`{"channel_id":"`+coord.GeneralChannelID+`","body":"ghi chú cho cả phòng"}`)); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+	if turn.count() != 0 {
+		t.Fatal("a line addressed to nobody woke an agent")
 	}
 }

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -167,9 +167,9 @@ func NewMethodHandler(deps Deps) MethodHandler {
 		case "accounts.use":
 			return handleAccountsUse(deps, params)
 		case "admin.settings":
-			return handleAdminSettings(deps)
+			return handleAdminSettingsAll(deps)
 		case "admin.set_model":
-			return handleAdminSetModel(deps, params)
+			return handleAdminSetModelOn(deps, params)
 		case "admin.overview":
 			return handleAdminOverview(deps)
 		case "traces.list":

--- a/internal/gateway/notify.go
+++ b/internal/gateway/notify.go
@@ -67,6 +67,18 @@ func PokeURL(wsAddr string) (string, error) {
 	return u.String(), nil
 }
 
+// PeerURL derives any loopback HTTP route on a peer from the WebSocket address
+// it registered, the same way PokeURL derives the doorbell. Two agents on one
+// machine are loopback to each other, which is what lets the settings screen
+// read and change a peer without a login.
+func PeerURL(wsAddr, path string) (string, error) {
+	u, err := PokeURL(wsAddr)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(u, "/api/tasks/poke") + path, nil
+}
+
 // PokeHandler is the HTTP side of the doorbell. poke is the local runner's
 // Poke; a nil-safe no-op when this agent does not claim tasks, so the route can
 // always be mounted and a peer never gets a 404 for ringing.

--- a/internal/gateway/settings.go
+++ b/internal/gateway/settings.go
@@ -1,9 +1,15 @@
 package gateway
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/ngocp/goterm-control/internal/config"
 )
@@ -27,6 +33,12 @@ type AgentSettings struct {
 	Choices    []config.ModelChoice `json:"choices"`
 	CanRestart bool                 `json:"can_restart"`
 	Busy       bool                 `json:"busy"` // a turn or task is running right now
+
+	// Reachable says whether this row is an answer or a guess. A peer that is
+	// down appears with the reason rather than being dropped: an agent missing
+	// from the list reads as an agent that does not exist.
+	Reachable bool   `json:"reachable"`
+	Error     string `json:"error,omitempty"`
 }
 
 func handleAdminSettings(deps Deps) (json.RawMessage, error) {
@@ -97,4 +109,149 @@ func handleAdminSetModel(deps Deps, params json.RawMessage) (json.RawMessage, er
 		}
 	}()
 	return json.Marshal(map[string]any{"written": true, "restarted": true})
+}
+
+// --- the other agents ------------------------------------------------------
+//
+// A gateway can only read its own config file, so a settings screen that
+// showed one agent was telling the truth and being useless: the machine runs
+// three, and the question "which backend is each on" is asked about all of
+// them at once.
+//
+// The answer is the peers, over the same loopback HTTP the doorbell uses.
+// Two agents on one machine are local to each other, which is why those routes
+// are exempt from the dashboard login — and why this one carries no
+// credentials of its own.
+
+// handleAdminSettingsAll gathers this agent's settings and every peer's.
+//
+// A peer that is down, or too old to answer, appears with Reachable false
+// rather than being left out: an agent missing from the list reads as an agent
+// that does not exist.
+func handleAdminSettingsAll(deps Deps) (json.RawMessage, error) {
+	mine, err := handleAdminSettings(deps)
+	if err != nil {
+		return nil, err
+	}
+	var self AgentSettings
+	if err := json.Unmarshal(mine, &self); err != nil {
+		return nil, err
+	}
+	self.Reachable = true
+	out := []AgentSettings{self}
+
+	if deps.Coord != nil {
+		agents, err := deps.Coord.ListAgents()
+		if err != nil {
+			return nil, err
+		}
+		client := &http.Client{Timeout: 5 * time.Second}
+		for _, a := range agents {
+			if a.ID == deps.AgentID {
+				continue
+			}
+			out = append(out, peerSettings(client, a.ID, a.DisplayName, a.WSAddr))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AgentID < out[j].AgentID })
+	return json.Marshal(out)
+}
+
+func peerSettings(client *http.Client, id, name, wsAddr string) AgentSettings {
+	fail := func(err error) AgentSettings {
+		return AgentSettings{AgentID: id, AgentName: name, Reachable: false, Error: err.Error()}
+	}
+	if client == nil {
+		// A timeout is the one thing this call must not go without: a peer
+		// that accepts the connection and never answers would otherwise hold
+		// the settings screen open forever.
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	url, err := PeerURL(wsAddr, "/api/settings")
+	if err != nil {
+		return fail(err)
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fail(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fail(fmt.Errorf("HTTP %d", resp.StatusCode))
+	}
+	var s AgentSettings
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return fail(err)
+	}
+	s.Reachable = true
+	return s
+}
+
+// handleAdminSetModelOn routes a change to whichever agent owns that config.
+func handleAdminSetModelOn(deps Deps, params json.RawMessage) (json.RawMessage, error) {
+	var p struct {
+		AgentID string `json:"agent_id"`
+		setModelParams
+	}
+	if err := decodeParams(params, &p); err != nil {
+		return nil, err
+	}
+	if p.AgentID == "" || p.AgentID == deps.AgentID {
+		return handleAdminSetModel(deps, params)
+	}
+	if deps.Coord == nil {
+		return nil, errNoCoord()
+	}
+	agents, err := deps.Coord.ListAgents()
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range agents {
+		if a.ID != p.AgentID {
+			continue
+		}
+		url, err := PeerURL(a.WSAddr, "/api/settings/model")
+		if err != nil {
+			return nil, err
+		}
+		body, _ := json.Marshal(p.setModelParams)
+		resp, err := (&http.Client{Timeout: 15 * time.Second}).Post(url, "application/json", bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("reach %s: %w", p.AgentID, err)
+		}
+		defer resp.Body.Close()
+		raw, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			// The peer's own words: it knows why better than this does.
+			return nil, fmt.Errorf("%s: %s", p.AgentID, strings.TrimSpace(string(raw)))
+		}
+		return raw, nil
+	}
+	return nil, fmt.Errorf("no agent %q is registered", p.AgentID)
+}
+
+// SettingsHandler is the loopback HTTP face of the two settings methods, for
+// peers. Mounted behind the same rule as /api/status: a login, or a local
+// caller — and a peer on this machine is local.
+func SettingsHandler(deps Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var raw json.RawMessage
+		var err error
+		switch r.Method {
+		case http.MethodGet:
+			raw, err = handleAdminSettings(deps)
+		case http.MethodPost:
+			body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+			raw, err = handleAdminSetModel(deps, body)
+		default:
+			http.Error(w, `{"error":"GET or POST"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(raw)
+	}
 }

--- a/internal/gateway/settings_test.go
+++ b/internal/gateway/settings_test.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A peer that is down must appear with the reason, not vanish: an agent
+// missing from the settings list reads as an agent that does not exist, and
+// the person goes looking for a bug that is not there.
+func TestAnUnreachablePeerIsListedNotDropped(t *testing.T) {
+	s := peerSettings(nil, "bomclaw9", "Agent 9", "ws://127.0.0.1:1/ws")
+	if s.AgentID != "bomclaw9" || s.AgentName != "Agent 9" {
+		t.Fatalf("identity lost: %+v", s)
+	}
+	if s.Reachable {
+		t.Fatal("a dead peer reported itself reachable")
+	}
+	if s.Error == "" {
+		t.Fatal("unreachable with no reason given")
+	}
+}
+
+// A peer with a malformed address fails the same way — described, not dropped.
+func TestABadPeerAddressIsDescribed(t *testing.T) {
+	s := peerSettings(nil, "bomclaw9", "Agent 9", "not-a-url")
+	if s.Reachable || !strings.Contains(s.Error, "not-a-url") {
+		t.Fatalf("expected the bad address in the reason: %+v", s)
+	}
+}
+
+// Routing: a change for this agent stays here rather than going out over the
+// network to itself.
+func TestSetModelForSelfDoesNotGoOverTheWire(t *testing.T) {
+	deps := Deps{AgentID: "bomclaw"} // no ConfigPath: the local handler must be the one to complain
+	_, err := handleAdminSetModelOn(deps, json.RawMessage(`{"agent_id":"bomclaw","model":"x"}`))
+	if err == nil || !strings.Contains(err.Error(), "config path") {
+		t.Fatalf("expected the local handler's error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Tôi hiểu sai ngay từ đầu

Ô chọn trong composer cho phép **đăng bài với tư cách một agent**, nên chọn `bomclaw2` khiến câu hỏi của chính anh xuất hiện như lời của agent đó — mà lời agent thì không đánh thức ai, nên câu hỏi nằm im.

Hôm qua tôi "sửa" bằng cách làm trạng thái đó **hiện rõ**. Hiện rõ là mục tiêu sai. Đứng ở mặt web thì **tác giả luôn là người dùng**, và lựa chọn duy nhất đáng có là: **nói chuyện với agent nào**.

## Sửa

Ô chọn giờ là `to: bomclaw2`, và tin nhắn được **địa chỉ hoá**, không phải **hoá trang**.

Việc địa chỉ hoá đi qua `Notify` — thứ `coord` đã có từ khi channels ra đời, đúng vì lý do *"một DM được địa chỉ hoá bằng cấu trúc chứ không phải bằng văn xuôi"*. Chọn agent từ danh sách rồi **lại phải gõ `@bomclaw2`** là hỏi cùng một câu hai lần, và quên nửa sau thì nhận về sự im lặng.

## Và Settings phủ cả ba agent

Hiện mỗi agent 1 là **đúng nhưng vô dụng**: máy chạy ba con, và "mỗi con đang ở backend nào" là câu hỏi về cả ba.

Một gateway chỉ đọc được config của chính nó, nên hai con kia trả lời qua **cùng loopback HTTP mà chuông đang dùng** — hai agent trên một máy là local với nhau, đó cũng là lý do các route đó miễn login.

Agent đang tắt được **liệt kê kèm lý do**, không bị bỏ khỏi danh sách: một agent vắng mặt đọc ra thành một agent không tồn tại, và người dùng sẽ đi tìm một cái bug không có thật.

Một test bắt được `peerSettings` nil-deref khi client nil trên đường làm.

## Test

- `TestAddressingAnAgentWakesItWithoutTyping` — tác giả là **người**, body **không bị viết thêm**, agent được chọn trả lời
- `TestAddressingNobodyWakesNobody`
- `TestAnUnreachablePeerIsListedNotDropped`, `TestABadPeerAddressIsDescribed`
- `TestSetModelForSelfDoesNotGoOverTheWire`

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)