### PR TITLE
feat(tasks): a running task says what it is doing, in the room and on the board

### DIFF
--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -111,6 +111,14 @@ function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask, onOpenTh
 
   useEffect(() => { load() }, [load])
 
+  // While something is running, the drawer is a live view and has to behave
+  // like one; opened on a finished task it stays still.
+  useEffect(() => {
+    if (!detail?.live) return
+    const t = setInterval(load, 3000)
+    return () => clearInterval(t)
+  }, [detail?.live, load])
+
   // Cancelling a parent cancels its unfinished children too — say so before
   // doing it, since those may be running on another agent right now.
   const openChildren = detail?.children?.filter(c => !['completed', 'failed', 'canceled', 'rejected'].includes(c.state)).length ?? 0
@@ -263,6 +271,42 @@ function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask, onOpenTh
                   </dd>
                 </div>
               </dl>
+
+              {/* A row saying "running" for four minutes tells you less than
+                  the log would. This is what it is actually doing. */}
+              {detail.live && (
+                <div className="rounded-md ring-1 ring-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-xs">
+                  <span className="text-amber-300">⏳ đang chạy</span>
+                  <span className="text-gray-500"> · {detail.live.agent}</span>
+                  {detail.live.last_tool && (
+                    <span className="text-gray-300 font-mono"> · {detail.live.last_tool}</span>
+                  )}
+                  {detail.live.tool_count > 0 && (
+                    <span className="text-gray-500"> · {detail.live.tool_count} tool calls</span>
+                  )}
+                  {detail.live.started_at && (
+                    <span className="text-gray-500"> · {ago(detail.live.started_at)}</span>
+                  )}
+                </div>
+              )}
+
+              {/* A row saying "running" for four minutes tells you less than
+                  the log would. This is what it is actually doing. */}
+              {detail.live && (
+                <div className="rounded-md ring-1 ring-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-xs">
+                  <span className="text-amber-300">⏳ đang chạy</span>
+                  <span className="text-gray-500"> · {detail.live.agent}</span>
+                  {detail.live.last_tool && (
+                    <span className="text-gray-300 font-mono"> · {detail.live.last_tool}</span>
+                  )}
+                  {detail.live.tool_count > 0 && (
+                    <span className="text-gray-500"> · {detail.live.tool_count} tool calls</span>
+                  )}
+                  {detail.live.started_at && (
+                    <span className="text-gray-500"> · {ago(detail.live.started_at)}</span>
+                  )}
+                </div>
+              )}
 
               {detail.thread_root && onOpenThread && (
                 <button

--- a/dashboard/src/admin/types.ts
+++ b/dashboard/src/admin/types.ts
@@ -134,7 +134,16 @@ export interface TaskDetail {
   children: Task[]
   context_count?: number
   context_cap?: number
-  thread_root?: string // the tasks it split off (`bomclaw task sub`); empty for a leaf
+  thread_root?: string // the conversation this work came out of, when it came from one
+
+  // What the run is doing right now, when one is running on this gateway. A
+  // board that says "running" for four minutes tells you less than the log.
+  live?: {
+    agent: string
+    last_tool?: string
+    tool_count: number
+    started_at?: string
+  }
 }
 
 export interface Message {

--- a/internal/gateway/admin.go
+++ b/internal/gateway/admin.go
@@ -143,6 +143,23 @@ type TaskDetail struct {
 	// The conversation this work came out of, when it came out of one, so the
 	// board has a way back to the room instead of being a dead end.
 	ThreadRoot string `json:"thread_root,omitempty"`
+
+	// Live is what the run is doing right now, when one is running HERE. The
+	// task_runs row only says a run is open; a board that shows "running 0s"
+	// for four minutes is telling you less than the log would.
+	//
+	// Empty when the run belongs to another gateway: this one can read the
+	// shared row but not the other's session, and inventing an answer is worse
+	// than admitting the board only sees its own work in this much detail.
+	Live *LiveRun `json:"live,omitempty"`
+}
+
+// LiveRun is the part of a running turn a person wants while they wait.
+type LiveRun struct {
+	Agent     string `json:"agent"`
+	LastTool  string `json:"last_tool,omitempty"`
+	ToolCount int    `json:"tool_count"`
+	StartedAt string `json:"started_at,omitempty"`
 }
 
 func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -177,10 +194,22 @@ func handleTaskGet(deps Deps, params json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	var live *LiveRun
+	if deps.Runs != nil {
+		for _, r := range deps.Runs() {
+			if r.TaskID == p.ID {
+				live = &LiveRun{
+					Agent: deps.AgentID, LastTool: r.LastTool,
+					ToolCount: r.ToolCount, StartedAt: r.StartedAt,
+				}
+				break
+			}
+		}
+	}
 	return json.Marshal(TaskDetail{
 		Task: task, Events: events, Runs: runs, Children: children,
 		ContextCount: inContext, ContextCap: deps.Coord.MaxTasksPerContext(),
-		ThreadRoot: threadRoot,
+		ThreadRoot: threadRoot, Live: live,
 	})
 }
 

--- a/internal/taskrunner/progress.go
+++ b/internal/taskrunner/progress.go
@@ -1,0 +1,145 @@
+package taskrunner
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+// Saying what a task is doing, in the room that asked for it.
+//
+// A task opened from a conversation runs for minutes and the thread shows
+// nothing until it is over. That is the same silence a channel turn had before
+// it started reporting progress — except worse, because a task is the long
+// kind of work, so the silence lasts longer and the person watching has more
+// reason to wonder whether anything is happening at all.
+//
+// One line per RUN, edited in place and removed when the run ends. Not kept
+// between runs on purpose: between runs nothing IS running, and a line that
+// still said "working" would be a lie the rest of the time. The report the
+// reporter posts when the task finishes is the permanent record; this is only
+// the window while it happens.
+const progressPrefix = "⏳ "
+
+// progressLine owns the message a run keeps updated.
+type progressLine struct {
+	db        *coord.DB
+	messageID string
+	channelID string
+	taskID    string
+	title     string
+	started   time.Time
+
+	mu    sync.Mutex
+	tools []string
+	last  time.Time
+}
+
+const progressEvery = 3 * time.Second
+
+// openProgress puts a line in the thread this task came from, if it came from
+// one. Nil when it did not, and every method below tolerates nil — a task
+// queued from the CLI or a schedule has no room to report into and must not
+// invent one.
+func openProgress(db *coord.DB, task *coord.Task) *progressLine {
+	if db == nil || task == nil {
+		return nil
+	}
+	rootID, channelID, err := db.TaskThread(task.ID)
+	if err != nil || rootID == "" {
+		return nil
+	}
+
+	// Sweep a line left behind by a run that died with the gateway. Without
+	// this, a crash leaves the room with an agent permanently about to finish.
+	if thread, err := db.ThreadMessages(rootID); err == nil {
+		for _, m := range thread {
+			if m.AuthorKind == coord.MemberAgent && strings.HasPrefix(m.Body, progressPrefix) &&
+				strings.Contains(m.Body, task.ID) {
+				if err := db.DeleteMessage(m.ID); err != nil {
+					log.Printf("taskrunner: stale progress line: %v", err)
+				}
+			}
+		}
+	}
+
+	p := &progressLine{
+		db: db, channelID: channelID, taskID: task.ID,
+		title: task.Title, started: time.Now(),
+	}
+	msg, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: channelID, ThreadRoot: rootID,
+		AuthorKind: coord.MemberAgent, AuthorID: task.ClaimedBy,
+		Body: p.body(),
+	})
+	if err != nil {
+		log.Printf("taskrunner: could not open a progress line: %v", err)
+		return nil
+	}
+	p.messageID = msg.ID
+	return p
+}
+
+// Tool records what the run just reached for and updates the room. A new tool
+// reports at once; that is the part worth watching, and it changes on the
+// order of seconds rather than tokens.
+func (p *progressLine) Tool(name string) {
+	if p == nil || name == "" {
+		return
+	}
+	p.mu.Lock()
+	if len(p.tools) == 0 || p.tools[len(p.tools)-1] != name {
+		p.tools = append(p.tools, name)
+	}
+	stale := time.Since(p.last) >= progressEvery
+	if stale {
+		p.last = time.Now()
+	}
+	body := p.bodyLocked()
+	p.mu.Unlock()
+
+	if !stale {
+		return
+	}
+	if err := p.db.UpdateMessageBody(p.messageID, body); err != nil {
+		log.Printf("taskrunner: progress update: %v", err)
+	}
+}
+
+// Close removes the line. The result belongs to the reporter, which posts it
+// when the task itself finishes rather than when one run of it does.
+func (p *progressLine) Close() {
+	if p == nil {
+		return
+	}
+	if err := p.db.DeleteMessage(p.messageID); err != nil {
+		log.Printf("taskrunner: could not close the progress line: %v", err)
+	}
+}
+
+func (p *progressLine) body() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.bodyLocked()
+}
+
+func (p *progressLine) bodyLocked() string {
+	var b strings.Builder
+	b.WriteString(progressPrefix)
+	fmt.Fprintf(&b, "_đang chạy_ `%s` · %s", p.taskID, time.Since(p.started).Round(time.Second))
+	if len(p.tools) > 0 {
+		from := 0
+		if len(p.tools) > 5 {
+			from = len(p.tools) - 5
+		}
+		fmt.Fprintf(&b, " · %s", strings.Join(p.tools[from:], " → "))
+	}
+	if t := strings.TrimSpace(p.title); t != "" {
+		fmt.Fprintf(&b, "\n\n%s", t)
+	}
+	return b.String()
+}

--- a/internal/taskrunner/progress_test.go
+++ b/internal/taskrunner/progress_test.go
@@ -1,0 +1,123 @@
+package taskrunner
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ngocp/goterm-control/internal/coord"
+)
+
+func progressDB(t *testing.T) *coord.DB {
+	t.Helper()
+	db, err := coord.Open(filepath.Join(t.TempDir(), "coord.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.RegisterAgent(coord.Agent{ID: "a1", DisplayName: "a1", WSAddr: "ws://127.0.0.1:0/ws"}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// A task that came from a conversation says what it is doing there. Four
+// minutes of silence in the room that asked is the same failure a channel turn
+// had before it reported progress — worse, because a task is the long kind of
+// work.
+func TestATaskFromAThreadSaysWhatItIsDoing(t *testing.T) {
+	db := progressDB(t)
+	root, _, err := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "nghiên cứu giúp mình",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "nghiên cứu crypto", AssignedTo: "a1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := db.ClaimTask("a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := openProgress(db, claimed)
+	if p == nil {
+		t.Fatal("no progress line was opened for a task bound to a thread")
+	}
+	thread, _ := db.ThreadMessages(root.ID)
+	if len(thread) != 2 || !strings.Contains(thread[1].Body, "đang chạy") {
+		t.Fatalf("the room was not told: %+v", thread)
+	}
+	if !strings.Contains(thread[1].Body, task.ID) {
+		t.Error("the progress line does not name the task it belongs to")
+	}
+
+	// And it goes when the run does: the permanent record is the report the
+	// reporter posts, not a line that says "working" forever.
+	p.Close()
+	thread, _ = db.ThreadMessages(root.ID)
+	if len(thread) != 1 {
+		t.Fatalf("the progress line outlived the run: %+v", thread)
+	}
+}
+
+// Work queued from the CLI or a schedule has no room to report into, and must
+// not invent one.
+func TestATaskWithNoThreadReportsNowhere(t *testing.T) {
+	db := progressDB(t)
+	task, err := db.CreateTask(coord.NewTask{CreatedBy: "human", Title: "việc từ lịch", AssignedTo: "a1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, _ := db.ClaimTask("a1")
+	if p := openProgress(db, claimed); p != nil {
+		t.Fatal("a task with no conversation opened a progress line somewhere")
+	}
+	line, _ := db.ChannelMessages(coord.GeneralChannelID, 10)
+	if len(line) != 0 {
+		t.Fatalf("it posted into the channel anyway: %+v", line)
+	}
+	_ = task
+}
+
+// A run that died with the gateway leaves a line saying "working". The next
+// run clears it, because a room where an agent is permanently about to finish
+// is worse than one that says nothing.
+func TestAStaleProgressLineIsSweptByTheNextRun(t *testing.T) {
+	db := progressDB(t)
+	root, _, _ := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "việc dài",
+	})
+	task, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "việc dài", AssignedTo: "a1"})
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, _ := db.ClaimTask("a1")
+
+	first := openProgress(db, claimed) // the gateway dies here: no Close
+	if first == nil {
+		t.Fatal("no progress line")
+	}
+	second := openProgress(db, claimed)
+	if second == nil {
+		t.Fatal("no progress line on the second run")
+	}
+
+	thread, _ := db.ThreadMessages(root.ID)
+	var working int
+	for _, m := range thread {
+		if strings.HasPrefix(m.Body, progressPrefix) {
+			working++
+		}
+	}
+	if working != 1 {
+		t.Fatalf("expected exactly one progress line, found %d", working)
+	}
+}

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -392,10 +392,16 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	var reply strings.Builder
 	todoPending := false
 	call := span.Child(r.llm.Name(), coord.RunTypeLLM)
+	// Say what is happening in the room that asked for it. Nil when this task
+	// did not come from a conversation, and every call below tolerates that.
+	progress := openProgress(r.db, task)
+	defer progress.Close()
+
 	sendErr := r.llm.SendMessage(runCtx, sess, r.cfg.Model, prompt, "", chat.StreamCallbacks{
 		OnText: func(chunk string) { reply.WriteString(chunk) },
 		OnToolCall: func(name, input string) {
 			sess.NoteTool(name)
+			progress.Tool(name)
 			if name == "TodoWrite" && hasPendingTodos(input) {
 				todoPending = true
 			}


### PR DESCRIPTION
Dòng progress chiều nay **chỉ tồn tại ở làn mention**. Việc mà người ta thật sự ngồi chờ thì chạy ở làn kia — **task** — và làn đó không báo gì cả.

Nên một thread vừa mở task xong thì im lặng vài phút, còn kanban bên cạnh ghi `running 0s` suốt thời gian đó — ít thông tin hơn cả đọc log.

## Trong thread

Task sinh ra từ một cuộc nói chuyện giờ giữ một dòng trong chính cuộc đó: task nào, chạy bao lâu, và vài tool gần nhất.

**Một dòng cho mỗi run**, sửa tại chỗ, **xoá khi run kết thúc**. Không giữ giữa các run — giữa các run thì **không có gì đang chạy**, và một dòng vẫn ghi *đang chạy* sẽ là lời nói dối trong phần lớn vòng đời của task. Bản ghi vĩnh viễn là **báo cáo** reporter post khi task xong.

Run chết cùng gateway thì để lại dòng đó, nên **run kế tiếp quét sạch** mọi progress line của task ấy trước khi mở dòng mới. Một căn phòng có agent vĩnh viễn sắp xong còn tệ hơn căn phòng không nói gì.

Task từ CLI hay từ lịch **không có phòng nào để báo** nên không mở dòng nào, thay vì bịa ra một chỗ.

## Trên kanban

`tasks.get` giờ mang theo thứ run **đang** làm, khi run đó chạy ở gateway này: agent, tool cuối, số tool, thời gian. Drawer **poll khi còn sống** và đứng yên khi đã xong.

Run thuộc gateway khác thì **không báo gì** — gateway này đọc được hàng dùng chung nhưng không nhìn được vào session của con kia, và bịa ra một câu trả lời tệ hơn là thừa nhận bảng chỉ thấy chi tiết việc của chính nó.

## Test

- `TestATaskFromAThreadSaysWhatItIsDoing` — phòng được báo, dòng nêu đúng task, và **biến mất** khi run xong
- `TestATaskWithNoThreadReportsNowhere`
- `TestAStaleProgressLineIsSweptByTheNextRun` — mô phỏng gateway chết giữa run

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)