### PR TITLE
feat(channel): stream the answer forming, and stop putting words in your mouth

### DIFF
--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -149,20 +149,12 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
     }
   }
 
-  // Asking for a review is an ordinary message in the thread, addressed to the
-  // agent you are talking to — not a special mode. The agent already sees the
-  // artifact list in its prompt, so the id is all it needs.
-  const reviewFile = async (a: Artifact) => {
-    if (!to || !threadRoot || !active) return
-    try {
-      await call('channels.post', {
-        channel_id: active, thread_root: threadRoot, notify: [to],
-        body: `Xem lại giúp mình artifact \`${a.id}\` (${a.title}) — đọc nội dung rồi nói thẳng chỗ nào sai, thiếu, hoặc đáng ngờ.`,
-      })
-      await loadThread(threadRoot)
-    } catch (e: any) {
-      setErr(String(e?.message ?? e))
-    }
+  // Asking for a review FILLS THE BOX; it does not send. A button that posts
+  // words in your name the moment it is touched is a button you cannot try,
+  // and the first thing it did was put a sentence nobody wrote into a thread.
+  // Edit it, or delete it, then send — the way you would any other message.
+  const reviewFile = (a: Artifact) => {
+    setThreadBody(`Xem lại giúp mình artifact \`${a.id}\` (${a.title}) — đọc nội dung rồi nói thẳng chỗ nào sai, thiếu, hoặc đáng ngờ.`)
   }
 
   const ordered = useMemo(() => [...msgs].reverse(), [msgs])
@@ -421,7 +413,7 @@ function FileRow({ a, call, onReview, reviewer }: {
       <button
         onClick={onReview}
         disabled={!reviewer}
-        title={reviewer ? `Nhờ ${reviewer} xem lại` : 'Chọn một agent trước'}
+        title={reviewer ? `Soạn sẵn câu nhờ ${reviewer} xem lại — bạn bấm Send` : 'Chọn một agent trước'}
         className="shrink-0 px-1.5 py-0.5 rounded ring-1 ring-gray-700 text-gray-400 hover:text-sky-300 hover:ring-sky-500/40 disabled:opacity-40"
       >
         review

--- a/internal/chat/preview.go
+++ b/internal/chat/preview.go
@@ -1,0 +1,65 @@
+package chat
+
+import "strings"
+
+// Showing an answer as it forms.
+//
+// The shape is openclaw's (src/config/types.base.ts, BlockStreamingChunkConfig):
+// a preview updated in place, and the decision to update is a CHARACTER
+// threshold with a break preference — not a timer. A timer fires mid-word as
+// often as not, and a reader watching a sentence appear one fragment at a time
+// learns less than one who sees a paragraph land whole.
+type StreamPreview struct {
+	// MinGrowth is how much new text must arrive before it is worth showing
+	// again. Below this the reader gains nothing and the database takes a
+	// write per token.
+	MinGrowth int
+	// MaxRunes bounds what is shown; the tail is kept, because the end is
+	// where the answer currently is.
+	MaxRunes int
+
+	shownLen int
+}
+
+// DefaultPreview is tuned for a chat thread: roughly a sentence of growth
+// before an update, and a paragraph or two on screen.
+func DefaultPreview() *StreamPreview { return &StreamPreview{MinGrowth: 120, MaxRunes: 600} }
+
+// Ready reports whether the reply has grown enough to redraw, and records that
+// it was. Call it once per candidate update.
+func (p *StreamPreview) Ready(reply string) bool {
+	if p == nil {
+		return false
+	}
+	n := len([]rune(reply))
+	if n-p.shownLen < p.MinGrowth {
+		return false
+	}
+	p.shownLen = n
+	return true
+}
+
+// Cut returns the part of a forming reply worth showing: the tail, trimmed
+// back to a boundary so it never begins or ends mid-word.
+//
+// Preference order is openclaw's — paragraph, then line, then sentence —
+// because a cut at a paragraph reads as a pause and a cut mid-sentence reads
+// as a bug.
+func (p *StreamPreview) Cut(reply string) string {
+	max := 600
+	if p != nil && p.MaxRunes > 0 {
+		max = p.MaxRunes
+	}
+	r := []rune(strings.TrimSpace(reply))
+	if len(r) <= max {
+		return string(r)
+	}
+	tail := string(r[len(r)-max:])
+	// Start the visible part at a boundary rather than wherever the cut landed.
+	for _, sep := range []string{"\n\n", "\n", ". "} {
+		if i := strings.Index(tail, sep); i >= 0 && i < len(tail)/2 {
+			return "…" + strings.TrimSpace(tail[i+len(sep):])
+		}
+	}
+	return "…" + tail
+}

--- a/internal/chat/preview_test.go
+++ b/internal/chat/preview_test.go
@@ -1,0 +1,63 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+// The threshold is what stops a database write per token telling the reader
+// something they cannot read that fast.
+func TestPreviewWaitsForEnoughNewText(t *testing.T) {
+	p := &StreamPreview{MinGrowth: 10, MaxRunes: 100}
+	if p.Ready("short") {
+		t.Error("redrew after five characters")
+	}
+	if !p.Ready(strings.Repeat("a", 10)) {
+		t.Error("did not redraw after the threshold was passed")
+	}
+	// And having drawn it, it waits again rather than redrawing on every call.
+	if p.Ready(strings.Repeat("a", 12)) {
+		t.Error("redrew after two more characters")
+	}
+	if !p.Ready(strings.Repeat("a", 25)) {
+		t.Error("did not redraw after another threshold of growth")
+	}
+}
+
+// A cut mid-sentence reads as a bug; a cut at a paragraph reads as a pause.
+func TestCutPrefersAParagraphBoundary(t *testing.T) {
+	p := &StreamPreview{MaxRunes: 40}
+	long := "phần mở đầu đã cũ và dài dòng lắm rồi\n\nĐoạn mới bắt đầu ở đây."
+	got := p.Cut(long)
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("a trimmed preview should say so: %q", got)
+	}
+	if !strings.Contains(got, "Đoạn mới bắt đầu") {
+		t.Errorf("the newest paragraph is what the reader wants: %q", got)
+	}
+	if strings.Contains(got, "phần mở đầu") {
+		t.Errorf("the cut kept text it should have dropped: %q", got)
+	}
+}
+
+// Short replies are shown whole, with no ellipsis pretending something is
+// missing.
+func TestShortRepliesAreNotCut(t *testing.T) {
+	p := DefaultPreview()
+	if got := p.Cut("xong rồi"); got != "xong rồi" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// Multi-byte text must not be cut by bytes: Vietnamese would lose its
+// diacritics at the boundary.
+func TestCutCountsRunesNotBytes(t *testing.T) {
+	p := &StreamPreview{MaxRunes: 10}
+	got := p.Cut(strings.Repeat("ế", 40))
+	if n := len([]rune(strings.TrimPrefix(got, "…"))); n > 10 {
+		t.Fatalf("kept %d runes, cap is 10", n)
+	}
+	if strings.Contains(got, "�") {
+		t.Fatal("the cut split a character")
+	}
+}

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/coord"
 	"github.com/ngocp/goterm-control/internal/session"
 )
@@ -221,7 +222,7 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 		progress = nil // the turn still runs; it just runs unseen
 	}
 
-	sink := &replySink{}
+	sink := &replySink{preview: chat.DefaultPreview()}
 	if progress != nil {
 		sink.onProgress = func(tools []string, partial string, since time.Time) {
 			if err := w.deps.Coord.UpdateMessageBody(progress.ID, workingLine(tools, partial, since)); err != nil {
@@ -525,15 +526,21 @@ type replySink struct {
 	// onProgress is called with the tools used so far and the reply as it
 	// stands. Nil when nobody is watching.
 	onProgress func(tools []string, partial string, since time.Time)
+
+	preview *chat.StreamPreview
 }
 
 const progressEvery = 2 * time.Second
 
+// Write redraws when the answer has grown by enough to be worth reading again
+// — a character threshold rather than a timer, because a timer fires mid-word
+// as often as not and a reader learns more from a paragraph landing whole.
 func (r *replySink) Write(chunk string) {
 	r.mu.Lock()
 	r.b.WriteString(chunk)
+	grown := r.preview.Ready(r.b.String())
 	r.mu.Unlock()
-	r.report(false)
+	r.report(grown)
 }
 
 // NoteTool is the part worth watching: "reading the log" says more about what
@@ -602,7 +609,7 @@ func workingLine(tools []string, partial string, since time.Time) string {
 	}
 	if p := strings.TrimSpace(partial); p != "" {
 		b.WriteString("\n\n")
-		b.WriteString(truncateRunes(p, 600))
+		b.WriteString(chat.DefaultPreview().Cut(p))
 	}
 	return b.String()
 }

--- a/internal/taskrunner/progress.go
+++ b/internal/taskrunner/progress.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ngocp/goterm-control/internal/chat"
 	"github.com/ngocp/goterm-control/internal/coord"
 )
 
@@ -34,9 +35,11 @@ type progressLine struct {
 	title     string
 	started   time.Time
 
-	mu    sync.Mutex
-	tools []string
-	last  time.Time
+	mu      sync.Mutex
+	tools   []string
+	last    time.Time
+	reply   string
+	preview *chat.StreamPreview
 }
 
 const progressEvery = 3 * time.Second
@@ -69,7 +72,7 @@ func openProgress(db *coord.DB, task *coord.Task) *progressLine {
 
 	p := &progressLine{
 		db: db, channelID: channelID, taskID: task.ID,
-		title: task.Title, started: time.Now(),
+		title: task.Title, started: time.Now(), preview: chat.DefaultPreview(),
 	}
 	msg, _, err := db.PostMessage(coord.NewChannelMessage{
 		ChannelID: channelID, ThreadRoot: rootID,
@@ -110,6 +113,27 @@ func (p *progressLine) Tool(name string) {
 	}
 }
 
+// Text shows the answer as it forms. The threshold is a character count, not a
+// timer: a timer fires mid-word as often as not, and the point of watching is
+// to see the reasoning arrive in readable pieces.
+func (p *progressLine) Text(chunk string) {
+	if p == nil || chunk == "" {
+		return
+	}
+	p.mu.Lock()
+	p.reply += chunk
+	grown := p.preview.Ready(p.reply)
+	body := p.bodyLocked()
+	p.mu.Unlock()
+
+	if !grown {
+		return
+	}
+	if err := p.db.UpdateMessageBody(p.messageID, body); err != nil {
+		log.Printf("taskrunner: progress update: %v", err)
+	}
+}
+
 // Close removes the line. The result belongs to the reporter, which posts it
 // when the task itself finishes rather than when one run of it does.
 func (p *progressLine) Close() {
@@ -140,6 +164,11 @@ func (p *progressLine) bodyLocked() string {
 	}
 	if t := strings.TrimSpace(p.title); t != "" {
 		fmt.Fprintf(&b, "\n\n%s", t)
+	}
+	// What it is actually saying, once it starts saying anything. This is the
+	// part a person waiting wants; the tool names above are context for it.
+	if r := strings.TrimSpace(p.reply); r != "" {
+		fmt.Fprintf(&b, "\n\n%s", p.preview.Cut(r))
 	}
 	return b.String()
 }

--- a/internal/taskrunner/progress_test.go
+++ b/internal/taskrunner/progress_test.go
@@ -121,3 +121,43 @@ func TestAStaleProgressLineIsSweptByTheNextRun(t *testing.T) {
 		t.Fatalf("expected exactly one progress line, found %d", working)
 	}
 }
+
+// The tool names say what it is reaching for; this is what it is actually
+// saying. A person waiting wants the second one, and until now the thread
+// showed only the first.
+func TestTheRoomSeesTheAnswerForming(t *testing.T) {
+	db := progressDB(t)
+	root, _, _ := db.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "nghiên cứu giúp mình",
+	})
+	task, _ := db.CreateTask(coord.NewTask{CreatedBy: "a1", Title: "nghiên cứu", AssignedTo: "a1"})
+	if err := db.BindThreadToTask(root.ID, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, _ := db.ClaimTask("a1")
+	p := openProgress(db, claimed)
+	if p == nil {
+		t.Fatal("no progress line")
+	}
+
+	// Below the threshold nothing is redrawn: a write per token tells the
+	// reader something they cannot read that fast.
+	p.Text("Bắt đầu. ")
+	thread, _ := db.ThreadMessages(root.ID)
+	if strings.Contains(thread[1].Body, "Bắt đầu") {
+		t.Error("redrew after a few characters")
+	}
+
+	// Past it, the room sees what is being written.
+	p.Text(strings.Repeat("Phân tích giai đoạn thị trường. ", 8))
+	thread, _ = db.ThreadMessages(root.ID)
+	if !strings.Contains(thread[1].Body, "Phân tích giai đoạn thị trường") {
+		t.Fatalf("the forming answer is not in the room:\n%s", thread[1].Body)
+	}
+	// And it is still a progress line, not the answer: the answer is what the
+	// reporter posts when the task is done.
+	if !strings.HasPrefix(thread[1].Body, progressPrefix) {
+		t.Error("the progress line stopped announcing itself as one")
+	}
+}

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -398,7 +398,10 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 	defer progress.Close()
 
 	sendErr := r.llm.SendMessage(runCtx, sess, r.cfg.Model, prompt, "", chat.StreamCallbacks{
-		OnText: func(chunk string) { reply.WriteString(chunk) },
+		OnText: func(chunk string) {
+			reply.WriteString(chunk)
+			progress.Text(chunk)
+		},
 		OnToolCall: func(name, input string) {
 			sess.NoteTool(name)
 			progress.Tool(name)


### PR DESCRIPTION
Hai thứ nhìn ra khi xem nó chạy thật.

## 1. Dòng progress chỉ hiện tool, không bao giờ hiện câu trả lời

Nó vẽ lại **khi có tool**, nên thread hiện `Bash(cd ~/goterm-workspace)` rồi **im vài phút** trong lúc câu trả lời đang được viết. Tên tool nói agent đang *với tới* cái gì; nó không nói agent đang *kết luận* gì — mà cái thứ hai mới là thứ người ngồi chờ muốn biết.

**Hình dạng của openclaw là đúng** (`src/config/types.base.ts`): một bản preview cập nhật tại chỗ, vẽ lại theo **ngưỡng ký tự** kèm **break preference**, không theo timer. Timer thì cứ vài lần lại bắn đúng giữa từ; ngưỡng cho phép một câu đáp xuống trọn vẹn.

`StreamPreview` làm đúng vậy: tối thiểu bao nhiêu chữ mới thì vẽ lại, giữ phần đuôi, cắt lùi về ranh giới **đoạn → dòng → câu**, và đếm bằng **rune** để tiếng Việt không mất dấu ngay chỗ cắt.

**Cả hai làn dùng nó** — lượt kênh, và task run vốn **không có** text streaming nào cả.

## 2. Nút review nói thay anh

Chạm vào nó là một câu **không ai viết** rơi vào thread **và được gửi luôn** — đó đúng là lý do nó đọc ra như hệ thống tự nói.

Giờ nó **điền vào ô soạn**. Sửa, xoá, hoặc gửi — như mọi tin nhắn khác. Một cái nút phát ngôn thay anh là cái nút anh không dám bấm thử.

## Test

- `TestPreviewWaitsForEnoughNewText` — dưới ngưỡng thì không vẽ lại, và vẽ rồi thì chờ tiếp
- `TestCutPrefersAParagraphBoundary` — giữ đoạn mới nhất, bỏ phần cũ
- `TestCutCountsRunesNotBytes` — cắt 40 chữ `ế` không sinh ký tự hỏng
- `TestTheRoomSeesTheAnswerForming` — dưới ngưỡng im, qua ngưỡng thì phòng thấy câu đang viết, và nó **vẫn là** dòng progress chứ chưa phải câu trả lời

`go build ./...`, `go test ./...`, `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)