### PR TITLE
fix(channel): a turn that outlived its deadline kept talking

### DIFF
--- a/internal/gateway/mentions.go
+++ b/internal/gateway/mentions.go
@@ -62,8 +62,15 @@ const (
 	MaxThreadContextRunes = 24000
 
 	// mentionTurnTimeout bounds one reply. A channel turn is a conversation,
-	// not a task: if it needs longer than this it needs a task.
-	mentionTurnTimeout = 3 * time.Minute
+	// not a task — but conversations here routinely involve reading a few
+	// files, and three minutes turned out to be shorter than an ordinary
+	// answer: an agent asked to set something up spent its whole budget on
+	// the setting up. Eight is long enough for real tool work and still well
+	// under the task lane's fifteen, which is where genuinely long work goes.
+	//
+	// The cost is real and worth stating: the watcher answers one mention at a
+	// time, so a turn using its whole budget holds up the next question.
+	mentionTurnTimeout = 8 * time.Minute
 )
 
 // MentionWatcher answers the mentions addressed to one agent.
@@ -235,6 +242,12 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 	sess.MarkRunning("channel: " + truncateLine(m.Body, 40))
 	w.live.Store(m.ID, sess)
 	_, err = w.deps.Turn.RunTurn(turnCtx, sess, sess.ChatID, w.model(), prompt, sink)
+	// The engine stops WAITING for a turn when the deadline passes; the turn
+	// itself keeps going in its lane. Its sink was still writing into the room
+	// afterwards, so a line this code had already closed came back to life
+	// saying "working" — and stayed that way. Nothing this turn produces from
+	// here is ours to publish.
+	sink.stop()
 	sess.MarkIdle()
 	w.live.Delete(m.ID)
 	if err != nil {
@@ -250,7 +263,16 @@ func (w *MentionWatcher) answer(ctx context.Context, m coord.ChannelMessage) {
 			return
 		}
 		log.Printf("mentions: turn for %s: %v", m.ID, err)
-		w.finishProgress(progress, "⚠️ lượt này hỏng giữa chừng: "+truncateLine(err.Error(), 200))
+		note := "⚠️ lượt này hỏng giữa chừng: " + truncateLine(err.Error(), 200)
+		if errors.Is(err, context.DeadlineExceeded) {
+			// Say what to do about it. "Deadline exceeded" tells the person
+			// nothing they can act on; the shape of the fix is a task, which
+			// has five times the budget and survives across runs.
+			note = fmt.Sprintf("⌛ hết %s cho một lượt trả lời — việc này dài hơn một câu trả lời. "+
+				"Nhờ lại và bảo mở task (`bomclaw task new --thread ...`), task chạy được lâu hơn và "+
+				"giữ tiến độ qua nhiều lượt.", mentionTurnTimeout)
+		}
+		w.finishProgress(progress, note)
 		clear("")
 		return
 	}
@@ -577,6 +599,15 @@ type replySink struct {
 	onProgress func(tools []string, partial string, since time.Time)
 
 	preview *chat.StreamPreview
+	done    bool
+}
+
+// stop ends progress reporting. A turn whose caller has given up keeps running
+// in its lane, and anything it writes after that belongs to nobody.
+func (r *replySink) stop() {
+	r.mu.Lock()
+	r.done = true
+	r.mu.Unlock()
 }
 
 const progressEvery = 2 * time.Second
@@ -609,7 +640,7 @@ func (r *replySink) NoteTool(label string) {
 
 func (r *replySink) report(now bool) {
 	r.mu.Lock()
-	if r.onProgress == nil {
+	if r.onProgress == nil || r.done {
 		r.mu.Unlock()
 		return
 	}

--- a/internal/gateway/mentions_test.go
+++ b/internal/gateway/mentions_test.go
@@ -770,3 +770,79 @@ func TestShutdownDoesNotEatTheQuestion(t *testing.T) {
 		}
 	}
 }
+
+// TestAnAbandonedTurnStopsWriting: the engine stops WAITING for a turn when
+// its deadline passes, but the turn keeps running in its lane. Its sink was
+// still writing into the room afterwards, so a line this code had already
+// closed came back to life saying "working" — and stayed that way, which is
+// exactly what a thread showed after a three-minute timeout.
+func TestAnAbandonedTurnStopsWriting(t *testing.T) {
+	turn := &recordingTurn{err: context.DeadlineExceeded}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	// The turn keeps a handle on its sink and writes after giving the caller
+	// back its error, the way a lane goroutine does.
+	var escaped TurnSink
+	turn.duringTurn = func(sink TurnSink) { escaped = sink }
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "việc dài", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	// Whatever it says now must not reach the room.
+	if escaped == nil {
+		t.Fatal("the test never got hold of the sink")
+	}
+	escaped.NoteTool("Bash")
+	escaped.Write(strings.Repeat("vẫn đang chạy đây. ", 20))
+
+	thread, err := cdb.ThreadMessages(root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range thread {
+		if strings.HasPrefix(m.Body, coord.ProgressPrefix) {
+			t.Fatalf("an abandoned turn revived its progress line: %q", m.Body)
+		}
+		if strings.Contains(m.Body, "vẫn đang chạy") {
+			t.Fatalf("an abandoned turn published text: %q", m.Body)
+		}
+	}
+}
+
+// And a timeout says what to do about it: "deadline exceeded" is not something
+// a person can act on.
+func TestATimeoutSuggestsATask(t *testing.T) {
+	turn := &recordingTurn{err: context.DeadlineExceeded}
+	deps, cdb := mentionTestDeps(t, turn)
+	deps.Sessions = session.NewManager(nil)
+
+	root, _, err := cdb.PostMessage(coord.NewChannelMessage{
+		ChannelID: coord.GeneralChannelID, AuthorKind: coord.MemberUser, AuthorID: coord.OwnerUserID,
+		Body: "việc dài", Notify: []coord.Member{{Kind: coord.MemberAgent, ID: "bomclaw2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	NewMentionWatcher(deps).sweep(context.Background())
+
+	thread, _ := cdb.ThreadMessages(root.ID)
+	var said string
+	for _, m := range thread {
+		if m.AuthorID == "bomclaw2" {
+			said = m.Body
+		}
+	}
+	if !strings.Contains(said, "task") {
+		t.Errorf("a timeout should point at the lane that can finish it: %q", said)
+	}
+	if strings.Contains(said, "deadline exceeded") {
+		t.Errorf("the raw error is not an instruction: %q", said)
+	}
+}


### PR DESCRIPTION
Thread hiện dòng progress đứng ở `2m54s … ⏰ Task timed out.`, còn log ghi lượt đó **hỏng vì context deadline exceeded**. Hai lời khai về cùng một lượt, không thể cùng đúng.

**Cả hai đều đúng.** `execution.Engine.Enqueue` ngừng **chờ** khi context của người gọi hết hạn — nhưng **công việc vẫn chạy tiếp trong lane của nó**.

Nên watcher đóng dòng progress lại, rồi chính cái lượt nó vừa bỏ cuộc **viết tiếp qua cùng sink đó và dựng dòng ấy dậy** — vĩnh viễn, vì không có lần đóng thứ hai nào nữa.

Giờ sink **bị tắt** ngay khi người gọi ngừng chờ: thứ gì lượt đó sinh ra sau đó **không thuộc về ai cả**.

## Ba phút cũng là quá ngắn

Lượt kênh được thiết kế là **hội thoại**, không phải task. Nhưng hội thoại ở đây thường xuyên bao gồm đọc vài file, và một agent được nhờ *thiết lập* một thứ đã tiêu hết ngân sách vào việc thiết lập.

**Tám phút** — đủ cho tool work thật, vẫn dưới hẳn mức **15 phút** của làn task, nơi việc dài thật sự nên đi.

Cái giá cần nói ra: watcher trả lời **một mention mỗi lần**, nên một lượt dùng hết ngân sách sẽ **chặn câu hỏi kế tiếp**.

## Và timeout giờ nói phải làm gì

`deadline exceeded` không phải thứ người dùng hành động được. Hình dạng của cách sửa là **một task** — gấp năm lần ngân sách, và giữ tiến độ qua nhiều run.

## Test

- `TestAnAbandonedTurnStopsWriting` — lượt bị bỏ rơi viết tiếp qua sink cũ, **không dòng nào lọt vào phòng**
- `TestATimeoutSuggestsATask` — thông báo nhắc tới task và **không** lộ chuỗi lỗi thô

`go build ./...`, `go test ./...` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)