### PR TITLE
feat(channel): an agent can put work on a clock, and a deploy stops eating questions

### DIFF
--- a/cmd/bomclaw/main.go
+++ b/cmd/bomclaw/main.go
@@ -502,6 +502,7 @@ func runGateway(args []string) {
 		Trace:         gwTrace,
 		PokeTasks:     runner.Poke,
 		PokeSchedules: sched.Poke,
+		SchedulesRun:  cfg.Schedules.Enabled,
 		NotesFile:     cfg.Coord.NotesFile,
 		Conversations: conversations,
 		ConfigPath:    absPath(*configPath),

--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -237,6 +238,17 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 	sess.MarkIdle()
 	w.live.Delete(m.ID)
 	if err != nil {
+		// A turn killed by shutdown is not an answered question. The gateway
+		// was restarting — a deploy, usually — and the person asked something
+		// that nobody will ever come back to if the mention is marked read
+		// here. Leave it: the next gateway sweeps unread mentions at startup
+		// and picks it up. Our own timeout is a different thing and does count,
+		// because retrying it forever would just burn the same three minutes.
+		if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+			log.Printf("mentions: %s interrupted by shutdown — leaving it unread for the next run", m.ID)
+			w.finishProgress(progress, "")
+			return
+		}
 		log.Printf("mentions: turn for %s: %v", m.ID, err)
 		w.finishProgress(progress, "⚠️ lượt này hỏng giữa chừng: "+truncateLine(err.Error(), 200))
 		clear("")
@@ -311,6 +323,7 @@ func (w *MentionWatcher) prompt(m coord.ChannelMessage, mem *coord.ThreadSession
 
 	fmt.Fprintf(&b, "## %s said\n\n%s\n\n", m.AuthorID, strings.TrimSpace(m.Body))
 	b.WriteString(w.threadArtifacts(m))
+	b.WriteString(w.schedules())
 	b.WriteString(w.roster())
 
 	b.WriteString("## How to answer\n\n")
@@ -368,6 +381,42 @@ func (w *MentionWatcher) threadArtifacts(m coord.ChannelMessage) string {
 	b.WriteString("\nRead one with `bomclaw artifact get <id>` — by id, not by path, so it still " +
 		"resolves after the file moves. If you are asked to review one, read it first and say what " +
 		"is wrong with it; agreeing with a file you have not opened is worse than not answering.\n\n")
+	return b.String()
+}
+
+// schedules tells the agent it can put work on a clock, and whether anything
+// on this machine would actually run it.
+//
+// Asked to "check the price every five minutes", an agent that has not been
+// told about schedules will either refuse or promise to remember — and then
+// not, because it does not run between turns. The command has existed since
+// P1a; nothing ever said so in a prompt.
+//
+// The second half matters as much: a schedule row is inert unless some gateway
+// has schedules.enabled. Letting an agent create one into a machine where
+// nothing fires it is worse than refusing, because it looks like it worked.
+func (w *MentionWatcher) schedules() string {
+	var b strings.Builder
+	b.WriteString("## Work on a clock\n\n")
+	if !w.deps.SchedulesRun {
+		// Accurate rather than sweeping: this gateway knows its own config and
+		// not its peers'. A row created here is not wrong, it is waiting — and
+		// saying which of those it is beats guessing for the whole machine.
+		b.WriteString("This gateway does not fire schedules (`schedules.enabled` is off here). " +
+			"You can still create one — `bomclaw schedule add` writes to the shared database — but it " +
+			"waits for a gateway that does run them. Say that when you create one, so nobody is left " +
+			"expecting it to go off.\n\n")
+		return b.String()
+	}
+	b.WriteString("`bomclaw schedule add --name <short-name> --every 5m --agent-task \"<what to do>\" " +
+		"[--body \"<detail>\"] [--to <agent>]` puts work on a clock. `--cron \"0 8 * * 1-5\"` for a " +
+		"time of day, `--at <RFC3339>` for once.\n")
+	b.WriteString("A schedule does not run a model by itself: at each tick it creates an ordinary " +
+		"task, and whichever agent claims it does the work. So write the task title as an " +
+		"instruction someone else could follow — the agent that claims it will not have this " +
+		"conversation.\n")
+	b.WriteString("`bomclaw schedule list|show|disable|remove` for the rest. Tell the person the " +
+		"name you gave it, so they can turn it off without asking you.\n\n")
 	return b.String()
 }
 

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -25,6 +25,7 @@ type recordingTurn struct {
 	resumed  []string
 	reply    string
 	newID    string
+	err      error
 
 	// duringTurn runs against the sink before the reply is written, so a test
 	// can watch what the room sees while the turn is still going.
@@ -46,6 +47,9 @@ func (r *recordingTurn) RunTurn(ctx context.Context, sess *session.Session, chat
 
 	if newID != "" {
 		sess.SetSessionID(newID) // the CLI hands back the session it just wrote
+	}
+	if r.err != nil {
+		return nil, r.err
 	}
 	sink.Write(reply)
 	return &execution.RunResult{SessionID: sess.ID, Status: execution.RunSuccess}, nil
@@ -673,5 +677,96 @@ func TestAThreadWithNoTaskListsNoFiles(t *testing.T) {
 	NewMentionWatcher(deps).sweep(context.Background())
 	if strings.Contains(turn.prompts[0], "has produced") {
 		t.Error("a thread with no work behind it listed files")
+	}
+}
+
+// TestTheAgentIsToldItCanSchedule: asked to "check the price every five
+// minutes", an agent that has not been told about schedules either refuses or
+// promises to remember — and then does not, because it does not run between
+// turns. The command has existed since P1a; nothing ever said so in a prompt.
+func TestTheAgentIsToldItCanSchedule(t *testing.T) {
+	turn := &recordingTurn{reply: "ok", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+	deps.SchedulesRun = true
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body:   "tạo 1 schedule 5 phút 1 lần cho tôi nắm giá top 10 crypto",
+		Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	p := turn.prompts[0]
+	for _, want := range []string{"schedule add", "--every", "--agent-task"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("the prompt does not offer %q:\n%s", want, p)
+		}
+	}
+	// And the part that is easy to get wrong: the task it creates is claimed
+	// by some other agent, which will not have this conversation.
+	if !strings.Contains(p, "will not have this") {
+		t.Error("the prompt does not warn that the claiming agent lacks this context")
+	}
+}
+
+// A gateway that does not fire schedules must say so rather than let an agent
+// promise something nothing will run.
+func TestAGatewayThatDoesNotFireSchedulesSaysSo(t *testing.T) {
+	turn := &recordingTurn{reply: "ok", newID: "s1"}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+	deps.SchedulesRun = false
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "mỗi sáng gửi tôi tóm tắt", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	p := turn.prompts[0]
+	if !strings.Contains(p, "does not fire schedules") {
+		t.Errorf("the prompt hides that nothing here would run it:\n%s", p)
+	}
+}
+
+// TestShutdownDoesNotEatTheQuestion: a turn killed by a deploy is not an
+// answered question. Marking the mention read would lose it for good — the
+// person would have to notice and ask again.
+func TestShutdownDoesNotEatTheQuestion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	turn := &recordingTurn{reply: "không bao giờ tới"}
+	turn.duringTurn = func(TurnSink) { cancel() }
+	turn.err = context.Canceled
+
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	if _, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "câu hỏi quan trọng", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(ctx)
+
+	// Still unread: the next gateway will answer it.
+	left, err := cdb.UnreadMentions(coord.MemberAgent, "bomclaw2", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) != 1 {
+		t.Fatalf("a question interrupted by shutdown was consumed anyway (%d unread)", len(left))
+	}
+	// And no half-finished progress line was left in the room.
+	thread, _ := cdb.ChannelMessages(coord.GeneralChannelID, 10, time.Time{})
+	for _, m := range thread {
+		if strings.HasPrefix(m.Body, coord.ProgressPrefix) {
+			t.Fatal("a progress line outlived the interrupted turn")
+		}
 	}
 }

--- a/internal/gateway/methods.go
+++ b/internal/gateway/methods.go
@@ -60,6 +60,11 @@ type Deps struct {
 	// Nil when this agent does not claim tasks.
 	PokeTasks func()
 
+	// SchedulesRun is whether any gateway on this machine fires schedules. An
+	// agent told it can put work on a clock, on a machine where nothing runs
+	// the clock, produces rows that never fire — which looks like it worked.
+	SchedulesRun bool
+
 	// PokeSchedules asks the local scheduler loop to tick now (after a
 	// "run now"). Nil when schedules are disabled on this gateway; the row is
 	// still updated and another gateway's tick fires it.


### PR DESCRIPTION
Nhờ agent *"tạo 1 schedule 5 phút 1 lần cho tôi nắm giá top 10 crypto"* thì nhận về `⚠️ lượt này hỏng giữa chừng: context canceled`. **Hai vấn đề riêng biệt** nấp sau một câu lỗi.

## 1. Lượt bị giết bởi một lần deploy — và câu hỏi biến mất

Log xác nhận: gateway restart lúc **18:40:46**, tin nhắn gửi lúc **18:40:35**.

Nhưng phần tệ hơn là mention **bị đánh dấu đã đọc** trên đường ra. Câu hỏi mất hẳn — anh phải tự nhận ra và hỏi lại.

Một lượt bị **shutdown** cắt **không phải** một câu hỏi đã được trả lời. Giờ nó **để nguyên mention chưa đọc**, và gateway kế tiếp nhặt lên. Timeout của chính chúng ta thì vẫn tính là đã xử lý — thử lại mãi chỉ đốt đúng ba phút đó thêm lần nữa.

## 2. Mà kể cả không bị cắt, nó cũng không tạo được schedule

`bomclaw schedule add` **có từ P1a** và **chưa prompt nào nhắc tới**. Một agent được nhờ việc lặp lại thì hoặc từ chối, hoặc hứa sẽ nhớ — rồi không nhớ, vì **nó không chạy giữa các lượt**.

Prompt giờ đưa ra lệnh đó, kèm đúng chỗ dễ sai nhất: **schedule không chạy model**; mỗi tick nó **tạo một task**, và agent nào claim task đó sẽ **không có cuộc nói chuyện này** — nên tiêu đề task phải tự đứng được.

Gateway không fire schedule thì **nói ra**, thay vì để agent hứa một thứ không gì chạy. Và nó nói **về chính nó**, không nói thay cả máy: nó biết config của mình chứ không biết của peer, nên *"đang chờ một gateway có bật"* mới là câu đúng.

## Kèm theo: bật scheduler cho agent 1

Log ghi `scheduler: disabled (schedules.enabled=false)` **47 lần**. Không có nó thì mọi schedule agent tạo ra đều nằm im. Config agent 1 giờ bật,  — **chỉ thêm 10 dòng, không sửa dòng nào** (`diff` xác nhận 0), và đã chạy qua `Load`+`Validate` trước khi ghi đè.

## Test

- `TestShutdownDoesNotEatTheQuestion` — mention **vẫn chưa đọc** sau khi lượt bị huỷ, và không để lại dòng progress dở
- `TestTheAgentIsToldItCanSchedule` — prompt có `schedule add`, `--every`, `--agent-task`, **và** lời cảnh báo agent claim task sẽ không có ngữ cảnh này
- `TestAGatewayThatDoesNotFireSchedulesSaysSo`

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)