### PR TITLE
fix(tasks): the board shows the command, and shows it once

### DIFF
--- a/dashboard/src/admin/TaskBoard.tsx
+++ b/dashboard/src/admin/TaskBoard.tsx
@@ -290,24 +290,6 @@ function TaskDrawer({ call, id, agents, onClose, onChanged, onOpenTask, onOpenTh
                 </div>
               )}
 
-              {/* A row saying "running" for four minutes tells you less than
-                  the log would. This is what it is actually doing. */}
-              {detail.live && (
-                <div className="rounded-md ring-1 ring-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-xs">
-                  <span className="text-amber-300">⏳ đang chạy</span>
-                  <span className="text-gray-500"> · {detail.live.agent}</span>
-                  {detail.live.last_tool && (
-                    <span className="text-gray-300 font-mono"> · {detail.live.last_tool}</span>
-                  )}
-                  {detail.live.tool_count > 0 && (
-                    <span className="text-gray-500"> · {detail.live.tool_count} tool calls</span>
-                  )}
-                  {detail.live.started_at && (
-                    <span className="text-gray-500"> · {ago(detail.live.started_at)}</span>
-                  )}
-                </div>
-              )}
-
               {detail.thread_root && onOpenThread && (
                 <button
                   onClick={() => onOpenThread(detail.thread_root!)}

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -2,7 +2,6 @@ package bot
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -475,7 +474,7 @@ func (h *Handler) runFlush(ctx context.Context, sess *session.Session, modelID s
 		OnText: func(chunk string) { reply.WriteString(chunk) },
 		OnToolCall: func(name, inputJSON string) {
 			sess.NoteTool(name)
-			log.Printf("memory: flush tool %s", toolLabel(name, inputJSON))
+			log.Printf("memory: flush tool %s", chat.ToolLabel(name, inputJSON))
 		},
 	}
 
@@ -780,7 +779,7 @@ func (h *Handler) runClaude(ctx context.Context, sess *session.Session, chatID i
 		OnToolCall: func(name string, inputJSON string) {
 			addEvent(transcript.Event{Type: transcript.EventToolCall, ToolName: name, ToolInput: inputJSON})
 			pushTool(name, inputJSON)
-			label := toolLabel(name, inputJSON)
+			label := chat.ToolLabel(name, inputJSON)
 			// Compact tool progress with short snippet: Bash(cd stock_d) → Read(main.go)
 			streamer.NoteTool(label)
 			// Mirror to session so /status can show what's running right now.
@@ -1116,137 +1115,6 @@ func truncateLabel(text string, maxRunes int) string {
 	return text
 }
 
-// toolLabel creates a short label like Bash(cd stock_d) or Read(bot/handler.go)
-func toolLabel(name, inputJSON string) string {
-	var m map[string]any
-	if json.Unmarshal([]byte(inputJSON), &m) != nil {
-		return name
-	}
-
-	// Path keys get tail-truncated (show meaningful end); others get head-truncated.
-	pathKeys := map[string]bool{"path": true, "file_path": true}
-
-	for _, key := range []string{"command", "path", "file_path", "url", "query", "pattern", "script", "expression", "name", "ref", "text", "glob", "regex"} {
-		if v, ok := m[key]; ok {
-			s := fmt.Sprintf("%v", v)
-			if s == "" {
-				continue
-			}
-			if pathKeys[key] {
-				s = shortenPath(s, 25)
-			} else if key == "command" {
-				s = shortenBashCommand(s, 25)
-			} else {
-				r := []rune(s)
-				if len(r) > 20 {
-					s = string(r[:20])
-				}
-			}
-			return name + "(" + s + ")"
-		}
-	}
-	return name
-}
-
-// shortenBashCommand extracts the first segment of a shell command (before
-// &&, ||, |, ;) and shortens any path-like argument while keeping the
-// command prefix (cd, ls, grep, etc.).
-//
-//	"cd /Users/ngocp/Documents/projects/meClaw/goterm-control" → "cd ../goterm-control"
-//	"ls -la /very/long/path/to/dir"                            → "ls ../dir"
-//	"echo hello world"                                         → "echo hello world"
-func shortenBashCommand(s string, maxRunes int) string {
-	if len([]rune(s)) <= maxRunes {
-		return s
-	}
-
-	// Take the first command segment (before &&, ||, |, ;).
-	seg := s
-	for _, sep := range []string{" && ", " || ", " | ", "; "} {
-		if idx := strings.Index(seg, sep); idx >= 0 {
-			seg = seg[:idx]
-		}
-	}
-
-	// Split into tokens; find the command prefix and the first path argument.
-	tokens := strings.Fields(seg)
-	if len(tokens) == 0 {
-		return headTruncate(s, maxRunes)
-	}
-
-	cmd := tokens[0] // e.g. "cd", "ls", "grep"
-	var pathIdx int   // index of the first path-like token
-	var foundPath bool
-	for i := 1; i < len(tokens); i++ {
-		t := tokens[i]
-		if strings.HasPrefix(t, "/") || strings.HasPrefix(t, "./") ||
-			strings.HasPrefix(t, "~/") || strings.HasPrefix(t, "../") {
-			pathIdx = i
-			foundPath = true
-			break
-		}
-	}
-
-	if !foundPath {
-		return headTruncate(s, maxRunes)
-	}
-
-	// Budget for the path: maxRunes minus "cmd " prefix.
-	prefix := cmd
-	pathBudget := maxRunes - len([]rune(prefix)) - 1 // -1 for space
-	if pathBudget < 6 {
-		return headTruncate(s, maxRunes)
-	}
-
-	shortened := shortenPath(tokens[pathIdx], pathBudget)
-	return prefix + " " + shortened
-}
-
-// headTruncate keeps the first maxRunes runes of s.
-func headTruncate(s string, maxRunes int) string {
-	r := []rune(s)
-	if len(r) <= maxRunes {
-		return s
-	}
-	return string(r[:maxRunes])
-}
-
-// shortenPath keeps the last path components that fit within maxRunes,
-// so "/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go"
-// becomes "../bot/handler.go" instead of the useless "/Users/ngocp/Do".
-func shortenPath(s string, maxRunes int) string {
-	if len([]rune(s)) <= maxRunes {
-		return s
-	}
-	parts := strings.Split(s, "/")
-	// Build from the tail, accumulating components.
-	var tail string
-	for i := len(parts) - 1; i >= 0; i-- {
-		candidate := parts[i]
-		if tail != "" {
-			candidate = parts[i] + "/" + tail
-		}
-		if len([]rune(candidate))+3 > maxRunes { // +3 for "../"
-			break
-		}
-		tail = candidate
-	}
-	if tail == "" {
-		// Filename alone exceeds budget — truncate the filename.
-		r := []rune(parts[len(parts)-1])
-		if len(r) > maxRunes-3 {
-			tail = string(r[:maxRunes-3])
-		} else {
-			tail = string(r)
-		}
-	}
-	if tail == s {
-		return s
-	}
-	return "../" + tail
-}
-
-// sendText converts markdown to Telegram HTML and sends the message.
 func (h *Handler) sendText(chatID int64, text string) int {
 	html := markdownToTelegramHTML(text)
 	msg := tgbotapi.NewMessage(chatID, html)

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -7,221 +7,6 @@ import (
 	"github.com/ngocp/goterm-control/internal/agent"
 )
 
-func TestShortenBashCommand(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		maxRunes int
-		want     string
-	}{
-		{
-			name:     "cd with long path",
-			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control",
-			maxRunes: 25,
-			want:     "cd ../goterm-control",
-		},
-		{
-			name:     "ls with long path and subdir",
-			input:    "ls /Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot",
-			maxRunes: 25,
-			want:     "ls ../internal/bot",
-		},
-		{
-			name:     "cd short path unchanged",
-			input:    "cd /tmp",
-			maxRunes: 25,
-			want:     "cd /tmp",
-		},
-		{
-			name:     "ls with flags no path",
-			input:    "ls -la",
-			maxRunes: 25,
-			want:     "ls -la",
-		},
-		{
-			name:     "multi-command takes first segment",
-			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control && ls",
-			maxRunes: 25,
-			want:     "cd ../goterm-control",
-		},
-		{
-			name:     "no path fallback to head truncate",
-			input:    "echo hello world this is a very long command string",
-			maxRunes: 25,
-			want:     "echo hello world this is ",
-		},
-		{
-			name:     "flags before path",
-			input:    "ls -la /Users/ngocp/Documents/projects/meClaw/goterm-control/internal",
-			maxRunes: 25,
-			want:     "ls ../internal",
-		},
-		{
-			name:     "grep with path",
-			input:    "grep -r pattern /Users/ngocp/Documents/projects/meClaw/goterm-control",
-			maxRunes: 25,
-			want:     "grep ../goterm-control",
-		},
-		{
-			name:     "pipe separator",
-			input:    "cat /Users/ngocp/Documents/projects/long/path/file.go | head -20",
-			maxRunes: 25,
-			want:     "cat ../long/path/file.go",
-		},
-		{
-			name:     "relative path with ./",
-			input:    "cat ./very/long/nested/deep/directory/structure/file.txt",
-			maxRunes: 25,
-			want:     "cat ../structure/file.txt",
-		},
-		{
-			name:     "tilde path",
-			input:    "ls ~/Documents/projects/meClaw/goterm-control/internal/bot/handler.go",
-			maxRunes: 25,
-			want:     "ls ../bot/handler.go",
-		},
-		{
-			name:     "already short enough",
-			input:    "cd /tmp && ls -la",
-			maxRunes: 25,
-			want:     "cd /tmp && ls -la",
-		},
-		{
-			name:     "semicolon separator",
-			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control; ls",
-			maxRunes: 25,
-			want:     "cd ../goterm-control",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shortenBashCommand(tt.input, tt.maxRunes)
-			if got != tt.want {
-				t.Errorf("shortenBashCommand(%q, %d)\n  got  %q\n  want %q",
-					tt.input, tt.maxRunes, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestToolLabel_BashCommand(t *testing.T) {
-	tests := []struct {
-		name      string
-		toolName  string
-		inputJSON string
-		want      string
-	}{
-		{
-			name:      "bash cd long path",
-			toolName:  "Bash",
-			inputJSON: `{"command":"cd /Users/ngocp/Documents/projects/meClaw/goterm-control"}`,
-			want:      "Bash(cd ../goterm-control)",
-		},
-		{
-			name:      "bash ls short",
-			toolName:  "Bash",
-			inputJSON: `{"command":"ls -la"}`,
-			want:      "Bash(ls -la)",
-		},
-		{
-			name:      "read file_path shortened",
-			toolName:  "Read",
-			inputJSON: `{"file_path":"/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go"}`,
-			want:      "Read(../bot/handler.go)",
-		},
-		{
-			name:      "edit path key shortened",
-			toolName:  "Edit",
-			inputJSON: `{"path":"/Users/ngocp/Documents/projects/meClaw/goterm-control/config.yaml"}`,
-			want:      "Edit(../config.yaml)",
-		},
-		{
-			name:      "empty json returns name only",
-			toolName:  "Bash",
-			inputJSON: `{}`,
-			want:      "Bash",
-		},
-		{
-			name:      "invalid json returns name only",
-			toolName:  "Bash",
-			inputJSON: `not json`,
-			want:      "Bash",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := toolLabel(tt.toolName, tt.inputJSON)
-			if got != tt.want {
-				t.Errorf("toolLabel(%q, %q)\n  got  %q\n  want %q",
-					tt.toolName, tt.inputJSON, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestShortenPath(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		maxRunes int
-		want     string
-	}{
-		{
-			name:     "long absolute path",
-			input:    "/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go",
-			maxRunes: 25,
-			want:     "../bot/handler.go",
-		},
-		{
-			name:     "short path unchanged",
-			input:    "/tmp/file.txt",
-			maxRunes: 25,
-			want:     "/tmp/file.txt",
-		},
-		{
-			name:     "exact budget",
-			input:    "exactly-twenty-five-rune",
-			maxRunes: 25,
-			want:     "exactly-twenty-five-rune",
-		},
-		{
-			name:     "single deep file",
-			input:    "/a/b/c/d/e/f/g/handler.go",
-			maxRunes: 20,
-			want:     "../e/f/g/handler.go",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shortenPath(tt.input, tt.maxRunes)
-			if got != tt.want {
-				t.Errorf("shortenPath(%q, %d)\n  got  %q\n  want %q",
-					tt.input, tt.maxRunes, got, tt.want)
-			}
-		})
-	}
-}
-
-// mockMessageStore implements MessageStore for testing.
-type mockMessageStore struct {
-	messages []agent.Message
-}
-
-func (m *mockMessageStore) Append(_ string, msg agent.Message) error {
-	m.messages = append(m.messages, msg)
-	return nil
-}
-
-func (m *mockMessageStore) LoadHistory(_ string, limit int) ([]agent.Message, error) {
-	if limit > 0 && len(m.messages) > limit {
-		return m.messages[len(m.messages)-limit:], nil
-	}
-	return m.messages, nil
-}
-
 func TestBuildHistoryContext_WithMessages(t *testing.T) {
 	store := &mockMessageStore{
 		messages: []agent.Message{
@@ -284,4 +69,21 @@ func TestBuildHistoryContext_TruncatesLongMessages(t *testing.T) {
 	if !strings.Contains(ctx, "...") {
 		t.Error("expected truncation indicator '...'")
 	}
+}
+
+// mockMessageStore implements MessageStore for testing.
+type mockMessageStore struct {
+	messages []agent.Message
+}
+
+func (m *mockMessageStore) Append(_ string, msg agent.Message) error {
+	m.messages = append(m.messages, msg)
+	return nil
+}
+
+func (m *mockMessageStore) LoadHistory(_ string, limit int) ([]agent.Message, error) {
+	if limit > 0 && len(m.messages) > limit {
+		return m.messages[len(m.messages)-limit:], nil
+	}
+	return m.messages, nil
 }

--- a/internal/chat/toollabel.go
+++ b/internal/chat/toollabel.go
@@ -1,0 +1,147 @@
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Naming a tool call so a person can tell what the agent is doing.
+//
+// This lived in internal/bot, where only the chat lane could reach it — so the
+// task board showed "Bash" while a thread watching the same agent showed
+// "Bash(cd ../goterm-workspace)". Same agent, same second, two different
+// answers to "what is it doing", and the less useful one on the screen built
+// for watching work.
+
+// ToolLabel creates a short label like Bash(cd stock_d) or Read(bot/handler.go)
+func ToolLabel(name, inputJSON string) string {
+	var m map[string]any
+	if json.Unmarshal([]byte(inputJSON), &m) != nil {
+		return name
+	}
+
+	// Path keys get tail-truncated (show meaningful end); others get head-truncated.
+	pathKeys := map[string]bool{"path": true, "file_path": true}
+
+	for _, key := range []string{"command", "path", "file_path", "url", "query", "pattern", "script", "expression", "name", "ref", "text", "glob", "regex"} {
+		if v, ok := m[key]; ok {
+			s := fmt.Sprintf("%v", v)
+			if s == "" {
+				continue
+			}
+			if pathKeys[key] {
+				s = shortenPath(s, 25)
+			} else if key == "command" {
+				s = shortenBashCommand(s, 25)
+			} else {
+				r := []rune(s)
+				if len(r) > 20 {
+					s = string(r[:20])
+				}
+			}
+			return name + "(" + s + ")"
+		}
+	}
+	return name
+}
+
+// shortenBashCommand extracts the first segment of a shell command (before
+// &&, ||, |, ;) and shortens any path-like argument while keeping the
+// command prefix (cd, ls, grep, etc.).
+//
+//	"cd /Users/ngocp/Documents/projects/meClaw/goterm-control" → "cd ../goterm-control"
+//	"ls -la /very/long/path/to/dir"                            → "ls ../dir"
+//	"echo hello world"                                         → "echo hello world"
+func shortenBashCommand(s string, maxRunes int) string {
+	if len([]rune(s)) <= maxRunes {
+		return s
+	}
+
+	// Take the first command segment (before &&, ||, |, ;).
+	seg := s
+	for _, sep := range []string{" && ", " || ", " | ", "; "} {
+		if idx := strings.Index(seg, sep); idx >= 0 {
+			seg = seg[:idx]
+		}
+	}
+
+	// Split into tokens; find the command prefix and the first path argument.
+	tokens := strings.Fields(seg)
+	if len(tokens) == 0 {
+		return headTruncate(s, maxRunes)
+	}
+
+	cmd := tokens[0] // e.g. "cd", "ls", "grep"
+	var pathIdx int  // index of the first path-like token
+	var foundPath bool
+	for i := 1; i < len(tokens); i++ {
+		t := tokens[i]
+		if strings.HasPrefix(t, "/") || strings.HasPrefix(t, "./") ||
+			strings.HasPrefix(t, "~/") || strings.HasPrefix(t, "../") {
+			pathIdx = i
+			foundPath = true
+			break
+		}
+	}
+
+	if !foundPath {
+		return headTruncate(s, maxRunes)
+	}
+
+	// Budget for the path: maxRunes minus "cmd " prefix.
+	prefix := cmd
+	pathBudget := maxRunes - len([]rune(prefix)) - 1 // -1 for space
+	if pathBudget < 6 {
+		return headTruncate(s, maxRunes)
+	}
+
+	shortened := shortenPath(tokens[pathIdx], pathBudget)
+	return prefix + " " + shortened
+}
+
+// headTruncate keeps the first maxRunes runes of s.
+func headTruncate(s string, maxRunes int) string {
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:maxRunes])
+}
+
+// shortenPath keeps the last path components that fit within maxRunes,
+// so "/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go"
+// becomes "../bot/handler.go" instead of the useless "/Users/ngocp/Do".
+func shortenPath(s string, maxRunes int) string {
+	if len([]rune(s)) <= maxRunes {
+		return s
+	}
+	parts := strings.Split(s, "/")
+	// Build from the tail, accumulating components.
+	var tail string
+	for i := len(parts) - 1; i >= 0; i-- {
+		candidate := parts[i]
+		if tail != "" {
+			candidate = parts[i] + "/" + tail
+		}
+		if len([]rune(candidate))+3 > maxRunes { // +3 for "../"
+			break
+		}
+		tail = candidate
+	}
+	if tail == "" {
+		// Filename alone exceeds budget — truncate the filename.
+		r := []rune(parts[len(parts)-1])
+		if len(r) > maxRunes-3 {
+			tail = string(r[:maxRunes-3])
+		} else {
+			tail = string(r)
+		}
+	}
+	if tail == s {
+		return s
+	}
+	return "../" + tail
+}
+
+// sendText converts markdown to Telegram HTML and sends the message.

--- a/internal/chat/toollabel_test.go
+++ b/internal/chat/toollabel_test.go
@@ -1,0 +1,206 @@
+package chat
+
+import "testing"
+
+// These moved here with the code they pin. The label is used by both lanes now,
+// and a test living in the chat lane's package could only ever check one of
+// them — which is how the task board ended up showing "Bash" for months while
+// a thread watching the same agent showed the command.
+
+func TestShortenBashCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxRunes int
+		want     string
+	}{
+		{
+			name:     "cd with long path",
+			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control",
+			maxRunes: 25,
+			want:     "cd ../goterm-control",
+		},
+		{
+			name:     "ls with long path and subdir",
+			input:    "ls /Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot",
+			maxRunes: 25,
+			want:     "ls ../internal/bot",
+		},
+		{
+			name:     "cd short path unchanged",
+			input:    "cd /tmp",
+			maxRunes: 25,
+			want:     "cd /tmp",
+		},
+		{
+			name:     "ls with flags no path",
+			input:    "ls -la",
+			maxRunes: 25,
+			want:     "ls -la",
+		},
+		{
+			name:     "multi-command takes first segment",
+			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control && ls",
+			maxRunes: 25,
+			want:     "cd ../goterm-control",
+		},
+		{
+			name:     "no path fallback to head truncate",
+			input:    "echo hello world this is a very long command string",
+			maxRunes: 25,
+			want:     "echo hello world this is ",
+		},
+		{
+			name:     "flags before path",
+			input:    "ls -la /Users/ngocp/Documents/projects/meClaw/goterm-control/internal",
+			maxRunes: 25,
+			want:     "ls ../internal",
+		},
+		{
+			name:     "grep with path",
+			input:    "grep -r pattern /Users/ngocp/Documents/projects/meClaw/goterm-control",
+			maxRunes: 25,
+			want:     "grep ../goterm-control",
+		},
+		{
+			name:     "pipe separator",
+			input:    "cat /Users/ngocp/Documents/projects/long/path/file.go | head -20",
+			maxRunes: 25,
+			want:     "cat ../long/path/file.go",
+		},
+		{
+			name:     "relative path with ./",
+			input:    "cat ./very/long/nested/deep/directory/structure/file.txt",
+			maxRunes: 25,
+			want:     "cat ../structure/file.txt",
+		},
+		{
+			name:     "tilde path",
+			input:    "ls ~/Documents/projects/meClaw/goterm-control/internal/bot/handler.go",
+			maxRunes: 25,
+			want:     "ls ../bot/handler.go",
+		},
+		{
+			name:     "already short enough",
+			input:    "cd /tmp && ls -la",
+			maxRunes: 25,
+			want:     "cd /tmp && ls -la",
+		},
+		{
+			name:     "semicolon separator",
+			input:    "cd /Users/ngocp/Documents/projects/meClaw/goterm-control; ls",
+			maxRunes: 25,
+			want:     "cd ../goterm-control",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortenBashCommand(tt.input, tt.maxRunes)
+			if got != tt.want {
+				t.Errorf("shortenBashCommand(%q, %d)\n  got  %q\n  want %q",
+					tt.input, tt.maxRunes, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToolLabel_BashCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		inputJSON string
+		want      string
+	}{
+		{
+			name:      "bash cd long path",
+			toolName:  "Bash",
+			inputJSON: `{"command":"cd /Users/ngocp/Documents/projects/meClaw/goterm-control"}`,
+			want:      "Bash(cd ../goterm-control)",
+		},
+		{
+			name:      "bash ls short",
+			toolName:  "Bash",
+			inputJSON: `{"command":"ls -la"}`,
+			want:      "Bash(ls -la)",
+		},
+		{
+			name:      "read file_path shortened",
+			toolName:  "Read",
+			inputJSON: `{"file_path":"/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go"}`,
+			want:      "Read(../bot/handler.go)",
+		},
+		{
+			name:      "edit path key shortened",
+			toolName:  "Edit",
+			inputJSON: `{"path":"/Users/ngocp/Documents/projects/meClaw/goterm-control/config.yaml"}`,
+			want:      "Edit(../config.yaml)",
+		},
+		{
+			name:      "empty json returns name only",
+			toolName:  "Bash",
+			inputJSON: `{}`,
+			want:      "Bash",
+		},
+		{
+			name:      "invalid json returns name only",
+			toolName:  "Bash",
+			inputJSON: `not json`,
+			want:      "Bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToolLabel(tt.toolName, tt.inputJSON)
+			if got != tt.want {
+				t.Errorf("ToolLabel(%q, %q)\n  got  %q\n  want %q",
+					tt.toolName, tt.inputJSON, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShortenPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxRunes int
+		want     string
+	}{
+		{
+			name:     "long absolute path",
+			input:    "/Users/ngocp/Documents/projects/meClaw/goterm-control/internal/bot/handler.go",
+			maxRunes: 25,
+			want:     "../bot/handler.go",
+		},
+		{
+			name:     "short path unchanged",
+			input:    "/tmp/file.txt",
+			maxRunes: 25,
+			want:     "/tmp/file.txt",
+		},
+		{
+			name:     "exact budget",
+			input:    "exactly-twenty-five-rune",
+			maxRunes: 25,
+			want:     "exactly-twenty-five-rune",
+		},
+		{
+			name:     "single deep file",
+			input:    "/a/b/c/d/e/f/g/handler.go",
+			maxRunes: 20,
+			want:     "../e/f/g/handler.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortenPath(tt.input, tt.maxRunes)
+			if got != tt.want {
+				t.Errorf("shortenPath(%q, %d)\n  got  %q\n  want %q",
+					tt.input, tt.maxRunes, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/taskrunner/runner.go
+++ b/internal/taskrunner/runner.go
@@ -403,8 +403,12 @@ func (r *Runner) execute(ctx context.Context, task *coord.Task) {
 			progress.Text(chunk)
 		},
 		OnToolCall: func(name, input string) {
-			sess.NoteTool(name)
-			progress.Tool(name)
+			// The label, not the bare name: the board is the screen built for
+			// watching work, and "Bash" tells a watcher less than
+			// "Bash(cd ../goterm-workspace)" does.
+			label := chat.ToolLabel(name, input)
+			sess.NoteTool(label)
+			progress.Tool(label)
 			if name == "TodoWrite" && hasPendingTodos(input) {
 				todoPending = true
 			}

--- a/internal/taskrunner/runner_test.go
+++ b/internal/taskrunner/runner_test.go
@@ -464,7 +464,10 @@ func TestLiveRunsAreVisibleWhileRunning(t *testing.T) {
 	if !info.Running || info.CurrentTask != "visible work" || live[0].ID != "task_"+created.ID {
 		t.Errorf("live run info = %+v id=%s", info, live[0].ID)
 	}
-	if info.LastTool != "Bash" || info.ToolCount != 1 {
+	// The label, not the bare name. "Bash" tells a watcher which tool; the
+	// command tells them what the agent is doing, which is the question the
+	// board is there to answer.
+	if info.LastTool != "Bash(ls)" || info.ToolCount != 1 {
 		t.Errorf("tool activity not reflected: %+v", info)
 	}
 


### PR DESCRIPTION
Hai thứ trong drawer.

## 1. Nó ghi `Bash`, trong khi thread ghi `Bash(cd ../goterm-workspace)`

Cùng một agent, cùng một giây, **hai câu trả lời khác nhau** cho câu hỏi *"nó đang làm gì"* — và cái ít hữu ích hơn lại nằm trên đúng màn hình sinh ra để theo dõi công việc.

Nguyên nhân: hàm dựng nhãn viết trong `internal/bot`, nên **chỉ làn chat với tới được**. Task runner truyền tên tool trần vì đó là tất cả những gì nó có.

Nhãn giờ nằm ở `internal/chat` — package **cả hai làn đều đã import** — và test của nó chuyển theo: một test sống trong package của một làn thì mãi mãi chỉ kiểm tra được làn đó, và đó chính là lý do task board hiện `Bash` suốt mà không ai thấy sai.

Test `TestLiveRunsAreVisibleWhileRunning` giờ ghim `Bash(ls)` thay vì `Bash`.

## 2. Dòng "đang chạy" hiện hai lần

Tôi chèn block đó **hai lần** lúc vá file và không nhìn lại kết quả. Giờ còn một.

`go test ./...` — 28 package xanh. `tsc --noEmit` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)