### PR TITLE
feat(channel): one agent at a time, and it arrives having read the thread

### DIFF
--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -24,9 +24,11 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
   // The thread keeps its own draft. One shared box meant typing a reply in the
   // panel on the right while the words appeared in the box on the left.
   const [threadBody, setThreadBody] = useState('')
-  // Who the message is addressed to. From a browser the author is always the
-  // person at it; the only choice to make is which agent you are talking to.
+  // Which agent you are talking to. Always exactly one: a message to the room
+  // in general is a message nobody answers, and a thread with three agents in
+  // it answering at once is the same question asked three times.
   const [to, setTo] = useState<string>('')
+  useEffect(() => { setTo(t => t || agents[0] || '') }, [agents])
   const [err, setErr] = useState<string | null>(null)
   const sending = useRef(false)
   const bottom = useRef<HTMLDivElement>(null)
@@ -112,13 +114,12 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
   // is decided by the caller, not by a mode the composer is left sitting in.
   const post = async (inThread: boolean) => {
     const text = (inThread ? threadBody : body).trim()
-    if (!text || !active || sending.current) return
+    if (!text || !active || !to || sending.current) return
     if (inThread && !threadRoot) return
     sending.current = true
     try {
       const posted: ChannelMessage = await call('channels.post', {
-        channel_id: active, body: text,
-        ...(to ? { notify: [to] } : {}),
+        channel_id: active, body: text, notify: [to],
         ...(inThread ? { thread_root: threadRoot } : {}),
       })
       if (inThread) setThreadBody(''); else setBody('')
@@ -317,11 +318,8 @@ function Composer({ value, onChange, onSend, to, setTo, agents, placeholder }: {
           value={to}
           onChange={e => setTo(e.target.value)}
           title="Which agent this is for"
-          className={`px-2 py-2 text-sm bg-gray-950 rounded ring-1 outline-none ${
-            to ? 'ring-sky-500/50 text-sky-300' : 'ring-gray-800 text-gray-400'
-          }`}
+          className="px-2 py-2 text-sm bg-gray-950 rounded ring-1 ring-sky-500/50 text-sky-300 outline-none"
         >
-          <option value="">to: everyone</option>
           {agents.map(a => <option key={a} value={a}>to: {a}</option>)}
         </select>
         <input
@@ -334,12 +332,12 @@ function Composer({ value, onChange, onSend, to, setTo, agents, placeholder }: {
             if (e.nativeEvent.isComposing || e.keyCode === 229) return
             if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend() }
           }}
-          placeholder={to ? `${placeholder} — ${to} will answer` : `${placeholder} — nobody is interrupted`}
+          placeholder={`${placeholder} — ${to || 'no agent'} will answer`}
           className="flex-1 px-3 py-2 text-sm bg-gray-950 rounded ring-1 ring-gray-800 focus:ring-gray-600 outline-none text-gray-200 placeholder:text-gray-600"
         />
         <button
           onClick={onSend}
-          disabled={!value.trim()}
+          disabled={!value.trim() || !to}
           className="px-4 py-2 text-sm rounded bg-gray-100 text-gray-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
         >
           Send

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -50,6 +50,15 @@ const (
 	// that was down, a poke that lost its race with this process starting.
 	mentionPoll = 30 * time.Second
 
+	// MaxThreadMessageRunes is how much of one message travels into the prompt.
+	// The old figure was 400, which cut a colleague's analysis off mid-sentence
+	// and handed the next agent a question whose premise was missing.
+	MaxThreadMessageRunes = 4000
+
+	// MaxThreadContextRunes bounds the whole quoted thread, because a room
+	// that has been busy all day must still fit in front of a model.
+	MaxThreadContextRunes = 24000
+
 	// mentionTurnTimeout bounds one reply. A channel turn is a conversation,
 	// not a task: if it needs longer than this it needs a task.
 	mentionTurnTimeout = 3 * time.Minute
@@ -256,20 +265,7 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 		fmt.Fprintf(&b, "You were named in %s, a room you share with the other agents and the owner.\n\n", channel)
 	}
 
-	// A thread has a history the model may not have seen — it may have been
-	// answered by another agent, or by this one before a restart.
-	if m.ThreadRoot != "" {
-		if thread, err := w.deps.Coord.ThreadMessages(m.ThreadRoot); err == nil && len(thread) > 1 {
-			b.WriteString("## The thread so far\n\n")
-			for _, t := range thread {
-				if t.ID == m.ID {
-					continue
-				}
-				fmt.Fprintf(&b, "- %s: %s\n", t.AuthorID, truncateLine(t.Body, 400))
-			}
-			b.WriteString("\n")
-		}
-	}
+	b.WriteString(w.threadContext(m, mem))
 
 	fmt.Fprintf(&b, "## %s said\n\n%s\n\n", m.AuthorID, strings.TrimSpace(m.Body))
 
@@ -286,6 +282,97 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 		"has to watch the board for an answer they asked for in a room. The board is for work; "+
 		"this room is for talking about it.\n", key)
 	return b.String()
+}
+
+// threadContext is what the agent needs to read before answering, and it is a
+// different thing depending on whether it has been here before.
+//
+// An agent named into a thread for the first time has no CLI session for it, so
+// this prompt is the ONLY thing it will ever know about the conversation. It
+// gets the whole thread, generously: being handed "@you what do you think" with
+// four hundred characters of somebody else's analysis is how you get an agent
+// confidently answering a question nobody asked.
+//
+// An agent that has spoken here resumes its own session and remembers its own
+// turns. Re-pasting the whole thread at it every time is not free and not
+// clarifying — it needs what happened WHILE IT WAS AWAY, which is everything
+// after its own last message.
+func (w *MentionWatcher) threadContext(m coord.ChannelMessage, mem *coord.ThreadSession) string {
+	if m.ThreadRoot == "" {
+		return "" // a line that starts a thread has nothing behind it
+	}
+	thread, err := w.deps.Coord.ThreadMessages(m.ThreadRoot)
+	if err != nil || len(thread) <= 1 {
+		return ""
+	}
+
+	newHere := mem.Turns == 0
+	from := 0
+	if !newHere {
+		for i := len(thread) - 1; i >= 0; i-- {
+			if thread[i].AuthorKind == coord.MemberAgent && thread[i].AuthorID == w.deps.AgentID {
+				from = i + 1
+				break
+			}
+		}
+	}
+
+	var lines []string
+	for _, t := range thread[from:] {
+		if t.ID == m.ID {
+			continue // it is quoted on its own below
+		}
+		who := t.AuthorID
+		if t.AuthorKind == coord.MemberUser {
+			who = "the owner"
+		}
+		lines = append(lines, fmt.Sprintf("**%s:** %s", who, truncateRunes(strings.TrimSpace(t.Body), MaxThreadMessageRunes)))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	// A long thread is trimmed from the FRONT: the oldest messages are the
+	// ones a reader can most afford to lose, and dropping the newest would
+	// hide the turn this one is answering.
+	dropped := 0
+	for total(lines) > MaxThreadContextRunes && len(lines) > 1 {
+		lines = lines[1:]
+		dropped++
+	}
+
+	var b strings.Builder
+	if newHere {
+		b.WriteString("## The conversation you have just been brought into\n\n" +
+			"You have not spoken here before, so this is all of it. Read it before answering: " +
+			"the question below assumes it.\n\n")
+	} else {
+		b.WriteString("## What was said while you were away\n\n" +
+			"You remember your own side of this thread. These are the messages since your last one.\n\n")
+	}
+	if dropped > 0 {
+		fmt.Fprintf(&b, "_(%d earlier message(s) omitted for length)_\n\n", dropped)
+	}
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteString("\n\n")
+	}
+	return b.String()
+}
+
+func total(lines []string) int {
+	n := 0
+	for _, l := range lines {
+		n += len([]rune(l))
+	}
+	return n
+}
+
+func truncateRunes(s string, n int) string {
+	if r := []rune(s); len(r) > n {
+		return string(r[:n-1]) + "…"
+	}
+	return s
 }
 
 // replySink collects a turn's text. A channel has no stream to write to: the

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -353,3 +353,108 @@ func TestAddressingNobodyWakesNobody(t *testing.T) {
 		t.Fatal("a line addressed to nobody woke an agent")
 	}
 }
+
+// TestAnAgentBroughtIntoAThreadGetsAllOfIt is the case that matters when you
+// switch who you are talking to mid-conversation: the second agent has no
+// session for this thread, so the prompt is the only thing it will ever know
+// about it.
+func TestAnAgentBroughtIntoAThreadGetsAllOfIt(t *testing.T) {
+	turn := &recordingTurn{reply: "đã đọc", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw tổng hợp kinh tế VN 3 tháng qua",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The first agent works in the thread. Its analysis is long — the thing
+	// the old 400-rune cut used to destroy.
+	longAnswer := "GDP quý gần nhất tăng 6.9%. " + strings.Repeat("Chi tiết từng ngành và nguồn số liệu. ", 30)
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw", Body: longAnswer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now the owner switches to the other agent, in the same thread.
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body:   "bạn thấy sao?",
+		Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if turn.count() != 1 {
+		t.Fatalf("the newly named agent did not answer (%d turns)", turn.count())
+	}
+	p := turn.prompts[0]
+	// It must see the question that started the thread...
+	if !strings.Contains(p, "tổng hợp kinh tế VN 3 tháng qua") {
+		t.Error("the thread's opening question is missing from the prompt")
+	}
+	// ...and its colleague's answer, not a truncated stub of it.
+	if !strings.Contains(p, "GDP quý gần nhất tăng 6.9%") {
+		t.Error("the other agent's answer is missing")
+	}
+	if !strings.Contains(p, longAnswer[len(longAnswer)-40:]) {
+		t.Error("the other agent's answer was cut off — a premise the question depends on")
+	}
+	// And it is told plainly that it is new here.
+	if !strings.Contains(p, "not spoken here before") {
+		t.Errorf("the prompt does not say it is new to the thread:\n%s", p)
+	}
+}
+
+// An agent that has spoken here resumes its own session, so it needs what
+// happened while it was away — not the whole thread pasted at it again.
+func TestAReturningAgentGetsOnlyWhatItMissed(t *testing.T) {
+	turn := &recordingTurn{reply: "ok", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+	w := NewMentionWatcher(deps)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@bomclaw2 câu hỏi mở đầu", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.sweep(context.Background()) // bomclaw2 answers once, into the thread
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID, AuthorID: "bomclaw",
+		Body: "một đồng nghiệp bổ sung dữ kiện mới",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID, Body: "còn giờ thì sao?",
+		Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	w.sweep(context.Background())
+
+	if turn.count() != 2 {
+		t.Fatalf("expected two turns, got %d", turn.count())
+	}
+	p := turn.prompts[1]
+	if !strings.Contains(p, "while you were away") {
+		t.Errorf("a returning agent was treated as new:\n%s", p)
+	}
+	if !strings.Contains(p, "một đồng nghiệp bổ sung dữ kiện mới") {
+		t.Error("what happened while it was away is missing")
+	}
+	// Its own earlier line is not pasted back at it: it resumes and remembers.
+	if strings.Count(p, "câu hỏi mở đầu") > 0 {
+		t.Error("the thread was replayed to an agent that already remembers it")
+	}
+}


### PR DESCRIPTION
Hai thay đổi chỉ có nghĩa khi đi cùng nhau.

## 1. Chọn đúng một agent để nói chuyện

Bỏ `to: everyone`. Một tin nhắn gửi cho cả phòng là tin **không ai trả lời**, còn một thread mà ba agent cùng trả lời là **cùng một câu hỏi được hỏi ba lần** — đúng cảnh sáng nay.

## 2. Đổi agent giữa thread giờ mới thật sự dùng được

Đó mới là lý do có nút đổi.

Một agent **lần đầu** bị gọi vào thread thì **không có session CLI nào** cho thread đó — prompt là **thứ duy nhất** nó sẽ từng biết về cuộc nói chuyện. Giờ nó nhận **toàn bộ**, mỗi tin nhắn được `4000` rune thay vì `400`.

Con số cũ không phải chi tiết vặt: đưa cho một agent câu *"@bạn thấy sao?"* kèm **bốn trăm ký tự** phân tích của đồng nghiệp bị cắt ngang câu chính là cách khiến nó tự tin trả lời một câu hỏi không ai hỏi.

Agent **đã nói trong thread** thì ngược lại: nó resume session của chính nó và nhớ phần của mình, nên nó được đưa **những gì xảy ra lúc nó vắng mặt**. Dán lại cả thread cho nó vừa không rẻ vừa không sáng tỏ hơn.

Thread quá dài thì **cắt từ đầu**: tin cũ nhất là thứ người đọc chịu mất được, còn bỏ tin mới nhất sẽ giấu mất chính lượt đang được trả lời.

## Test

- `TestAnAgentBroughtIntoAThreadGetsAllOfIt` — agent thứ hai thấy **câu hỏi mở thread** và **trọn vẹn** câu trả lời dài của đồng nghiệp (kiểm tra cả 40 ký tự cuối, tức không bị cắt), và được nói rõ là nó mới vào
- `TestAReturningAgentGetsOnlyWhatItMissed` — agent quay lại nhận đúng phần vắng mặt, và **không** bị dán lại lời của chính nó

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)