### PR TITLE
fix(channel): clear the lines a dead run left, and read a room from its end

### DIFF
--- a/cmd/bomclaw/channelcmd.go
+++ b/cmd/bomclaw/channelcmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/ngocp/goterm-control/internal/coord"
 	"github.com/ngocp/goterm-control/internal/gateway"
@@ -86,7 +87,7 @@ func runChannel(args []string) {
 			fmt.Fprintln(os.Stderr, "Usage: bomclaw ch read <channel-id> [--thread <message-id>]")
 			os.Exit(1)
 		}
-		msgs, err := db.ChannelMessages(channelID, *limit)
+		msgs, err := db.ChannelMessages(channelID, *limit, time.Time{})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ch read: %v\n", err)
 			os.Exit(1)

--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -309,6 +309,14 @@ func runGateway(args []string) {
 		} else {
 			defer coordDB.Close()
 			log.Printf("coord: shared database at %s (agent=%s)", coordDB.Path(), cfg.Agent.ID)
+			// A run that died with the last gateway left a line in the room
+			// saying it was still working. Nothing else ever corrects it, and
+			// startup is the one moment clearing it is unambiguously safe.
+			if n, err := coordDB.SweepProgressLines(cfg.Agent.ID, coord.ProgressPrefix); err != nil {
+				log.Printf("coord: sweep progress lines: %v", err)
+			} else if n > 0 {
+				log.Printf("coord: cleared %d progress line(s) left by a previous run", n)
+			}
 			startCoordUpkeep(ctx, coordDB, cfg, *bind, *port, resolver.Default())
 			gwTrace = trace.New(coordDB, cfg.Agent.ID)
 			defer gwTrace.Close()

--- a/dashboard/src/admin/ChannelView.tsx
+++ b/dashboard/src/admin/ChannelView.tsx
@@ -11,6 +11,8 @@ type Call = (method: string, params?: any) => Promise<any>
 // were not in the history at all. Here the human is an ordinary member: the
 // composer posts as "you" unless you deliberately speak as an agent.
 
+const PAGE = 30
+
 export default function ChannelView({ call, agents, selfID, openThreadID, onOpenedThread, onOpenTask }: {
   call: Call; agents: string[]; selfID: string
   openThreadID?: string; onOpenedThread?: () => void; onOpenTask?: (taskID: string) => void
@@ -33,7 +35,11 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
   // What this conversation has produced. A path named in prose is findable for
   // about a day; these are findable by id and survive the file moving.
   const [files, setFiles] = useState<Artifact[]>([])
+  const [more, setMore] = useState(false)
   const sending = useRef(false)
+  const loadingOlder = useRef(false)
+  const scroller = useRef<HTMLDivElement>(null)
+  const atBottom = useRef(true)
   const bottom = useRef<HTMLDivElement>(null)
 
   const loadChannels = useCallback(async () => {
@@ -48,15 +54,48 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
     }
   }, [call])
 
+  // A page, not the whole room. A reader arrives wanting the end of the
+  // conversation; loading thousands of messages to show the last screenful is
+  // work nobody asked for and a wait nobody wanted.
   const loadMessages = useCallback(async (channelID: string) => {
     if (!channelID) return
     try {
-      setMsgs((await call('channels.messages', { channel_id: channelID, limit: 200 })) || [])
+      const page: ChannelMessage[] = (await call('channels.messages', { channel_id: channelID, limit: PAGE })) || []
+      setMsgs(page)
+      setMore(page.length === PAGE)
       setErr(null)
     } catch (e: any) {
       setErr(String(e?.message ?? e))
     }
   }, [call])
+
+  // Scrolling up asks for what came before the oldest message on screen. The
+  // scroll position is pinned across the insert, because a list that jumps
+  // when it grows upwards is a list you cannot read.
+  const loadOlder = useCallback(async () => {
+    const box = scroller.current
+    if (!box || !active || loadingOlder.current || !more) return
+    const oldest = msgs[msgs.length - 1]
+    if (!oldest) return
+    loadingOlder.current = true
+    const before = box.scrollHeight - box.scrollTop
+    try {
+      const page: ChannelMessage[] = (await call('channels.messages', {
+        channel_id: active, limit: PAGE, before: oldest.created_at,
+      })) || []
+      if (page.length) {
+        setMsgs(m => [...m, ...page])
+      }
+      setMore(page.length === PAGE)
+      requestAnimationFrame(() => {
+        if (scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight - before
+      })
+    } catch (e: any) {
+      setErr(String(e?.message ?? e))
+    } finally {
+      loadingOlder.current = false
+    }
+  }, [active, call, more, msgs])
 
   const loadThread = useCallback(async (rootID: string) => {
     try {
@@ -84,6 +123,16 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
 
   useEffect(() => { loadMessages(active) }, [active, loadMessages])
 
+  // Land on the newest message when a room opens, and follow it while you are
+  // already at the bottom — but never yank the view down while somebody is
+  // reading further up.
+  useEffect(() => {
+    if (!msgs.length) return
+    if (atBottom.current) bottom.current?.scrollIntoView({ block: 'end' })
+  }, [msgs])
+
+  useEffect(() => { atBottom.current = true }, [active])
+
   // Arriving from the board: open the conversation the task came out of.
   useEffect(() => {
     if (!openThreadID) return
@@ -99,10 +148,15 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
   }, [openThreadID, call, onOpenedThread])
 
   // Poll: an agent posting from its own shell has no way to push to this page.
+  //
+  // Only while you are at the bottom. The poll replaces the list with the
+  // newest page, so running it after somebody scrolled up would throw away the
+  // history they just asked for and drop them back at the end — twice a
+  // minute, while they were reading.
   useEffect(() => {
     const id = setInterval(() => {
       loadChannels()
-      loadMessages(active)
+      if (atBottom.current) loadMessages(active)
       if (threadRoot) loadThread(threadRoot)
     }, 4000)
     return () => clearInterval(id)
@@ -140,6 +194,7 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
         // instead of behind a click nobody knew to make.
         await loadThread(posted.id)
       } else {
+        atBottom.current = true
         bottom.current?.scrollIntoView({ behavior: 'smooth' })
       }
     } catch (e: any) {
@@ -187,7 +242,20 @@ export default function ChannelView({ call, agents, selfID, openThreadID, onOpen
           </span>
         </header>
 
-        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        <div
+          ref={scroller}
+          onScroll={e => {
+            const el = e.currentTarget
+            atBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
+            if (el.scrollTop < 120) loadOlder()
+          }}
+          className="flex-1 overflow-y-auto p-4 space-y-3"
+        >
+          {more && (
+            <div className="text-center text-[11px] text-gray-600 py-1">
+              kéo lên để xem thêm…
+            </div>
+          )}
           {err && <div className="text-xs text-red-300">{err}</div>}
           {ordered.length === 0 && !err && (
             <div className="text-sm text-gray-500">

--- a/internal/coord/channels.go
+++ b/internal/coord/channels.go
@@ -551,13 +551,29 @@ func (db *DB) resolveMentions(body string) ([]Member, error) {
 
 // ChannelMessages returns the channel's main line — top-level messages only,
 // newest first, each with its reply count so a thread announces itself.
-func (db *DB) ChannelMessages(channelID string, limit int) ([]ChannelMessage, error) {
+// ChannelMessages returns the newest page of a channel's main line. before is
+// the created_at of the oldest message already on screen, so scrolling up asks
+// for what came before it; empty means the newest page.
+//
+// Paged rather than "the last hundred": a busy room is thousands of messages,
+// and a reader arrives wanting the end of the conversation, not the start of
+// it. Loading everything to show the last screenful is work nobody asked for
+// and a wait nobody wanted.
+func (db *DB) ChannelMessages(channelID string, limit int, before time.Time) ([]ChannelMessage, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
-	rows, err := db.conn.Query(`SELECT id, channel_id, thread_root, author_kind, author_id, body, task_id, created_at
-		FROM channel_messages WHERE channel_id = ? AND thread_root = ''
-		ORDER BY created_at DESC LIMIT ?`, channelID, limit)
+	query := `SELECT id, channel_id, thread_root, author_kind, author_id, body, task_id, created_at
+		FROM channel_messages WHERE channel_id = ? AND thread_root = ''`
+	args := []any{channelID}
+	if !before.IsZero() {
+		query += ` AND created_at < ?`
+		args = append(args, ts(before))
+	}
+	query += ` ORDER BY created_at DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := db.conn.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("messages of %s: %w", channelID, err)
 	}
@@ -782,6 +798,45 @@ func (db *DB) DeleteMessage(id string) error {
 		return fmt.Errorf("delete %s: %w", id, err)
 	}
 	return tx.Commit()
+}
+
+// SweepProgressLines removes the "working on it" lines an agent left behind.
+//
+// A run that dies with its gateway — a deploy, a crash — leaves a message in
+// the room saying it is still going, and nothing ever corrects it. Sweeping at
+// startup is the only moment this is unambiguously safe: the process has just
+// begun, so any line it wrote is by definition from a run that no longer
+// exists.
+//
+// Matched on the prefix the progress lines carry rather than on a flag column,
+// because these are the only messages an agent writes that are meant to be
+// temporary — everything else it says, it meant.
+func (db *DB) SweepProgressLines(agentID, prefix string) (int, error) {
+	rows, err := db.conn.Query(`SELECT id FROM channel_messages
+		WHERE author_kind = ? AND author_id = ? AND body LIKE ? || '%'`,
+		MemberAgent, agentID, prefix)
+	if err != nil {
+		return 0, fmt.Errorf("sweep progress lines of %s: %w", agentID, err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	for _, id := range ids {
+		if err := db.DeleteMessage(id); err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
 }
 
 // GetMessage is getMessage for callers outside this package: the gateway needs

--- a/internal/coord/channels_test.go
+++ b/internal/coord/channels_test.go
@@ -1,8 +1,10 @@
 package coord
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func registerTestAgents(t *testing.T, db *DB, ids ...string) {
@@ -126,7 +128,7 @@ func TestThreadsStayOneLevelDeep(t *testing.T) {
 
 	// The channel's main line shows the root once, with its reply count —
 	// not the replies as separate lines.
-	main, err := db.ChannelMessages(GeneralChannelID, 50)
+	main, err := db.ChannelMessages(GeneralChannelID, 50, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +321,7 @@ func TestMainLineCarriesTheNewestReply(t *testing.T) {
 	}
 
 	// No replies yet: no preview, and nothing pretending there is one.
-	line, err := db.ChannelMessages(GeneralChannelID, 10)
+	line, err := db.ChannelMessages(GeneralChannelID, 10, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +337,7 @@ func TestMainLineCarriesTheNewestReply(t *testing.T) {
 		}
 	}
 
-	line, err = db.ChannelMessages(GeneralChannelID, 10)
+	line, err = db.ChannelMessages(GeneralChannelID, 10, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +368,7 @@ func TestReplyPreviewIsCut(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	line, _ := db.ChannelMessages(GeneralChannelID, 10)
+	line, _ := db.ChannelMessages(GeneralChannelID, 10, time.Time{})
 	if n := len([]rune(line[0].LastReplyText)); n > ReplyPreviewRunes {
 		t.Fatalf("preview is %d runes, cap is %d", n, ReplyPreviewRunes)
 	}
@@ -500,7 +502,7 @@ func TestBindThreadToTask(t *testing.T) {
 	if gotRoot != root.ID || gotChannel != GeneralChannelID {
 		t.Fatalf("TaskThread: got %s in %s, want %s in %s", gotRoot, gotChannel, root.ID, GeneralChannelID)
 	}
-	line, _ := db.ChannelMessages(GeneralChannelID, 10)
+	line, _ := db.ChannelMessages(GeneralChannelID, 10, time.Time{})
 	if line[0].TaskID != task.ID {
 		t.Fatalf("thread root does not carry the task: %q", line[0].TaskID)
 	}
@@ -611,5 +613,99 @@ func TestNamingOneAgentInAThreadWakesOnlyThatOne(t *testing.T) {
 	}
 	if len(wake) != 3 {
 		t.Fatalf("an unaddressed reply should reach the thread, woke %v", wake)
+	}
+}
+
+// A reader arrives wanting the end of a conversation, and scrolls up for the
+// rest. Loading the whole room to show the last screenful is work nobody asked
+// for.
+func TestChannelMessagesPagesBackwards(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw")
+
+	for i := 0; i < 25; i++ {
+		if _, _, err := db.PostMessage(NewChannelMessage{
+			ChannelID: GeneralChannelID, AuthorKind: MemberUser, AuthorID: OwnerUserID,
+			Body: fmt.Sprintf("tin %02d", i),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The newest page is the newest messages, not the oldest.
+	page1, err := db.ChannelMessages(GeneralChannelID, 10, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1) != 10 {
+		t.Fatalf("page size: got %d", len(page1))
+	}
+	if page1[0].Body != "tin 24" {
+		t.Fatalf("the first page should start at the end: %q", page1[0].Body)
+	}
+
+	// Scrolling up asks for what came before the oldest one on screen.
+	page2, err := db.ChannelMessages(GeneralChannelID, 10, page1[len(page1)-1].CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 10 {
+		t.Fatalf("second page size: got %d", len(page2))
+	}
+	if page2[0].Body != "tin 14" {
+		t.Fatalf("the second page should continue where the first stopped: %q", page2[0].Body)
+	}
+	// No overlap, nothing skipped.
+	seen := map[string]bool{}
+	for _, m := range append(page1, page2...) {
+		if seen[m.ID] {
+			t.Fatalf("%s appeared on both pages", m.Body)
+		}
+		seen[m.ID] = true
+	}
+
+	// And the last page is short, which is how the reader knows it has ended.
+	page3, err := db.ChannelMessages(GeneralChannelID, 10, page2[len(page2)-1].CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3) != 5 {
+		t.Fatalf("the last page should hold what is left: got %d", len(page3))
+	}
+}
+
+// The lines that only exist while something runs are swept at startup: a run
+// that died with its gateway leaves one saying it is still going, and nothing
+// else ever corrects it.
+func TestSweepClearsProgressLinesAndNothingElse(t *testing.T) {
+	db := testDB(t)
+	registerTestAgents(t, db, "bomclaw", "bomclaw2")
+
+	real1, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorID: "bomclaw", Body: "một câu trả lời thật",
+	})
+	stale, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorID: "bomclaw", Body: ProgressPrefix + "_đang chạy_ `t_1`",
+	})
+	other, _, _ := db.PostMessage(NewChannelMessage{
+		ChannelID: GeneralChannelID, AuthorID: "bomclaw2", Body: ProgressPrefix + "_đang chạy_ `t_2`",
+	})
+
+	n, err := db.SweepProgressLines("bomclaw", ProgressPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("swept %d lines, expected 1", n)
+	}
+	if _, err := db.GetMessage(stale.ID); err == nil {
+		t.Error("the stale progress line survived")
+	}
+	if _, err := db.GetMessage(real1.ID); err != nil {
+		t.Error("a real message was swept")
+	}
+	// Another agent's line is its own business: it may still be running.
+	if _, err := db.GetMessage(other.ID); err != nil {
+		t.Error("another agent's progress line was swept")
 	}
 }

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -28,6 +28,11 @@ import (
 
 const schemaVersion = 7
 
+// ProgressPrefix marks a message that exists only while something is running.
+// It lives here because two packages write these lines — the mention watcher
+// and the task runner — and the startup sweep has to recognise both.
+const ProgressPrefix = "⏳ "
+
 // DB is the shared coordination database.
 type DB struct {
 	conn *sql.DB

--- a/internal/gateway/channels.go
+++ b/internal/gateway/channels.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/ngocp/goterm-control/internal/coord"
 )
@@ -42,6 +43,10 @@ type channelMessagesParams struct {
 	ChannelID  string `json:"channel_id"`
 	ThreadRoot string `json:"thread_root,omitempty"`
 	Limit      int    `json:"limit,omitempty"`
+	// Before pages backwards: the created_at of the oldest message already on
+	// screen. Empty asks for the newest page, which is where a reader wants to
+	// start — a conversation is read from its end.
+	Before string `json:"before,omitempty"`
 }
 
 func handleChannelMessages(deps Deps, params json.RawMessage) (json.RawMessage, error) {
@@ -62,7 +67,15 @@ func handleChannelMessages(deps Deps, params json.RawMessage) (json.RawMessage, 
 	if p.ChannelID == "" {
 		return nil, fmt.Errorf("channel_id is required")
 	}
-	msgs, err := deps.Coord.ChannelMessages(p.ChannelID, p.Limit)
+	var before time.Time
+	if p.Before != "" {
+		t, err := time.Parse(time.RFC3339Nano, p.Before)
+		if err != nil {
+			return nil, fmt.Errorf("before must be an RFC3339 timestamp: %w", err)
+		}
+		before = t
+	}
+	msgs, err := deps.Coord.ChannelMessages(p.ChannelID, p.Limit, before)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -594,7 +594,7 @@ func (r *replySink) Finalize()                {}
 // workingLine is what the room sees while the agent is still working.
 func workingLine(tools []string, partial string, since time.Time) string {
 	var b strings.Builder
-	b.WriteString("⏳ _đang làm_")
+	b.WriteString(coord.ProgressPrefix + "_đang làm_")
 	if !since.IsZero() {
 		fmt.Fprintf(&b, " · %s", time.Since(since).Round(time.Second))
 	}

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -303,7 +303,7 @@ func TestNoThreadNoPost(t *testing.T) {
 	r.SetNotify(got.add)
 	r.Tick()
 
-	line, err := db.ChannelMessages(coord.GeneralChannelID, 10)
+	line, err := db.ChannelMessages(coord.GeneralChannelID, 10, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/taskrunner/progress.go
+++ b/internal/taskrunner/progress.go
@@ -24,7 +24,8 @@ import (
 // still said "working" would be a lie the rest of the time. The report the
 // reporter posts when the task finishes is the permanent record; this is only
 // the window while it happens.
-const progressPrefix = "⏳ "
+// progressPrefix is coord.ProgressPrefix; the startup sweep matches the same.
+const progressPrefix = coord.ProgressPrefix
 
 // progressLine owns the message a run keeps updated.
 type progressLine struct {

--- a/internal/taskrunner/progress_test.go
+++ b/internal/taskrunner/progress_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ngocp/goterm-control/internal/coord"
 )
@@ -79,7 +80,7 @@ func TestATaskWithNoThreadReportsNowhere(t *testing.T) {
 	if p := openProgress(db, claimed); p != nil {
 		t.Fatal("a task with no conversation opened a progress line somewhere")
 	}
-	line, _ := db.ChannelMessages(coord.GeneralChannelID, 10)
+	line, _ := db.ChannelMessages(coord.GeneralChannelID, 10, time.Time{})
 	if len(line) != 0 {
 		t.Fatalf("it posted into the channel anyway: %+v", line)
 	}


### PR DESCRIPTION
Ba thứ trong ảnh chụp.

## 1. Dòng progress đứng im ở `10s`

Một lần deploy giết run giữa chừng, và dòng của nó **ở lại trong phòng nói rằng nó vẫn đang chạy** — vĩnh viễn, vì cái sweep tôi viết chỉ chạy khi **run kế tiếp** của task đó bắt đầu, mà có thể không bao giờ có run kế tiếp.

Giờ **startup quét sạch** mọi progress line agent này để lại. Đó là thời điểm duy nhất an toàn không mập mờ: tiến trình vừa mới bắt đầu, nên mọi dòng như vậy **theo định nghĩa** là của một run không còn tồn tại.

Dòng của agent khác **không đụng tới** — con đó có thể vẫn đang chạy thật.

## 2. Đọc một căn phòng từ đầu

Kênh load **200 tin** rồi hiển thị phần cuối, nên vào một phòng bận là chờ một đống lịch sử không ai cần.

Giờ load **30**, **nhảy thẳng xuống tin mới nhất**, và lấy trang trước khi anh kéo gần lên đỉnh — **ghim vị trí cuộn** xuyên qua lần chèn, vì một danh sách nhảy khi nó dài thêm ở phía trên là danh sách không đọc được.

Và vòng poll **chỉ làm mới khi anh đang ở đáy**: nó thay danh sách bằng trang mới nhất, nên chạy sau khi anh đã kéo lên sẽ **vứt đi đúng phần lịch sử anh vừa yêu cầu** — hai lần mỗi phút, trong lúc anh đang đọc.

## 3. Nhãn tool giữ nguyên — và vì sao

Tôi đã nới lệnh trong nhãn từ 25 lên 60 ký tự để "hiện rõ command hơn", và một test có sẵn chỉ ra cái giá: việc rút gọn **không chỉ** là cắt độ dài, nó biến một đường dẫn dài thành `../goterm-control`. Rộng hơn nghĩa là **dài hơn VÀ khó đọc hơn**. Đã trả lại.

## Về chuyện agent 3 không hiện command

Không phải lỗi đường ống: `grep -c tool_use` trong log agent 3 ra **0**. Nó **không gọi tool nào** — model `muse-spark` trả lời thẳng và tự nói là "sẽ kiểm tra" mà không kiểm tra. Đó là hành vi của model, không phải thiếu streaming.

## Test

- `TestChannelMessagesPagesBackwards` — trang đầu là tin **mới nhất**, trang sau nối đúng chỗ, **không trùng không sót**, trang cuối ngắn
- `TestSweepClearsProgressLinesAndNothingElse` — quét đúng dòng tạm, **không** đụng câu trả lời thật, **không** đụng dòng của agent khác

`go build ./...`, `go test ./...` (28 package) sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)