### PR TITLE
feat(channel): show the work as it happens, and say who else is here

### DIFF
--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -742,6 +742,48 @@ func (db *DB) SaveThreadSession(threadKey, agentID, provider, sessionID string) 
 	return nil
 }
 
+// UpdateMessageBody rewrites a message in place.
+//
+// It exists for one thing: an agent working on an answer puts a line in the
+// thread saying what it is doing, and that line becomes the answer when the
+// answer arrives. Posting progress as separate messages would leave a room
+// full of "I am reading the log" under every real reply — the progress is
+// interesting while it is happening and noise the moment it is not.
+//
+// created_at is deliberately left alone. The message keeps its place in the
+// thread: it was said when it was said, and a reply that jumped to the bottom
+// on every edit would reorder a conversation as it was being read.
+func (db *DB) UpdateMessageBody(id, body string) error {
+	res, err := db.conn.Exec(`UPDATE channel_messages SET body = ? WHERE id = ?`, body, id)
+	if err != nil {
+		return fmt.Errorf("update %s: %w", id, err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("message %s: no such message", id)
+	}
+	return nil
+}
+
+// DeleteMessage removes a message and the mentions that pointed at it.
+//
+// Only for a progress line whose turn produced nothing: leaving "working on
+// it…" in a thread forever is worse than never having said it. Real messages
+// are not deleted — a room where things vanish cannot be read back.
+func (db *DB) DeleteMessage(id string) error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("delete %s: %w", id, err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`DELETE FROM channel_mentions WHERE message_id = ?`, id); err != nil {
+		return fmt.Errorf("delete mentions of %s: %w", id, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM channel_messages WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete %s: %w", id, err)
+	}
+	return tx.Commit()
+}
+
 func (db *DB) getMessage(id string) (*ChannelMessage, error) {
 	row := db.conn.QueryRow(`SELECT id, channel_id, thread_root, author_kind, author_id, body, task_id, created_at
 		FROM channel_messages WHERE id = ?`, id)

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -199,29 +199,70 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 	turnCtx, cancel := context.WithTimeout(ctx, mentionTurnTimeout)
 	defer cancel()
 
+	// Build the prompt BEFORE announcing anything. The progress line is a
+	// message from this agent, so posting it first would make the thread look
+	// as though this agent had just spoken — and "what was said while you were
+	// away" would come back empty every time. A test caught exactly that.
+	prompt := w.prompt(m, mem, key)
+
+	// Say something before doing anything. A turn that reads six files takes
+	// long enough that a silent thread is indistinguishable from a broken one,
+	// and the person watching has no way to tell which. This line is a real
+	// message in the thread, and it becomes the answer when the answer exists
+	// — progress is worth seeing while it happens and noise the moment it
+	// stops, so it is edited rather than added to.
+	progress, _, err := w.deps.Coord.PostMessage(coord.NewChannelMessage{
+		ChannelID: m.ChannelID, ThreadRoot: key,
+		AuthorKind: coord.MemberAgent, AuthorID: w.deps.AgentID,
+		Body: workingLine(nil, "", time.Time{}),
+	})
+	if err != nil {
+		log.Printf("mentions: could not open a progress line: %v", err)
+		progress = nil // the turn still runs; it just runs unseen
+	}
+
 	sink := &replySink{}
+	if progress != nil {
+		sink.onProgress = func(tools []string, partial string, since time.Time) {
+			if err := w.deps.Coord.UpdateMessageBody(progress.ID, workingLine(tools, partial, since)); err != nil {
+				log.Printf("mentions: progress update: %v", err)
+			}
+		}
+	}
+
 	sess.MarkRunning("channel: " + truncateLine(m.Body, 40))
 	w.live.Store(m.ID, sess)
-	_, err = w.deps.Turn.RunTurn(turnCtx, sess, sess.ChatID, w.model(), w.prompt(m, mem, key), sink)
+	_, err = w.deps.Turn.RunTurn(turnCtx, sess, sess.ChatID, w.model(), prompt, sink)
 	sess.MarkIdle()
 	w.live.Delete(m.ID)
 	if err != nil {
 		log.Printf("mentions: turn for %s: %v", m.ID, err)
+		w.finishProgress(progress, "⚠️ lượt này hỏng giữa chừng: "+truncateLine(err.Error(), 200))
 		clear("")
 		return
 	}
 
 	reply := strings.TrimSpace(sink.Text())
 	if reply == "" {
+		// Nothing to say, so nothing should be left saying it is thinking.
+		w.finishProgress(progress, "")
 		clear("turn produced nothing to say")
 		return
 	}
 
-	// The reply belongs where the mention was: in the thread if the mention was
-	// in one, otherwise starting a thread under it — so the main line stays
-	// readable and the exchange stays in one place. That place is the same key
-	// the session is kept under, which is what makes the next turn remember.
-	if _, wake, err := w.deps.Coord.PostMessage(coord.NewChannelMessage{
+	// The answer takes the place of the progress line: same message, same spot
+	// in the thread, so the conversation reads as one reply rather than a
+	// running commentary with the point at the end.
+	if progress != nil {
+		if err := w.deps.Coord.UpdateMessageBody(progress.ID, reply); err != nil {
+			log.Printf("mentions: could not land the reply in place: %v", err)
+		}
+		// Mentions inside the final text still have to ring: the progress line
+		// was written before the agent knew what it would say.
+		for _, who := range w.mentionedAgents(reply) {
+			NotifyAgents(w.deps.Coord, who, w.deps.AgentID, "about a mention in "+m.ChannelID)
+		}
+	} else if _, wake, err := w.deps.Coord.PostMessage(coord.NewChannelMessage{
 		ChannelID:  m.ChannelID,
 		ThreadRoot: key,
 		AuthorKind: coord.MemberAgent,
@@ -268,6 +309,7 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 	b.WriteString(w.threadContext(m, mem))
 
 	fmt.Fprintf(&b, "## %s said\n\n%s\n\n", m.AuthorID, strings.TrimSpace(m.Body))
+	b.WriteString(w.roster())
 
 	b.WriteString("## How to answer\n\n")
 	b.WriteString("Reply in plain prose. What you write is posted into that thread as your " +
@@ -281,6 +323,53 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 		"the task it produced, and the result is posted back here when it finishes, so nobody "+
 		"has to watch the board for an answer they asked for in a room. The board is for work; "+
 		"this room is for talking about it.\n", key)
+	return b.String()
+}
+
+// roster is who else is here, generated from the agents table.
+//
+// It used to be a paragraph in each agent's config, hand-written and copied.
+// That shape guarantees drift and duly delivered it: agent 1 and agent 2 were
+// still describing a two-agent machine months after the third arrived, and
+// agent 1 said so out loud in a thread — "bomclaw3 là agent nào thì em vẫn
+// chưa biết". A roster that has to be edited in three files when a fourth
+// agent appears is a roster that will be wrong.
+//
+// Generated, it cannot drift: the same table `bomclaw agents` reads, which
+// every gateway writes to at startup with its own provider and model.
+func (w *MentionWatcher) roster() string {
+	agents, err := w.deps.Coord.ListAgents()
+	if err != nil || len(agents) <= 1 {
+		return ""
+	}
+	var lines []string
+	for _, a := range agents {
+		if a.ID == w.deps.AgentID {
+			continue
+		}
+		state := "online"
+		if !a.Online {
+			state = "offline right now"
+		}
+		backend := a.Provider
+		if a.Model != "" {
+			backend = fmt.Sprintf("%s · %s", a.Provider, a.Model)
+		}
+		lines = append(lines, fmt.Sprintf("- **%s** — %s (%s)", a.ID, backend, state))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## The other agents on this machine\n\n")
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nThey run different backends, so they are good at different things and cost " +
+		"different amounts. Name one with @ to bring it into this thread — it arrives having read " +
+		"the conversation. Hand work over with `bomclaw task new --to <agent>`; " +
+		"`bomclaw agents` is the same list, live.\n\n")
 	return b.String()
 }
 
@@ -375,17 +464,70 @@ func truncateRunes(s string, n int) string {
 	return s
 }
 
-// replySink collects a turn's text. A channel has no stream to write to: the
-// reply is one message, posted when the turn is done.
+// replySink collects a turn's text and, if the caller asked for one, reports
+// progress as it goes.
+//
+// Throttled on purpose. The interesting thing about a long turn is WHICH tools
+// it is reaching for, and that changes on the order of seconds; writing the
+// room a new line per token would cost a database write per token to tell the
+// reader something they cannot read that fast anyway.
 type replySink struct {
-	mu sync.Mutex
-	b  strings.Builder
+	mu      sync.Mutex
+	b       strings.Builder
+	tools   []string
+	started time.Time
+	last    time.Time
+
+	// onProgress is called with the tools used so far and the reply as it
+	// stands. Nil when nobody is watching.
+	onProgress func(tools []string, partial string, since time.Time)
 }
+
+const progressEvery = 2 * time.Second
 
 func (r *replySink) Write(chunk string) {
 	r.mu.Lock()
 	r.b.WriteString(chunk)
 	r.mu.Unlock()
+	r.report(false)
+}
+
+// NoteTool is the part worth watching: "reading the log" says more about what
+// a turn is doing than the half-sentence it has written so far, so a new tool
+// always reports immediately rather than waiting out the interval.
+func (r *replySink) NoteTool(label string) {
+	if label == "" {
+		return
+	}
+	r.mu.Lock()
+	if len(r.tools) == 0 || r.tools[len(r.tools)-1] != label {
+		r.tools = append(r.tools, label)
+	}
+	r.mu.Unlock()
+	r.report(true)
+}
+
+func (r *replySink) report(now bool) {
+	r.mu.Lock()
+	if r.onProgress == nil {
+		r.mu.Unlock()
+		return
+	}
+	if r.started.IsZero() {
+		r.started = time.Now()
+	}
+	if !now && time.Since(r.last) < progressEvery {
+		r.mu.Unlock()
+		return
+	}
+	r.last = time.Now()
+	tools := append([]string(nil), r.tools...)
+	partial := r.b.String()
+	started := r.started
+	fn := r.onProgress
+	r.mu.Unlock()
+
+	fn(tools, partial, started)
 }
 
 func (r *replySink) Text() string {
@@ -394,10 +536,70 @@ func (r *replySink) Text() string {
 	return r.b.String()
 }
 
-func (r *replySink) NoteTool(string)          {}
 func (r *replySink) Flush()                   {}
 func (r *replySink) SendPhoto(string, string) {}
 func (r *replySink) Finalize()                {}
+
+// workingLine is what the room sees while the agent is still working.
+func workingLine(tools []string, partial string, since time.Time) string {
+	var b strings.Builder
+	b.WriteString("⏳ _đang làm_")
+	if !since.IsZero() {
+		fmt.Fprintf(&b, " · %s", time.Since(since).Round(time.Second))
+	}
+	if len(tools) > 0 {
+		// The last few, newest last: what it is doing now matters more than
+		// what it did first, and the whole list gets long on a real task.
+		from := 0
+		if len(tools) > 5 {
+			from = len(tools) - 5
+		}
+		fmt.Fprintf(&b, " · %s", strings.Join(tools[from:], " → "))
+	}
+	if p := strings.TrimSpace(partial); p != "" {
+		b.WriteString("\n\n")
+		b.WriteString(truncateRunes(p, 600))
+	}
+	return b.String()
+}
+
+// finishProgress replaces the progress line with its final form, or removes it
+// when there is nothing to replace it with. A thread must never be left with
+// an agent that is permanently about to say something.
+func (w *MentionWatcher) finishProgress(progress *coord.ChannelMessage, body string) {
+	if progress == nil {
+		return
+	}
+	if strings.TrimSpace(body) == "" {
+		if err := w.deps.Coord.DeleteMessage(progress.ID); err != nil {
+			log.Printf("mentions: could not remove the progress line: %v", err)
+		}
+		return
+	}
+	if err := w.deps.Coord.UpdateMessageBody(progress.ID, body); err != nil {
+		log.Printf("mentions: could not close the progress line: %v", err)
+	}
+}
+
+// mentionedAgents finds the peers named in a finished reply. The progress line
+// was posted before the agent knew what it would write, so its @ names were
+// not there to be resolved at post time.
+func (w *MentionWatcher) mentionedAgents(body string) []string {
+	agents, err := w.deps.Coord.ListAgents()
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, a := range agents {
+		if a.ID == w.deps.AgentID {
+			continue
+		}
+		if strings.Contains(body, "@"+a.ID) {
+			out = append(out, a.ID)
+		}
+	}
+	return out
+}
 
 func truncateLine(s string, n int) string {
 	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -25,10 +25,17 @@ type recordingTurn struct {
 	resumed  []string
 	reply    string
 	newID    string
+
+	// duringTurn runs against the sink before the reply is written, so a test
+	// can watch what the room sees while the turn is still going.
+	duringTurn func(TurnSink)
 }
 
 func (r *recordingTurn) RunTurn(ctx context.Context, sess *session.Session, chatID int64,
 	modelID, userText string, sink TurnSink) (*execution.RunResult, error) {
+	if r.duringTurn != nil {
+		r.duringTurn(sink)
+	}
 	r.mu.Lock()
 	r.calls++
 	r.prompts = append(r.prompts, userText)
@@ -456,5 +463,143 @@ func TestAReturningAgentGetsOnlyWhatItMissed(t *testing.T) {
 	// Its own earlier line is not pasted back at it: it resumes and remembers.
 	if strings.Count(p, "câu hỏi mở đầu") > 0 {
 		t.Error("the thread was replayed to an agent that already remembers it")
+	}
+}
+
+// TestTheRoomSeesWorkInProgress: a turn that reads six files takes long enough
+// that a silent thread is indistinguishable from a broken one. The progress
+// line is what tells them apart — and it must become the answer, not sit above
+// it, or every reply ends up with a running commentary attached.
+func TestTheRoomSeesWorkInProgress(t *testing.T) {
+	var duringBody string
+	turn := &recordingTurn{reply: "xong rồi, đây là kết quả", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "xem hộ log", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	turn.duringTurn = func(sink TurnSink) {
+		// A tool reports immediately: which tool it reached for says more than
+		// the half-sentence it has written.
+		sink.NoteTool("Read")
+		sink.NoteTool("Bash")
+		thread, err := cdb.ThreadMessages(root.ID)
+		if err != nil {
+			t.Errorf("thread: %v", err)
+			return
+		}
+		for _, m := range thread {
+			if m.AuthorID == "bomclaw2" {
+				duringBody = m.Body
+			}
+		}
+	}
+
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if duringBody == "" {
+		t.Fatal("the room saw nothing while the agent worked")
+	}
+	if !strings.Contains(duringBody, "đang làm") {
+		t.Errorf("progress line does not say it is working: %q", duringBody)
+	}
+	for _, tool := range []string{"Read", "Bash"} {
+		if !strings.Contains(duringBody, tool) {
+			t.Errorf("progress line does not name %s: %q", tool, duringBody)
+		}
+	}
+
+	// And when it is done, the progress is gone: one message, holding the
+	// answer, in the place the progress line had.
+	thread, err := cdb.ThreadMessages(root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mine []coord.ChannelMessage
+	for _, m := range thread {
+		if m.AuthorID == "bomclaw2" {
+			mine = append(mine, m)
+		}
+	}
+	if len(mine) != 1 {
+		t.Fatalf("expected one message from the agent, got %d — progress was left behind", len(mine))
+	}
+	if mine[0].Body != "xong rồi, đây là kết quả" {
+		t.Fatalf("the answer did not replace the progress: %q", mine[0].Body)
+	}
+	if strings.Contains(mine[0].Body, "đang làm") {
+		t.Error("the finished reply still carries progress text")
+	}
+}
+
+// A turn that produces nothing must not leave an agent permanently about to
+// speak.
+func TestAnEmptyTurnLeavesNoProgressBehind(t *testing.T) {
+	turn := &recordingTurn{reply: "   "}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "hỏi gì đó", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	thread, err := cdb.ThreadMessages(root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range thread {
+		if m.AuthorID == "bomclaw2" {
+			t.Fatalf("a turn with nothing to say left %q in the thread", m.Body)
+		}
+	}
+}
+
+// TestThePromptNamesThePeers: the roster used to be a paragraph in each config,
+// hand-copied — and it drifted exactly as that shape guarantees. Agent 1 said
+// so out loud in a thread: "bomclaw3 là agent nào thì em vẫn chưa biết".
+// Generated from the table that every gateway writes at startup, it cannot.
+func TestThePromptNamesThePeers(t *testing.T) {
+	turn := &recordingTurn{reply: "ok", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+	// A third agent appears, and nobody edits a config file.
+	if err := cdb.RegisterAgent(coord.Agent{
+		ID: "bomclaw3", DisplayName: "Agent 3", Provider: "opencode",
+		Model: "opencode/muse-spark-1.3-contributor-free", WSAddr: "ws://127.0.0.1:0/ws",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "ai giúp mình việc này", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if turn.count() != 1 {
+		t.Fatalf("expected one turn, got %d", turn.count())
+	}
+	p := turn.prompts[0]
+	for _, want := range []string{"bomclaw", "bomclaw3", "opencode", "muse-spark"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("the roster does not mention %q:\n%s", want, p)
+		}
+	}
+	// And it does not introduce the agent to itself.
+	if strings.Contains(p, "**bomclaw2** —") {
+		t.Error("the agent was listed among its own peers")
 	}
 }

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -362,7 +362,7 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	// this task while nobody was running it, both belong in front of the model.
 	children, _ := r.db.Children(task.ID)
 	inbox := r.taskMail(task.ID)
-	prompt := taskPrompt(task, r.cfg.Timeout, resumed, children, inbox)
+	prompt := taskPrompt(task, r.cfg.Timeout, resumed, children, inbox, r.peers())
 	span.SetInputs(prompt)
 	if tid := span.TraceID(); tid != "" {
 		if err := r.db.AttachTrace(task.ID, tid); err != nil {
@@ -590,7 +590,25 @@ func (r *Runner) taskMail(taskID string) []coord.Message {
 	return mine
 }
 
-func taskPrompt(t *coord.Task, budget time.Duration, resumed bool, children []coord.Task, inbox []coord.Message) string {
+// peers is who else could take work, read from the agents table rather than
+// from a paragraph someone remembered to update. An agent that does not know a
+// colleague exists cannot hand anything to it — which is how a machine ends up
+// running three agents and using two.
+func (r *Runner) peers() []coord.Agent {
+	all, err := r.db.ListAgents()
+	if err != nil {
+		return nil
+	}
+	out := make([]coord.Agent, 0, len(all))
+	for _, a := range all {
+		if a.ID != r.cfg.AgentID {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func taskPrompt(t *coord.Task, budget time.Duration, resumed bool, children []coord.Task, inbox []coord.Message, peers []coord.Agent) string {
 	var b strings.Builder
 	if t.Continuations > 0 || resumed {
 		fmt.Fprintf(&b, "You are continuing a task from the shared queue (run %d).\n\n", t.Continuations+1)
@@ -634,6 +652,23 @@ func taskPrompt(t *coord.Task, budget time.Duration, resumed bool, children []co
 			}
 		}
 	}
+	if len(peers) > 0 {
+		b.WriteString("\n## The other agents you can hand work to\n\n")
+		for _, p := range peers {
+			state := "online"
+			if !p.Online {
+				state = "offline right now"
+			}
+			backend := p.Provider
+			if p.Model != "" {
+				backend = fmt.Sprintf("%s · %s", p.Provider, p.Model)
+			}
+			fmt.Fprintf(&b, "- **%s** — %s (%s)\n", p.ID, backend, state)
+		}
+		b.WriteString("\nDifferent backends, so different strengths and different costs. " +
+			"`bomclaw task new --to <agent>` hands a piece over; omit --to and any of them may take it.\n")
+	}
+
 	if len(inbox) > 0 {
 		b.WriteString("\n## Messages about this task\n\n")
 		for _, m := range inbox {


### PR DESCRIPTION
Hai thứ căn phòng không nhìn thấy được.

## 1. Agent đang làm gì

Một lượt đọc sáu file mất đủ lâu để một thread im lặng **không phân biệt được với một thread hỏng** — và người ngồi nhìn vừa trải qua đúng một buổi sáng mà nó hỏng thật.

Nên agent post một dòng **trước khi** bắt đầu rồi **sửa tại chỗ**: thời gian đã trôi, vài tool gần nhất, và phần trả lời đang có.

**Sửa chứ không thêm**, và câu trả lời cuối **chiếm chỗ** dòng đó. Progress đáng xem lúc đang diễn ra và là rác ngay khi dừng; post thành tin riêng sẽ để lại *đang đọc log* nằm dưới mọi câu trả lời thật, vĩnh viễn. Lượt không sinh ra gì thì **xoá** dòng đó — thread không bao giờ được để lại một agent vĩnh viễn sắp nói.

Throttle 2 giây, **trừ khi có tool mới** thì báo ngay: nó vừa với tới tool nào nói lên nhiều hơn nửa câu nó vừa viết, còn ghi DB mỗi token là để nói một thứ người đọc không đọc kịp.

## 2. Ai khác đang ở đây

Roster là đoạn văn **chép tay trong config từng agent**, và đã lệch đúng như hình dạng đó bảo đảm. Agent 1 tự nói ra trong thread: *bomclaw3 là agent nào thì em vẫn chưa biết.*

Giờ nó **sinh ra từ bảng agents** mà mọi gateway ghi lúc khởi động — cả prompt kênh lẫn prompt task. Thêm agent thứ tư không phải sửa file nào.

## Một tương tác giữa hai thứ, do test bắt

Dòng progress **là tin của chính agent đó**. Post trước khi dựng prompt khiến agent quay lại thread thấy phần *những gì xảy ra lúc bạn vắng mặt* **rỗng** — nó tưởng nó vừa nói xong. Prompt giờ dựng trước, progress post sau.

## Test

- `TestTheRoomSeesWorkInProgress` — giữa lượt có dòng đang-làm kèm tên tool; xong lượt agent chỉ còn **đúng một** tin và đó là câu trả lời
- `TestAnEmptyTurnLeavesNoProgressBehind`
- `TestThePromptNamesThePeers` — agent thứ ba xuất hiện, không sửa config nào, prompt biết ngay
- `TestAReturningAgentGetsOnlyWhatItMissed` — chính test bắt lỗi thứ tự

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)