### PR TITLE
feat(channel): what the work produced is attached to the thread, and reviewable

### DIFF
--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { Channel, ChannelMessage } from './types'
+import type { Artifact, Channel, ChannelMessage } from './types'
 import { ago, clock } from './format'
 
 type Call = (method: string, params?: any) => Promise<any>
@@ -30,6 +30,9 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
   const [to, setTo] = useState<string>('')
   useEffect(() => { setTo(t => t || agents[0] || '') }, [agents])
   const [err, setErr] = useState<string | null>(null)
+  // What this conversation has produced. A path named in prose is findable for
+  // about a day; these are findable by id and survive the file moving.
+  const [files, setFiles] = useState<Artifact[]>([])
   const sending = useRef(false)
   const bottom = useRef<HTMLDivElement>(null)
 
@@ -57,8 +60,13 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
 
   const loadThread = useCallback(async (rootID: string) => {
     try {
-      setThread((await call('channels.messages', { thread_root: rootID })) || [])
+      const msgs: ChannelMessage[] = (await call('channels.messages', { thread_root: rootID })) || []
+      setThread(msgs)
       setThreadRoot(rootID)
+      // Only a thread bound to a task can have produced anything; that binding
+      // is what #134 put on the root message.
+      const taskID = msgs[0]?.task_id
+      setFiles(taskID ? ((await call('artifacts.list', { task_id: taskID, tree: true })) || []) : [])
     } catch (e: any) {
       setErr(String(e?.message ?? e))
     }
@@ -141,6 +149,22 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
     }
   }
 
+  // Asking for a review is an ordinary message in the thread, addressed to the
+  // agent you are talking to — not a special mode. The agent already sees the
+  // artifact list in its prompt, so the id is all it needs.
+  const reviewFile = async (a: Artifact) => {
+    if (!to || !threadRoot || !active) return
+    try {
+      await call('channels.post', {
+        channel_id: active, thread_root: threadRoot, notify: [to],
+        body: `Xem lại giúp mình artifact \`${a.id}\` (${a.title}) — đọc nội dung rồi nói thẳng chỗ nào sai, thiếu, hoặc đáng ngờ.`,
+      })
+      await loadThread(threadRoot)
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    }
+  }
+
   const ordered = useMemo(() => [...msgs].reverse(), [msgs])
   const current = channels.find(c => c.id === active)
 
@@ -210,6 +234,18 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
               </div>
             ))}
           </div>
+          {files.length > 0 && (
+            <div className="border-t border-gray-800 px-3 py-2 space-y-1">
+              <div className="text-[11px] uppercase tracking-wide text-gray-500">Files</div>
+              {files.map(a => (
+                <FileRow
+                  key={a.id} a={a} call={call}
+                  onReview={() => reviewFile(a)}
+                  reviewer={to}
+                />
+              ))}
+            </div>
+          )}
           {/* Typing happens where you are reading. */}
           <Composer
             value={threadBody} onChange={setThreadBody} onSend={() => post(true)}
@@ -343,6 +379,53 @@ function Composer({ value, onChange, onSend, to, setTo, agents, placeholder }: {
           Send
         </button>
       </div>
+    </div>
+  )
+}
+
+// FileRow is one piece of work product: open it, or ask an agent about it.
+function FileRow({ a, call, onReview, reviewer }: {
+  a: Artifact; call: Call; onReview: () => void; reviewer: string
+}) {
+  const [busy, setBusy] = useState(false)
+
+  // Opened in a tab rather than rendered here: these are reports and patches,
+  // and the thread panel is not the place to read one.
+  const open = async () => {
+    setBusy(true)
+    try {
+      if (a.kind === 'link' && a.url) {
+        window.open(a.url, '_blank', 'noopener')
+        return
+      }
+      const r = await call('artifacts.get', { id: a.id })
+      const body: string = r?.content ?? ''
+      const type = a.content_type || (a.title.endsWith('.html') ? 'text/html' : 'text/plain')
+      const blob = new Blob([body], { type: type + ';charset=utf-8' })
+      const url = URL.createObjectURL(blob)
+      window.open(url, '_blank', 'noopener')
+      setTimeout(() => URL.revokeObjectURL(url), 60_000)
+    } catch (e) {
+      alert(String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <button onClick={open} disabled={busy} className="min-w-0 flex-1 text-left truncate text-sky-300 hover:underline">
+        {a.title}
+      </button>
+      <span className="text-gray-600 shrink-0">{a.kind}</span>
+      <button
+        onClick={onReview}
+        disabled={!reviewer}
+        title={reviewer ? `Nhờ ${reviewer} xem lại` : 'Chọn một agent trước'}
+        className="shrink-0 px-1.5 py-0.5 rounded ring-1 ring-gray-700 text-gray-400 hover:text-sky-300 hover:ring-sky-500/40 disabled:opacity-40"
+      >
+        review
+      </button>
     </div>
   )
 }

--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -784,6 +784,10 @@ func (db *DB) DeleteMessage(id string) error {
 	return tx.Commit()
 }
 
+// GetMessage is getMessage for callers outside this package: the gateway needs
+// a thread's root to find the task, and through it what the work produced.
+func (db *DB) GetMessage(id string) (*ChannelMessage, error) { return db.getMessage(id) }
+
 func (db *DB) getMessage(id string) (*ChannelMessage, error) {
 	row := db.conn.QueryRow(`SELECT id, channel_id, thread_root, author_kind, author_id, body, task_id, created_at
 		FROM channel_messages WHERE id = ?`, id)

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -309,6 +309,7 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 	b.WriteString(w.threadContext(m, mem))
 
 	fmt.Fprintf(&b, "## %s said\n\n%s\n\n", m.AuthorID, strings.TrimSpace(m.Body))
+	b.WriteString(w.threadArtifacts(m))
 	b.WriteString(w.roster())
 
 	b.WriteString("## How to answer\n\n")
@@ -317,12 +318,55 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 		"about what you are about to do.\n")
 	b.WriteString("Name an agent with @ only when you actually need it to act: @ is a doorbell " +
 		"and wakes that agent.\n")
+	fmt.Fprintf(&b, "Anything you produce that outlives this message — a report, a patch, a "+
+		"page — attach it with `bomclaw artifact put --task <task> --file <path> --title <what it is>`. "+
+		"A path in prose is findable for about a day; an artifact is findable by id, survives the file "+
+		"moving, and is what the next agent asked to review it will open.\n")
 	fmt.Fprintf(&b, "If this asks for real work — something with steps, or longer than a few "+
 		"minutes — say so briefly and open a task for it with `bomclaw task new --thread %s`. "+
 		"The --thread is what keeps the work attached to this conversation: the thread shows "+
 		"the task it produced, and the result is posted back here when it finishes, so nobody "+
 		"has to watch the board for an answer they asked for in a room. The board is for work; "+
 		"this room is for talking about it.\n", key)
+	return b.String()
+}
+
+// threadArtifacts lists what this conversation has already produced.
+//
+// Without it an agent asked to "review the report" has a filename at best and
+// a guess at worst, and a second agent brought in later has neither. With it,
+// the work product of the thread is addressable by id: the same id the
+// producer wrote it under, readable with one command, and stable even after
+// somebody moves the file.
+func (w *MentionWatcher) threadArtifacts(m coord.ChannelMessage) string {
+	root := m.ThreadRoot
+	if root == "" {
+		root = m.ID
+	}
+	rootMsg, err := w.deps.Coord.GetMessage(root)
+	if err != nil || rootMsg.TaskID == "" {
+		return "" // a thread with no task behind it has produced nothing yet
+	}
+	task, err := w.deps.Coord.GetTask(rootMsg.TaskID)
+	if err != nil {
+		return ""
+	}
+	arts, err := w.deps.Coord.ContextArtifacts(task.ContextID)
+	if err != nil || len(arts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## What this conversation has produced\n\n")
+	for _, a := range arts {
+		fmt.Fprintf(&b, "- `%s` — %s, %s", a.ID, a.Kind, a.Title)
+		if a.Bytes > 0 {
+			fmt.Fprintf(&b, " (%d bytes)", a.Bytes)
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\nRead one with `bomclaw artifact get <id>` — by id, not by path, so it still " +
+		"resolves after the file moves. If you are asked to review one, read it first and say what " +
+		"is wrong with it; agreeing with a file you have not opened is worse than not answering.\n\n")
 	return b.String()
 }
 

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -603,3 +603,75 @@ func TestThePromptNamesThePeers(t *testing.T) {
 		t.Error("the agent was listed among its own peers")
 	}
 }
+
+// TestTheThreadsOutputIsInThePrompt: an agent asked to review "the report" has
+// a filename at best and a guess at worst. The artifact index gives it an id
+// that survives the file moving, and the next agent brought in gets the same.
+func TestTheThreadsOutputIsInThePrompt(t *testing.T) {
+	turn := &recordingTurn{reply: "đã xem", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "tổng hợp việc làm IT Đà Nẵng",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := cdb.CreateTask(coord.NewTask{CreatedBy: "bomclaw", Title: "tổng hợp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cdb.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	art, err := cdb.PutArtifact(coord.NewArtifact{
+		TaskID: task.ID, Kind: coord.ArtifactDocument, Title: "index.html",
+		Content: []byte("<html>báo cáo</html>"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, ThreadRoot: root.ID,
+		AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "review giúp mình", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	if turn.count() != 1 {
+		t.Fatalf("expected one turn, got %d", turn.count())
+	}
+	p := turn.prompts[0]
+	if !strings.Contains(p, art.ID) {
+		t.Errorf("the artifact id is not in the prompt:\n%s", p)
+	}
+	if !strings.Contains(p, "index.html") {
+		t.Error("the artifact title is missing")
+	}
+	if !strings.Contains(p, "artifact get") {
+		t.Error("the prompt does not say how to read it")
+	}
+}
+
+// A thread with no task behind it has produced nothing, and must not claim to.
+func TestAThreadWithNoTaskListsNoFiles(t *testing.T) {
+	turn := &recordingTurn{reply: "ok", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "chào", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+	if strings.Contains(turn.prompts[0], "has produced") {
+		t.Error("a thread with no work behind it listed files")
+	}
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -200,11 +200,33 @@ func (r *Reporter) reportToThread(t *coord.Task) {
 	if author == "" {
 		author = r.cfg.AgentID
 	}
+	body := Format(t) + r.artifactIndex(t)
 	if _, _, err := r.db.PostMessage(coord.NewChannelMessage{
-		ChannelID: channelID, ThreadRoot: rootID, AuthorID: author, Body: Format(t),
+		ChannelID: channelID, ThreadRoot: rootID, AuthorID: author, Body: body,
 	}); err != nil {
 		log.Printf("reporter: report %s into thread %s: %v", t.ID, rootID, err)
 	}
+}
+
+// artifactIndex lists what the task produced, by id.
+//
+// A result that says "the report is done" and stops leaves the reader to go
+// and find it. The ids are what make it findable later — from the thread, from
+// Telegram, and by the next agent asked to look at it.
+func (r *Reporter) artifactIndex(t *coord.Task) string {
+	arts, err := r.db.TaskArtifacts(t.ID)
+	if err != nil || len(arts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n📎 ")
+	for i, a := range arts {
+		if i > 0 {
+			b.WriteString(" · ")
+		}
+		fmt.Fprintf(&b, "`%s` %s", a.ID, a.Title)
+	}
+	return b.String()
 }
 
 // Format writes the line the owner sees.

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -311,3 +311,50 @@ func TestNoThreadNoPost(t *testing.T) {
 		t.Fatalf("a task with no conversation posted into one: %+v", line)
 	}
 }
+
+// TestTheReportNamesWhatItProduced: a result that says "the report is done"
+// and stops leaves the reader to go and find it. The ids are what make it
+// findable from the thread, from Telegram, and by the next agent asked to look.
+func TestTheReportNamesWhatItProduced(t *testing.T) {
+	db := openDB(t)
+	for _, id := range []string{"a1", "a2"} {
+		if err := db.RegisterAgent(coord.Agent{ID: id, DisplayName: id, WSAddr: "ws://127.0.0.1:0/ws"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "@a1 làm hộ cái báo cáo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := delegate(t, db, "làm báo cáo", coord.TaskCompleted, "xong")
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	art, err := db.PutArtifact(coord.NewArtifact{
+		TaskID: task.ID, Kind: coord.ArtifactDocument, Title: "index.html",
+		Content: []byte("<html>ok</html>"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got collector
+	r := New(db, Config{AgentID: "a2"})
+	r.SetNotify(got.add)
+	r.Tick()
+
+	thread, err := db.ThreadMessages(root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := thread[len(thread)-1].Body
+	if !strings.Contains(report, art.ID) {
+		t.Errorf("the report does not name the artifact id:\n%s", report)
+	}
+	if !strings.Contains(report, "index.html") {
+		t.Errorf("the report does not name the file:\n%s", report)
+	}
+}


### PR DESCRIPTION
Một agent làm xong báo cáo rồi nói chỗ nó để file:

`~/goterm-workspace/reports/da-nang-it-jobs-2026-09/index.html`

Một đường dẫn nằm trong văn xuôi thì tìm lại được **khoảng một ngày**. Nó không tìm được từ Telegram, không tìm được bởi agent kế tiếp được nhờ xem, và **không tìm được nữa** khi file bị dời.

## Artifact đã giải xong chuyện đó, chỉ thiếu mọi đường nối

Bytes trên đĩa, một hàng làm con trỏ, địa chỉ hoá bằng **id** — P4 đã có. Thứ thiếu là mọi kết nối với cuộc nói chuyện đã sinh ra nó.

**Agent được dặn đính kèm thay vì nêu đường dẫn**, kèm lý do. Prompt nói thẳng: path tìm được một ngày, artifact tìm được bằng id, sống sót khi file dời, và là thứ agent kế tiếp sẽ mở.

**Agent bị đánh thức thấy artifact của thread ngay trong prompt** — id, kind, title, size. Nên *"review cái báo cáo"* phân giải thành một thứ nó mở được, thay vì một cái tên file nó phải đoán.

**Báo cáo task về thread mang theo id.** Một kết quả nói *"báo cáo xong rồi"* rồi dừng là bắt người đọc đi tìm.

**Thread panel liệt kê file**, mở được trong tab mới, và có nút **review** cạnh mỗi cái.

## Review không phải một chế độ mới

Nó là một tin nhắn bình thường trong thread, gửi tới đúng agent anh đang nói chuyện. Agent đã có danh sách artifact trong prompt nên **id là đủ**.

Và prompt nói phần quan trọng nhất: **đọc trước khi trả lời** — đồng ý với một file mình chưa mở còn tệ hơn không trả lời.

## Test

- `TestTheThreadsOutputIsInThePrompt` — id, tên file, và cách đọc đều có trong prompt
- `TestAThreadWithNoTaskListsNoFiles` — thread chưa sinh ra gì thì không được nói là có
- `TestTheReportNamesWhatItProduced` — báo cáo về thread mang id

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)