### PR TITLE
fix(channel): naming one agent stops meaning "and everyone else too"

### DIFF
--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -398,11 +398,17 @@ func (db *DB) PostMessage(n NewChannelMessage) (*ChannelMessage, []string, error
 	// conversation. Following a thread you have spoken in is Slack's rule and
 	// the right one here.
 	//
+	// But only when nothing was named. Naming someone — in the prose or by
+	// picking them — is a narrower statement than "whoever is in here", and
+	// the narrower one has to win: a person who picks one agent and watches
+	// three answer will stop picking. So this is a default for an unaddressed
+	// reply, not an addition to an addressed one.
+	//
 	// Only a PERSON's reply does this. An agent's reply waking every other
 	// agent in the thread is the loop the mention rule exists to prevent —
 	// three agents in one room answering each other's answers. An agent that
 	// means to summon a peer still writes @, which is a decision it made.
-	if n.ThreadRoot != "" && n.AuthorKind == MemberUser {
+	if n.ThreadRoot != "" && n.AuthorKind == MemberUser && len(addressed) == 0 {
 		followers, err := db.threadAgents(n.ThreadRoot)
 		if err != nil {
 			return nil, nil, err

--- a/internal/coord/channels_test.go
+++ b/internal/coord/channels_test.go
@@ -551,3 +551,65 @@ func TestTaskWithoutAThread(t *testing.T) {
 		t.Fatalf("a task with no conversation reported one: %s / %s", root, channel)
 	}
 }
+
+// TestNamingOneAgentInAThreadWakesOnlyThatOne: following a thread is a default
+// for a reply that named nobody, not an addition to one that did. A person who
+// picks one agent and watches three answer will stop picking.
+func TestNamingOneAgentInAThreadWakesOnlyThatOne(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2", "bomclaw3")
+
+	root, _, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID,
+		Body: "@bomclaw2 bắt đầu đi",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All three end up in the thread.
+	for _, who := range []string{"bomclaw", "bomclaw2", "bomclaw3"} {
+		if _, _, err := db.PostMessage(NewChannelMessage{
+			ChannelID: GeneralChannelID, ThreadRoot: root.ID, AuthorID: who, Body: "mình đây",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Picked from a dropdown: structure, not prose.
+	_, wake, err := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "reply đi",
+		Notify: []Member{{Kind: MemberAgent, ID: "bomclaw3"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake) != 1 || wake[0] != "bomclaw3" {
+		t.Fatalf("picking one agent woke %v", wake)
+	}
+
+	// Same rule when the name is written in the prose.
+	_, wake, err = db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "@bomclaw2 còn bạn?",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake) != 1 || wake[0] != "bomclaw2" {
+		t.Fatalf("naming one agent in prose woke %v", wake)
+	}
+
+	// And an unaddressed reply still reaches everyone in the thread — that is
+	// the case the rule was written for.
+	_, wake, err = db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: MemberUser, AuthorID: OwnerUserID, Body: "ai rảnh thì xem giúp",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake) != 3 {
+		t.Fatalf("an unaddressed reply should reach the thread, woke %v", wake)
+	}
+}


### PR DESCRIPTION
## Triệu chứng

Chọn `to: bomclaw3` trong thread, nhưng tin nhắn hiện `@bomclaw @bomclaw2 @bomclaw3` và **cả ba cùng trả lời**.

## Nguyên nhân

Luật ở #132 — *người trả lời trong thread thì đánh thức các agent đã ở trong thread* — đang **cộng thêm** vào lựa chọn tường minh thay vì **nhường chỗ** cho nó.

## Sửa

Gọi tên ai đó — trong văn xuôi hay bằng cách chọn từ danh sách — là một phát biểu **hẹp hơn** "ai đang ở trong đây", và cái hẹp hơn phải thắng.

Theo-dõi-thread là ý nghĩa của một reply **không nêu tên ai**; nó không phải cái sàn đặt dưới một reply đã nêu tên. Một người chọn một agent rồi thấy ba con trả lời sẽ **thôi không chọn nữa**.

Reply không nêu tên vẫn đánh thức cả thread — đó là ca mà luật này sinh ra để phục vụ, và là lý do nó ở lại.

## Test

`TestNamingOneAgentInAThreadWakesOnlyThatOne` phủ cả ba nhánh trong một thread có đủ ba agent:
- chọn từ dropdown (`Notify`) → đánh thức **1**
- gõ `@` trong văn xuôi → đánh thức **1**
- không nêu tên ai → đánh thức **3**

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)